### PR TITLE
Say on the site that abuuba can replace Mastodon

### DIFF
--- a/docs/admin/importing-from-mastodon.md
+++ b/docs/admin/importing-from-mastodon.md
@@ -248,7 +248,7 @@ needs to know before running it, not afterwards.
 
 | Left behind | What that costs |
 | --- | --- |
-| Login activity | The recent sign-ins list starts empty. abuuba records new ones from the first sign-in and does not show them anywhere yet |
+| Login activity | The recent sign-ins list in Security settings starts empty; abuuba records new ones from the first sign-in |
 | WebAuthn credentials | Nothing here reads them yet, so a copy would sit unused; anybody using a security key sets it up again when abuuba surfaces them |
 
 The list was built by comparing the source's tables against the ones here, so

--- a/site/index.html
+++ b/site/index.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>abuuba – a fediverse server that cares about performance</title>
-<meta name="description" content="abuuba is a fediverse server written in Elixir and Phoenix. It speaks the complete Mastodon client API and answers twelve to sixty-eight times faster than Mastodon on the same hardware.">
+<meta name="description" content="abuuba is a fediverse server written in Elixir and Phoenix. It does what Mastodon does, answers all 289 endpoints of the Mastodon client API, and can take over an existing instance. Twelve to sixty-eight times faster on the same hardware.">
 <meta property="og:title" content="abuuba">
-<meta property="og:description" content="A fediverse server written in Elixir and Phoenix, twelve to sixty-eight times faster than Mastodon on the same box.">
+<meta property="og:description" content="A fediverse server written in Elixir and Phoenix. It does what Mastodon does, takes over an existing instance, and runs twelve to sixty-eight times faster on the same box.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://abuuba.com/">
 <link rel="canonical" href="https://abuuba.com/">
@@ -37,7 +37,7 @@
       <div class="hero-grid">
         <div>
           <h1>The cheetah that outran the mastodon.</h1>
-          <p class="lede">abuuba is a fediverse server written in <a href="https://elixir-lang.org">Elixir</a> and <a href="https://www.phoenixframework.org">Phoenix</a>. It speaks <a href="https://joinmastodon.org">Mastodon</a>'s protocols: ActivityPub for federation and the complete Mastodon client API, all 289 endpoints, so existing apps work unchanged. It exists for one reason: <strong>Mastodon is too slow.</strong></p>
+          <p class="lede">abuuba is a fediverse server written in <a href="https://elixir-lang.org">Elixir</a> and <a href="https://www.phoenixframework.org">Phoenix</a>. It speaks <a href="https://joinmastodon.org">Mastodon</a>'s protocols: ActivityPub for federation and the complete Mastodon client API, all 289 endpoints, so existing apps work unchanged. It does what a Mastodon instance does, which means it can replace one, keeping the domain, the accounts and the posts. It exists for one reason: <strong>Mastodon is too slow.</strong></p>
         </div>
         <div class="giant" aria-live="polite">
           <span class="giant-num" id="giant-num">68<span class="times">×</span></span>
@@ -85,7 +85,7 @@
   <section class="band">
     <div class="wrap reveal">
       <h2>The same story, told in <em>JavaScript</em>.</h2>
-      <p>abuuba has no client application. LiveView renders on the server and sends diffs down a websocket, so the browser applies patches instead of keeping its own copy of the timeline. No <code>package.json</code>, no <code>node_modules</code>, no lockfile.</p>
+      <p>Open Mastodon in a browser and it hands you a second program to run: the JavaScript that fetches the timeline and draws it on your screen. abuuba has no such program. The server builds every page, and as posts arrive it sends the browser only the parts that changed. That is what LiveView does, the piece of Phoenix abuuba is built on, and it is why there is no <code>package.json</code>, no <code>node_modules</code>, no lockfile.</p>
       <div class="pair">
         <div class="big a"><span class="n num">364</span><span class="l"><b>abuuba</b> · lines of JavaScript · 0 npm dependencies</span></div>
         <div class="big"><span class="n num">97,209</span><span class="l"><b>Mastodon</b> · lines of JavaScript · 1,428 lockfile entries</span></div>
@@ -136,7 +136,31 @@
 
   <section class="band">
     <div class="wrap reveal">
-      <h2>Not here to replace Mastodon. <em>To push it.</em></h2>
+      <h2>Everything Mastodon does. <em>Then the speed.</em></h2>
+      <p>abuuba is a replacement, not a companion. Nobody has to give anything up to move.</p>
+      <ul class="nots">
+        <li><b>The whole client API.</b> All 289 endpoints Mastodon declares under <code>/api/v1</code> and <code>/api/v2</code> are answered here, and a test fails the build the day one stops being answered. An app pointed at this server cannot tell which one it is talking to, lists and all.</li>
+        <li><b>The features around it.</b> Polls, content warnings, scheduled posts, keyword filters, direct messages, two-step sign-in, CSV and archive import and export, and moving an account to another server with the aliases that make a move work. The admin area too: reports, appeals, roles, relays, domain blocks, webhooks, announcements, custom emoji, trends, an audit log.</li>
+        <li><b>The behaviour between servers.</b> A checklist cannot prove federation, so 32 scenarios drive follows, boosts, replies, edits, deletes, polls, quotes, media, reports and account moves against real Mastodon 4.4.7 and GoToSocial 0.19.1 containers, every night.</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="band">
+    <div class="wrap reveal">
+      <h2>Already running Mastodon? <em>Take the server over.</em></h2>
+      <p>Nothing has to be rebuilt. A Mastodon instance becomes an abuuba instance in place, keeping the domain it already has. That domain is the one thing a takeover cannot change: every post URL and every signature the old server published names it. <strong>Everything else moves.</strong> Accounts keep their passwords, posts keep their permalinks, followers stay followers, and the app on somebody's phone stays signed in, because the token it holds comes across too. Media, lists, filters, blocks and the whole moderation history follow.</p>
+      <p>The importer is a dry run by default. It reads the old database, checks everything that has to be true, counts what would move, and writes nothing. A run that gets interrupted continues where it stopped, and afterwards <code>--verify</code> asks the old server, while it is still up, whether every post arrived and every key still signs.</p>
+<pre>mix abuuba.import           <i># a dry run, and the default</i>
+mix abuuba.import --execute <i># do it</i>
+mix abuuba.import --verify  <i># check it afterwards</i></pre>
+      <p class="caption">What moves, what is deliberately left behind, and the two things not carried yet: <a href="https://github.com/wintermeyer/abuuba/blob/main/docs/admin/importing-from-mastodon.md">Taking over a Mastodon instance</a>.</p>
+    </div>
+  </section>
+
+  <section class="band">
+    <div class="wrap reveal">
+      <h2>Not here to kill Mastodon. <em>To push it.</em></h2>
       <blockquote class="quote">
         <p>This is the <a href="https://nginx.org">nginx</a> and <a href="https://httpd.apache.org">Apache</a> story. Apache was good software and still is; nginx turned up because a different shape of load arrived and an architecture built for the older one could not bend that far. The part worth remembering is what happened next: nginx did not kill Apache, it made Apache faster and better.</p>
         <p>That is what I hope abuuba does for Mastodon. If a server twelve times quicker on the same hardware pushes Mastodon to close that gap, the fediverse wins twice, and I will count that as the best thing this project ever did.</p>

--- a/site/press.html
+++ b/site/press.html
@@ -54,7 +54,7 @@
       </div>
       <div class="copyblock">
         <h3>A paragraph</h3>
-        <p>abuuba is a fediverse server written in Elixir and Phoenix, published under the MIT licence by Stefan Wintermeyer in Koblenz. It federates over ActivityPub and answers all 289 endpoints of the Mastodon client API, so existing Mastodon apps work against it unchanged. It exists because Mastodon is slow: measured on one machine against Mastodon 4.4.7, abuuba serves the home timeline 12 times faster at the median and fans a post out to 10,000 followers 68 times faster. It runs as one application process next to one Postgres database, with no Redis, no worker process and no JavaScript build.</p>
+        <p>abuuba is a fediverse server written in Elixir and Phoenix, published under the MIT licence by Stefan Wintermeyer in Koblenz. It federates over ActivityPub and answers all 289 endpoints of the Mastodon client API, so existing Mastodon apps work against it unchanged. It exists because Mastodon is slow: measured on one machine against Mastodon 4.4.7, abuuba serves the home timeline 12 times faster at the median and fans a post out to 10,000 followers 68 times faster. It runs as one application process next to one Postgres database, with no Redis, no worker process and no JavaScript build. An existing Mastodon instance can be taken over in place, on its own domain, with its accounts, posts, follows and moderation history.</p>
       </div>
       <div class="copyblock" lang="de">
         <h3>Ein Satz</h3>
@@ -83,6 +83,7 @@
         <dl>
           <dt>Client API</dt><dd>All 289 endpoints Mastodon 4.6 declares under <code>/api/v1</code> and <code>/api/v2</code></dd>
           <dt>Federation</dt><dd>Tested against Mastodon 4.4.7 and GoToSocial 0.19.1 in Docker, 32 scenarios</dd>
+          <dt>Migration</dt><dd>Takes over a Mastodon instance in place, on the same domain, with <code>mix abuuba.import</code></dd>
           <dt>Size</dt><dd>About 84,000 lines of application code, 4,347 tests, 364 lines of JavaScript, no npm dependencies</dd>
           <dt>Author</dt><dd>Stefan Wintermeyer, Koblenz, Germany</dd>
           <dt>Source</dt><dd><a href="https://github.com/wintermeyer/abuuba">github.com/wintermeyer/abuuba</a></dd>
@@ -122,7 +123,7 @@
         <li><b>Not a Mastodon fork.</b> No line of Mastodon's code is in it. Mastodon is AGPL, abuuba is MIT; what the two share is the protocols, which are written down in public.</li>
         <li><b>Not a hosted service.</b> There is no abuuba.com sign-up. It is software you install on your own server.</li>
         <li><b>Not a company product.</b> One person wrote it, as a side project of <a href="https://vutuv.de">vutuv</a>.</li>
-        <li><b>Not a bid to replace Mastodon.</b> The hope is the nginx effect: nginx did not kill Apache, it made Apache faster.</li>
+        <li><b>Not a bid to kill Mastodon.</b> An instance can be replaced by one of these, domain and accounts and posts intact, if its admin wants that. The hope is still the nginx effect: nginx did not kill Apache, it made Apache faster.</li>
       </ul>
     </div>
   </section>


### PR DESCRIPTION
The site never told an admin that an existing Mastodon instance can become an
abuuba one, and the JavaScript section explained LiveView in terms only a
Phoenix developer would follow.

Two new bands on the homepage: what abuuba does that Mastodon does, and what a
takeover keeps. The feature list was checked against the code first, so it
names only what abuuba's own interface really has — lists, bookmarks and
reporting are left out, because they exist in the client API alone. The essay
heading "Not here to replace Mastodon" contradicted all of it and now says
"kill", the word the nginx quote under it already uses. Press page and the
takeover doc's stale line about recent sign-ins follow.

Merging publishes abuuba.com.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01YLiwAQ1syMMmviScFkZFoE
