### PR TITLE
Put the origin story back on the site

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -160,6 +160,16 @@ mix abuuba.import --verify  <i># check it afterwards</i></pre>
 
   <section class="band">
     <div class="wrap reveal">
+      <h2>Why abuuba <em>exists</em>.</h2>
+      <p>I reinvented a perfectly good wheel. Here is why.</p>
+      <p>I am the founder of <a href="https://vutuv.de">vutuv</a>, a business network: an open source LinkedIn alternative that talks to the fediverse as well. It is fast on purpose, and testing it means driving federation through a real ActivityPub peer every day. A peer that cannot keep up drags the whole loop down to its own speed, and for a long time that peer was Mastodon. Seeding it with a thousand followers and two hundred posts took fifteen minutes. abuuba does the same in thirty-nine seconds.</p>
+      <p>That is not a complaint about Mastodon, and not one about <a href="https://rubyonrails.org">Ruby on Rails</a>. I love Rails. It is a pleasure to write and it has earned every bit of its reputation, and I wrote books about it. But Phoenix and Elixir are faster, and not by a little. The <a href="https://www.erlang.org/">BEAM</a> was built to run one system across several machines: nodes find each other and pass messages as ordinary work, with no Redis in the middle and no separate job runner to keep in step. Rails reaches the same place by adding those pieces and then keeping them alive.</p>
+      <p>So I wrote abuuba. The wheel was perfectly good. It was just too heavy for the cart I was building.</p>
+    </div>
+  </section>
+
+  <section class="band">
+    <div class="wrap reveal">
       <h2>Not here to kill Mastodon. <em>To push it.</em></h2>
       <blockquote class="quote">
         <p>This is the <a href="https://nginx.org">nginx</a> and <a href="https://httpd.apache.org">Apache</a> story. Apache was good software and still is; nginx turned up because a different shape of load arrived and an architecture built for the older one could not bend that far. The part worth remembering is what happened next: nginx did not kill Apache, it made Apache faster and better.</p>


### PR DESCRIPTION
Puts the vutuv origin story back on the front page as a new band, "Why abuuba exists", between the Mastodon takeover section and the nginx essay, so the two first-person pieces share one signature.

The text is the README’s account, trimmed: vutuv fast on purpose, its ActivityPub test peer not keeping up, fifteen minutes to seed a peer against thirty-nine seconds. The README’s closing clause about one application and one Postgres is left out, because a later band already makes that point.

Checked in Chrome against a local server: it renders, the reveal animation fires, no console errors.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01F27dF8b9sT9C7kfh6jNMHu