### PR TITLE
Ask an account that approves its followers, rather than following it

### DIFF
--- a/docs/de/user/profile.md
+++ b/docs/de/user/profile.md
@@ -91,6 +91,11 @@ weiter folgt, hat eine Timeline voll mit der gerade blockierten Person.
 Wen du blockierst, der sieht auch deine Beiträge nicht mehr, den direkten Link
 auf die Seite eines Beitrags eingeschlossen.
 
+Manche Leute bestätigen ihre Follower von Hand. Wer einem solchen Konto folgt,
+schickt stattdessen eine Anfrage, und aus dem Knopf wird **Folgeanfrage
+zurückziehen**, bis sie beantwortet ist. Ein Druck darauf nimmt die Anfrage
+zurück; solange du wartest, kommt nichts von dort bei dir an.
+
 ## Mit der Tastatur lesen
 
 `j` und `k` springen zwischen den Beiträgen auf jeder Seite, die welche

--- a/docs/user/profiles.md
+++ b/docs/user/profiles.md
@@ -82,6 +82,11 @@ full of the person they just blocked.
 Blocking somebody also hides your posts from them, including the direct link to
 a post's page.
 
+Some people approve their followers by hand. Following one of them sends a
+request instead, and the button becomes **Cancel follow request** until they
+answer. Press it to take the request back; nothing of theirs reaches you while
+you are waiting.
+
 ## Reading from the keyboard
 
 `j` and `k` move between posts on any page that lists them, and the post you

--- a/lib/abuuba/accounts/auth.ex
+++ b/lib/abuuba/accounts/auth.ex
@@ -272,7 +272,9 @@ defmodule Abuuba.Accounts.Auth do
   defp first_user?, do: Repo.aggregate(User, :count) == 1
 
   # The point of an invite is usually that the two people already know each
-  # other, so a new account arrives with somebody to read.
+  # other, so a new account arrives with somebody to read. Outright even for an
+  # account that approves its followers: whoever turned this on for their own
+  # invite has already said yes to whoever redeems it.
   defp autofollow(_account, nil), do: :ok
   defp autofollow(_account, %{autofollow: false}), do: :ok
 

--- a/lib/abuuba/accounts/migration.ex
+++ b/lib/abuuba/accounts/migration.ex
@@ -140,7 +140,10 @@ defmodule Abuuba.Accounts.Migration do
   # The followers on this server are this server's to move, and moving them is
   # the whole point. Follow first, then unfollow: the other order leaves
   # somebody following nobody if the second step fails, and following both for
-  # a moment is a much smaller wrong than following neither.
+  # a moment is a much smaller wrong than following neither. Outright even
+  # where the new account approves its followers, because a move needs an alias
+  # back and that makes both accounts the same person's: they are not being
+  # asked to approve people they already approved.
   defp move_local_followers(account, target) do
     account
     |> local_follower_ids()

--- a/lib/abuuba/federation/activity/move.ex
+++ b/lib/abuuba/federation/activity/move.ex
@@ -89,7 +89,10 @@ defmodule Abuuba.Federation.Activity.Move do
 
   # Follow first, then unfollow. The other order leaves somebody following
   # nobody if the second step fails, and following both for a moment is a much
-  # smaller wrong than following neither.
+  # smaller wrong than following neither. Outright rather than asked: the
+  # follow was granted by the same person, on the account they moved from, and
+  # a locked target answers the `Follow` we send with an `Accept` or a `Reject`
+  # of its own.
   defp refollow(follower, origin, target) do
     Relationships.follow(follower, target)
     Relationships.unfollow(follower, origin)

--- a/lib/abuuba/imports/csv_rows.ex
+++ b/lib/abuuba/imports/csv_rows.ex
@@ -72,7 +72,7 @@ defmodule Abuuba.Imports.CSVRows do
   @spec apply(atom(), map(), map()) :: :ok | {:error, atom()}
   def apply(:following, account, row) do
     with {:ok, target} <- lookup(row) do
-      relate(Relationships.follow(account, target, follow_options(row)))
+      relate(Relationships.follow_or_request(account, target, follow_options(row)))
     end
   end
 
@@ -111,7 +111,7 @@ defmodule Abuuba.Imports.CSVRows do
       # A list holds people somebody follows, so the follow comes first. An
       # exported list names accounts the old server knew they followed, and the
       # follow list may not have been imported yet — or at all.
-      Relationships.follow(account, target)
+      Relationships.follow_or_request(account, target)
 
       relate(Lists.add(list, [target.id]))
     else

--- a/lib/abuuba/relationships.ex
+++ b/lib/abuuba/relationships.ex
@@ -37,8 +37,9 @@ defmodule Abuuba.Relationships do
   ## Following
 
   @doc """
-  Follows an account outright. For an account that approves its followers
-  manually, use `request_follow/3`.
+  Follows an account outright, whatever that account asked for. Anything a
+  person presses goes through `follow_or_request/3` instead, which asks an
+  account that approves its followers rather than following it.
 
   Refused if either account has blocked the other: a follow that a block would
   immediately have to undo should never come into being.
@@ -137,6 +138,11 @@ defmodule Abuuba.Relationships do
       delete_edge(Endorsement, follower_id, target_id)
     end
 
+    # A request nobody has answered yet is the follow until they answer it, so
+    # whatever stops a follow stops this too. Without it, somebody who asked an
+    # account that never answers has no way out of waiting.
+    withdraw_request(follower_id, target_id)
+
     :ok
   end
 
@@ -171,6 +177,56 @@ defmodule Abuuba.Relationships do
           :ok
       end)
     end
+  end
+
+  @doc """
+  Follows an account, or asks it, whichever that account has said it wants.
+
+  The one door behind every "Follow" a person presses -- the profile, the
+  explore list, the API, a follow list being imported -- so that an account
+  which approves its followers is asked wherever the button is drawn, and not
+  only where somebody remembered to check. `follow/3` stays the way in for the
+  paths that mean an outright follow: a move carrying followers to a new
+  account, an invite whose owner asked for them.
+  """
+  @spec follow_or_request(Account.t(), Account.t(), map()) ::
+          {:ok, Follow.t() | FollowRequest.t()} | {:error, :blocked | Ecto.Changeset.t()}
+  def follow_or_request(follower, target, attrs \\ %{})
+
+  def follow_or_request(%Account{} = follower, %Account{} = target, attrs) do
+    # A follow already granted is changed by a repeat follow, on an account
+    # that approves its followers like on any other: somebody who locked their
+    # account afterwards has answered for the people already following them,
+    # and a fresh request would sit beside a follow that is already in place.
+    if approves_followers?(target) and not following?(follower, target) do
+      ask_to_follow(follower, target, attrs)
+    else
+      follow(follower, target, attrs)
+    end
+  end
+
+  # Asking twice is one request rather than an error: the second press carries
+  # whatever changed, the same way a repeat follow does.
+  defp ask_to_follow(follower, target, attrs) do
+    case get_follow_request(follower, target) do
+      nil ->
+        request_follow(follower, target, attrs)
+
+      pending ->
+        pending
+        |> FollowRequest.changeset(edge_attrs(attrs, follower.id, target.id))
+        |> Repo.update()
+    end
+  end
+
+  # Read from the row, not from the copy the caller is holding: a profile open
+  # in a browser was built when the page loaded, and what decides this is
+  # whether the account approves its followers at the moment of the press.
+  defp approves_followers?(%Account{id: id}) do
+    Account
+    |> where([a], a.id == ^id)
+    |> select([a], a.locked)
+    |> Repo.one()
   end
 
   @doc """
@@ -399,6 +455,19 @@ defmodule Abuuba.Relationships do
   end
 
   @doc """
+  The ids of the accounts an account has asked to follow and is waiting on.
+  """
+  @spec requested_ids(Account.t() | integer()) :: [integer()]
+  def requested_ids(%Account{id: id}), do: requested_ids(id)
+
+  def requested_ids(account_id) do
+    FollowRequest
+    |> where([r], r.account_id == ^account_id)
+    |> select([r], r.target_account_id)
+    |> Repo.all()
+  end
+
+  @doc """
   The ids of an account's followers.
   """
   @spec follower_ids(Account.t() | integer()) :: [integer()]
@@ -459,12 +528,11 @@ defmodule Abuuba.Relationships do
       |> Repo.insert()
 
     with {:ok, block} <- result do
-      # Both directions. A block that left the blocked account still following
-      # would have the API report "blocking" and "followed_by" at once.
+      # Both directions, and `unfollow/2` takes the unanswered requests with
+      # it. A block that left the blocked account still following would have
+      # the API report "blocking" and "followed_by" at once.
       unfollow(blocker_id, target_id)
       unfollow(target_id, blocker_id)
-      withdraw_request(blocker_id, target_id)
-      withdraw_request(target_id, blocker_id)
 
       # Both feeds, not only the blocker's: a block means neither of them is
       # reading the other, and `unfollow/2` above only clears one side when
@@ -811,8 +879,23 @@ defmodule Abuuba.Relationships do
     :ok
   end
 
-  defp withdraw_request(account_id, target_id),
-    do: delete_edge(FollowRequest, account_id, target_id)
+  # Wherever a request stops being one without being answered: the asker took
+  # it back, or a block tore it down. The `Undo` matters as much as the row,
+  # because the other server is holding a pending request of its own and
+  # nothing else tells it the question was withdrawn.
+  defp withdraw_request(account_id, target_id) do
+    case get_edge(FollowRequest, account_id, target_id) do
+      nil ->
+        :ok
+
+      request ->
+        Repo.delete(request)
+        forget_request(request)
+        Outbox.unfollowed(request)
+
+        :ok
+    end
+  end
 
   defp blocked_either_way?(account_id, target_id) do
     Block

--- a/lib/abuuba_web/controllers/api/account_controller.ex
+++ b/lib/abuuba_web/controllers/api/account_controller.ex
@@ -425,13 +425,11 @@ defmodule AbuubaWeb.API.AccountController do
         |> put_if(params, "notify", :notify)
         |> put_languages(params)
 
-      # A locked account is asked rather than followed. The request is the
-      # follow until they say yes.
-      # A follow request counts too: asking four hundred locked accounts in a
-      # day is the same list-building the allowance exists to stop.
+      # A follow request spends the allowance too: asking four hundred locked
+      # accounts in a day is the same list-building the number exists to stop.
       result =
         with :ok <- Relationships.take_follow_budget(account),
-             do: make_follow(account, target, attrs)
+             do: Relationships.follow_or_request(account, target, attrs)
 
       case result do
         {:ok, _edge} ->
@@ -656,15 +654,6 @@ defmodule AbuubaWeb.API.AccountController do
       end
     end)
   end
-
-  # A locked account is asked rather than followed. The request is the follow
-  # until they say yes, and it spends the same allowance: asking four hundred
-  # locked accounts in a day is the list-building the number exists to stop.
-  defp make_follow(account, %Account{locked: true} = target, attrs),
-    do: Relationships.request_follow(account, target, attrs)
-
-  defp make_follow(account, target, attrs),
-    do: Relationships.follow(account, target, attrs)
 
   defp render_relationship(conn, account, target) do
     json(conn, Entities.relationship(Relationships.relationship(account, target)))

--- a/lib/abuuba_web/live/explore_live.ex
+++ b/lib/abuuba_web/live/explore_live.ex
@@ -104,7 +104,7 @@ defmodule AbuubaWeb.ExploreLive do
           </div>
 
           <button
-            :if={followable?(@viewer, person, @following)}
+            :if={followable?(@viewer, person, @following) and not requested?(person, @requested)}
             type="button"
             phx-click="follow"
             phx-value-account={person.id}
@@ -112,6 +112,10 @@ defmodule AbuubaWeb.ExploreLive do
           >
             {gettext("Follow")}
           </button>
+
+          <span :if={requested?(person, @requested)} class="badge badge-ghost">
+            {gettext("Requested")}
+          </span>
         </li>
       </ul>
 
@@ -135,7 +139,7 @@ defmodule AbuubaWeb.ExploreLive do
            # A screen that suggests people to follow is the easiest place to
            # build a list from, so it is the last place to leave uncounted.
            :ok <- Relationships.take_follow_budget(viewer) do
-        Relationships.follow(viewer, target)
+        Relationships.follow_or_request(viewer, target)
       end
 
     socket =
@@ -218,7 +222,10 @@ defmodule AbuubaWeb.ExploreLive do
       tags: tags(socket.assigns.tab),
       people: people(socket.assigns.tab)
     )
-    |> assign(following: following(socket.assigns.tab, viewer))
+    |> assign(
+      following: following(socket.assigns.tab, viewer),
+      requested: requested(socket.assigns.tab, viewer)
+    )
   end
 
   # Read once for the page rather than once per card: twenty people on screen
@@ -227,6 +234,9 @@ defmodule AbuubaWeb.ExploreLive do
   # follow list is not a thing to fetch for a page of posts.
   defp following(tab, viewer) when tab != :people or is_nil(viewer), do: MapSet.new()
   defp following(_tab, viewer), do: viewer |> Relationships.following_ids() |> MapSet.new()
+
+  defp requested(tab, viewer) when tab != :people or is_nil(viewer), do: MapSet.new()
+  defp requested(_tab, viewer), do: viewer |> Relationships.requested_ids() |> MapSet.new()
 
   # Only the tab being looked at asks the database. Three queries for a page
   # that shows one of them is two queries nobody needed.
@@ -282,6 +292,12 @@ defmodule AbuubaWeb.ExploreLive do
   defp followable?(viewer, person, following) do
     viewer.id != person.id and not MapSet.member?(following, person.id)
   end
+
+  # There is no unfollow button on this screen, so there is no cancel either --
+  # that lives on the profile. What this owes somebody who pressed Follow on an
+  # account that approves its followers is the news that they did, rather than
+  # a button that quietly disappears as if the follow had gone through.
+  defp requested?(person, requested), do: MapSet.member?(requested, person.id)
 
   defp tabs do
     [

--- a/lib/abuuba_web/live/profile_live.ex
+++ b/lib/abuuba_web/live/profile_live.ex
@@ -138,12 +138,21 @@ defmodule AbuubaWeb.ProfileLive do
 
         <div :if={@actionable?} class="mt-4 flex flex-wrap items-center gap-2">
           <button
-            :if={!@relationship.following}
+            :if={!@relationship.following and not @relationship.requested}
             type="button"
             phx-click="follow"
             class="btn btn-primary btn-sm"
           >
             {gettext("Follow")}
+          </button>
+
+          <button
+            :if={@relationship.requested}
+            type="button"
+            phx-click="unfollow"
+            class="btn btn-sm"
+          >
+            {gettext("Cancel follow request")}
           </button>
 
           <button
@@ -402,7 +411,9 @@ defmodule AbuubaWeb.ProfileLive do
   def handle_event("follow", _params, socket) do
     case Relationships.take_follow_budget(socket.assigns.viewer) do
       :ok ->
-        act(socket, &Relationships.follow/2)
+        {:noreply, socket} = act(socket, &Relationships.follow_or_request/2)
+
+        {:noreply, explain_request(socket)}
 
       {:error, :rate_limited} ->
         {:noreply, put_flash(socket, :error, follow_limit_message())}
@@ -584,6 +595,19 @@ defmodule AbuubaWeb.ProfileLive do
   defp follow_limit_message do
     gettext("Too many follows today. Try again tomorrow.")
   end
+
+  # The button turning into "Cancel follow request" is the whole answer for
+  # anybody who knew the account was locked. For everybody else, pressing
+  # Follow and not following is a surprise that needs a sentence.
+  defp explain_request(%{assigns: %{relationship: %{requested: true}}} = socket) do
+    put_flash(
+      socket,
+      :info,
+      gettext("This account approves its followers. Your request is waiting for an answer.")
+    )
+  end
+
+  defp explain_request(socket), do: socket
 
   defp act(socket, fun) do
     if socket.assigns.actionable? do
@@ -789,6 +813,7 @@ defmodule AbuubaWeb.ProfileLive do
   defp relationship(nil, _subject),
     do: %{
       following: false,
+      requested: false,
       muting: false,
       blocking: false,
       endorsed: false,
@@ -802,6 +827,10 @@ defmodule AbuubaWeb.ProfileLive do
 
     %{
       following: follow != nil,
+      # An account that approves its followers leaves the button waiting on
+      # somebody else, and a button that says nothing about that reads as one
+      # that did not work.
+      requested: follow == nil and Relationships.get_follow_request(viewer, subject) != nil,
       muting: Relationships.muting?(viewer, subject),
       blocking: Relationships.blocking?(viewer, subject),
       endorsed: Relationships.endorsed?(viewer, subject),

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -13,21 +13,21 @@ msgstr ""
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/abuuba_web/formats.ex:69
+#: lib/abuuba_web/formats.ex:103
 #, elixir-autogen, elixir-format
 msgid "1 day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] "vor 1 Tag"
 msgstr[1] "vor %{count} Tagen"
 
-#: lib/abuuba_web/formats.ex:68
+#: lib/abuuba_web/formats.ex:102
 #, elixir-autogen, elixir-format
 msgid "1 hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] "vor 1 Stunde"
 msgstr[1] "vor %{count} Stunden"
 
-#: lib/abuuba_web/formats.ex:67
+#: lib/abuuba_web/formats.ex:101
 #, elixir-autogen, elixir-format
 msgid "1 minute ago"
 msgid_plural "%{count} minutes ago"
@@ -51,7 +51,7 @@ msgid "Change"
 msgstr "Ändern"
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:735
+#: lib/abuuba_web/live/compose_component.ex:736
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr "Sprache"
@@ -76,7 +76,7 @@ msgstr "Keine Internetverbindung"
 msgid "close"
 msgstr "schließen"
 
-#: lib/abuuba_web/formats.ex:66
+#: lib/abuuba_web/formats.ex:100
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr "gerade eben"
@@ -420,7 +420,7 @@ msgstr "Einschalten"
 msgid "Turn off two-factor authentication?"
 msgstr "Zwei-Faktor-Authentifizierung ausschalten?"
 
-#: lib/abuuba_web/live/settings_live.ex:898
+#: lib/abuuba_web/live/settings_live.ex:899
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:21
 #: lib/abuuba_web/live/two_factor_settings_live.ex:80
@@ -468,8 +468,8 @@ msgstr "%{app} autorisieren"
 
 #: lib/abuuba_web/live/admin_live.ex:1739
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:409
-#: lib/abuuba_web/live/compose_component.ex:422
+#: lib/abuuba_web/live/compose_component.ex:410
+#: lib/abuuba_web/live/compose_component.ex:423
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -626,14 +626,14 @@ msgstr "Diese Anwendung hat Berechtigungen angefragt, die dieser Server nicht ke
 msgid "Upload files as you"
 msgstr "Als du Dateien hochladen"
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:666
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:667
 #: lib/abuuba_web/controllers/well_known_controller.ex:42
 #: lib/abuuba_web/controllers/well_known_controller.ex:48
 #, elixir-autogen, elixir-format
 msgid "No such account here."
 msgstr "So ein Konto gibt es hier nicht."
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:586
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:587
 #: lib/abuuba_web/controllers/well_known_controller.ex:64
 #, elixir-autogen, elixir-format
 msgid "That account is gone."
@@ -644,12 +644,12 @@ msgstr "Dieses Konto gibt es nicht mehr."
 msgid "That is not a resource we understand."
 msgstr "Diese Ressource verstehen wir nicht."
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:684
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:685
 #, elixir-autogen, elixir-format
 msgid "A server may only ask about its own followers."
 msgstr "Ein Server darf nur nach seinen eigenen Followern fragen."
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:678
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:679
 #, elixir-autogen, elixir-format
 msgid "That request has to be signed."
 msgstr "Diese Anfrage muss signiert sein."
@@ -664,7 +664,7 @@ msgstr "Entdecken"
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
 #: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
@@ -691,14 +691,14 @@ msgstr "Hauptnavigation"
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr "Mitteilungen"
 
 #: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:117
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:118
+#: lib/abuuba_web/live/settings_live.ex:2112
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -720,39 +720,39 @@ msgid_plural "%{count} new posts"
 msgstr[0] "%{count} neuer Beitrag"
 msgstr[1] "%{count} neue Beiträge"
 
-#: lib/abuuba_web/components/status_component.ex:298
+#: lib/abuuba_web/components/status_component.ex:300
 #, elixir-autogen, elixir-format
 msgid "%{count} vote"
 msgid_plural "%{count} votes"
 msgstr[0] "%{count} Stimme"
 msgstr[1] "%{count} Stimmen"
 
-#: lib/abuuba_web/components/status_component.ex:152
+#: lib/abuuba_web/components/status_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "%{name} boosted"
 msgstr "%{name} hat geteilt"
 
-#: lib/abuuba_web/components/status_component.ex:237
+#: lib/abuuba_web/components/status_component.ex:239
 #, elixir-autogen, elixir-format
 msgid "Attachment"
 msgstr "Anhang"
 
-#: lib/abuuba_web/components/status_component.ex:419
+#: lib/abuuba_web/components/status_component.ex:421
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/abuuba_web/components/status_component.ex:396
+#: lib/abuuba_web/components/status_component.ex:398
 #, elixir-autogen, elixir-format
 msgid "Boost"
 msgstr "Teilen"
 
-#: lib/abuuba_web/components/status_component.ex:307
+#: lib/abuuba_web/components/status_component.ex:309
 #, elixir-autogen, elixir-format
 msgid "Closed"
 msgstr "Beendet"
 
-#: lib/abuuba_web/components/status_component.ex:408
+#: lib/abuuba_web/components/status_component.ex:410
 #, elixir-autogen, elixir-format
 msgid "Favourite"
 msgstr "Favorisieren"
@@ -762,13 +762,13 @@ msgstr "Favorisieren"
 msgid "Follow some people and their posts will appear here."
 msgstr "Folge ein paar Menschen, dann erscheinen ihre Beiträge hier."
 
-#: lib/abuuba_web/components/status_component.ex:265
-#: lib/abuuba_web/live/compose_component.ex:615
+#: lib/abuuba_web/components/status_component.ex:267
+#: lib/abuuba_web/live/compose_component.ex:616
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Umfrage"
 
-#: lib/abuuba_web/components/status_component.ex:384
+#: lib/abuuba_web/components/status_component.ex:386
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
@@ -778,7 +778,7 @@ msgstr "Antworten"
 msgid "That vote could not be counted."
 msgstr "Diese Stimme konnte nicht gezählt werden."
 
-#: lib/abuuba_web/components/status_component.ex:275
+#: lib/abuuba_web/components/status_component.ex:277
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr "Abstimmen"
@@ -788,308 +788,308 @@ msgstr "Abstimmen"
 msgid "You have reached the end."
 msgstr "Du bist am Ende angekommen."
 
-#: lib/abuuba_web/components/status_component.ex:283
+#: lib/abuuba_web/components/status_component.ex:285
 #, elixir-autogen, elixir-format
 msgid "Your choice"
 msgstr "Deine Wahl"
 
-#: lib/abuuba_web/live/compose_component.ex:1681
+#: lib/abuuba_web/live/compose_component.ex:1682
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr "1 Tag"
 
-#: lib/abuuba_web/live/compose_component.ex:1679
+#: lib/abuuba_web/live/compose_component.ex:1680
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr "1 Stunde"
 
-#: lib/abuuba_web/live/compose_component.ex:1682
+#: lib/abuuba_web/live/compose_component.ex:1683
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr "3 Tage"
 
-#: lib/abuuba_web/live/compose_component.ex:1678
+#: lib/abuuba_web/live/compose_component.ex:1679
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr "30 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1678
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr "5 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1680
+#: lib/abuuba_web/live/compose_component.ex:1681
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr "6 Stunden"
 
-#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/compose_component.ex:1684
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr "7 Tage"
 
-#: lib/abuuba_web/live/compose_component.ex:1155
+#: lib/abuuba_web/live/compose_component.ex:1156
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr "Eine Umfrage braucht mindestens zwei Antworten."
 
-#: lib/abuuba_web/live/compose_component.ex:650
+#: lib/abuuba_web/live/compose_component.ex:651
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr "Antwort hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:721
+#: lib/abuuba_web/live/compose_component.ex:722
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr "Umfrage hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:662
+#: lib/abuuba_web/live/compose_component.ex:663
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr "Mehrfachauswahl erlauben"
 
-#: lib/abuuba_web/live/compose_component.ex:1698
-#: lib/abuuba_web/live/settings_live.ex:2291
+#: lib/abuuba_web/live/compose_component.ex:1699
+#: lib/abuuba_web/live/settings_live.ex:2292
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr "Alle"
 
-#: lib/abuuba_web/live/compose_component.ex:1689
-#: lib/abuuba_web/live/settings_live.ex:2286
+#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/settings_live.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr "Alle, und überall gelistet"
 
-#: lib/abuuba_web/live/compose_component.ex:1690
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/compose_component.ex:1691
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr "Alle, aber nicht in öffentlichen Timelines"
 
-#: lib/abuuba_web/live/compose_component.ex:626
+#: lib/abuuba_web/live/compose_component.ex:627
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr "Antwort %{number}"
 
-#: lib/abuuba_web/live/compose_component.ex:450
-#: lib/abuuba_web/live/compose_component.ex:711
+#: lib/abuuba_web/live/compose_component.ex:451
+#: lib/abuuba_web/live/compose_component.ex:712
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/abuuba_web/live/compose_component.ex:812
+#: lib/abuuba_web/live/compose_component.ex:813
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr "Strg + Enter veröffentlicht"
 
-#: lib/abuuba_web/live/compose_component.ex:445
+#: lib/abuuba_web/live/compose_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr "Diese Person nicht mit anschreiben"
 
-#: lib/abuuba_web/components/status_component.ex:430
+#: lib/abuuba_web/components/status_component.ex:432
 #: lib/abuuba_web/live/admin_live.ex:1759
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/abuuba_web/live/compose_component.ex:415
+#: lib/abuuba_web/live/compose_component.ex:416
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/abuuba_web/live/compose_component.ex:666
+#: lib/abuuba_web/live/compose_component.ex:667
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr "Endet nach"
 
-#: lib/abuuba_web/live/compose_component.ex:1691
-#: lib/abuuba_web/live/profile_live.ex:837
+#: lib/abuuba_web/live/compose_component.ex:1692
+#: lib/abuuba_web/live/profile_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/abuuba_web/live/compose_component.ex:1692
+#: lib/abuuba_web/live/compose_component.ex:1693
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr "Erwähnte Personen"
 
 #: lib/abuuba_web/live/admin_live.ex:3419
-#: lib/abuuba_web/live/compose_component.ex:1700
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/compose_component.ex:1701
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr "Niemand"
 
-#: lib/abuuba_web/live/compose_component.ex:1691
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/compose_component.ex:1692
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr "Nur die Leute, die dir folgen"
 
-#: lib/abuuba_web/live/compose_component.ex:1692
+#: lib/abuuba_web/live/compose_component.ex:1693
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr "Nur die Leute, die du nennst"
 
-#: lib/abuuba_web/live/compose_component.ex:1699
-#: lib/abuuba_web/live/settings_live.ex:2292
+#: lib/abuuba_web/live/compose_component.ex:1700
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr "Leute, die dir folgen"
 
-#: lib/abuuba_web/live/compose_component.ex:1455
+#: lib/abuuba_web/live/compose_component.ex:1456
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/compose_component.ex:695
+#: lib/abuuba_web/live/compose_component.ex:696
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/abuuba_web/live/compose_component.ex:1689
-#: lib/abuuba_web/live/compose_component.ex:1707
+#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1708
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1691
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr "Still öffentlich"
 
-#: lib/abuuba_web/live/compose_component.ex:731
+#: lib/abuuba_web/live/compose_component.ex:732
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr "Umfrage entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:638
+#: lib/abuuba_web/live/compose_component.ex:639
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr "Diese Antwort entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:402
+#: lib/abuuba_web/live/compose_component.ex:403
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr "Antwort an %{name}"
 
-#: lib/abuuba_web/live/compose_component.ex:1453
+#: lib/abuuba_web/live/compose_component.ex:1454
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
 #: lib/abuuba_web/live/admin_live.ex:3380
-#: lib/abuuba_web/live/compose_component.ex:477
+#: lib/abuuba_web/live/compose_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr "Vorschläge"
 
-#: lib/abuuba_web/live/compose_component.ex:1117
+#: lib/abuuba_web/live/compose_component.ex:1118
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr "Das ist %{count} Zeichen zu lang."
 
-#: lib/abuuba_web/live/compose_component.ex:1179
-#: lib/abuuba_web/live/compose_component.ex:1214
-#: lib/abuuba_web/live/compose_component.ex:1409
+#: lib/abuuba_web/live/compose_component.ex:1180
+#: lib/abuuba_web/live/compose_component.ex:1215
+#: lib/abuuba_web/live/compose_component.ex:1410
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr "Der Beitrag konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/compose_component.ex:461
-#: lib/abuuba_web/live/compose_component.ex:467
+#: lib/abuuba_web/live/compose_component.ex:462
+#: lib/abuuba_web/live/compose_component.ex:468
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr "Was beschäftigt dich?"
 
-#: lib/abuuba_web/live/compose_component.ex:455
+#: lib/abuuba_web/live/compose_component.ex:456
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr "Wovor sollen die Leute gewarnt werden?"
 
-#: lib/abuuba_web/live/compose_component.ex:771
+#: lib/abuuba_web/live/compose_component.ex:772
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr "Wer das zitieren darf"
 
-#: lib/abuuba_web/live/compose_component.ex:751
+#: lib/abuuba_web/live/compose_component.ex:752
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr "Wer das sehen darf"
 
-#: lib/abuuba_web/live/compose_component.ex:1113
+#: lib/abuuba_web/live/compose_component.ex:1114
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr "Schreib erst mal etwas."
 
-#: lib/abuuba_web/live/compose_component.ex:1211
+#: lib/abuuba_web/live/compose_component.ex:1212
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr "Du hast gerade viel veröffentlicht. Versuch es später noch einmal."
 
-#: lib/abuuba_web/live/compose_component.ex:1651
+#: lib/abuuba_web/live/compose_component.ex:1652
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr "jemanden"
 
-#: lib/abuuba_web/live/compose_component.ex:818
+#: lib/abuuba_web/live/compose_component.ex:819
 #, elixir-autogen, elixir-format
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] "%{count} Entwurf"
 msgstr[1] "%{count} Entwürfe"
 
-#: lib/abuuba_web/live/compose_component.ex:850
+#: lib/abuuba_web/live/compose_component.ex:851
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] "%{count} Beitrag wartet auf den Versand"
 msgstr[1] "%{count} Beiträge warten auf den Versand"
 
-#: lib/abuuba_web/live/compose_component.ex:1159
+#: lib/abuuba_web/live/compose_component.ex:1160
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr "Eine Antwort ist zu lang. Halte jede unter %{count} Zeichen."
 
-#: lib/abuuba_web/live/compose_component.ex:881
+#: lib/abuuba_web/live/compose_component.ex:882
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr "Absagen"
 
-#: lib/abuuba_web/live/compose_component.ex:842
+#: lib/abuuba_web/live/compose_component.ex:843
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: lib/abuuba_web/live/compose_component.ex:681
+#: lib/abuuba_web/live/compose_component.ex:682
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr "Geht raus am"
 
-#: lib/abuuba_web/live/compose_component.ex:832
-#: lib/abuuba_web/live/compose_component.ex:871
+#: lib/abuuba_web/live/compose_component.ex:833
+#: lib/abuuba_web/live/compose_component.ex:872
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr "Öffnen"
 
-#: lib/abuuba_web/live/compose_component.ex:1130
-#: lib/abuuba_web/live/compose_component.ex:1400
+#: lib/abuuba_web/live/compose_component.ex:1131
+#: lib/abuuba_web/live/compose_component.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr "Sag, wann der Beitrag rausgehen soll."
 
-#: lib/abuuba_web/live/compose_component.ex:803
+#: lib/abuuba_web/live/compose_component.ex:804
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr "Planen"
 
-#: lib/abuuba_web/live/compose_component.ex:1454
+#: lib/abuuba_web/live/compose_component.ex:1455
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr "Einplanen"
 
-#: lib/abuuba_web/live/compose_component.ex:316
+#: lib/abuuba_web/live/compose_component.ex:317
 #, elixir-autogen, elixir-format
 msgid "That draft could not be saved."
 msgstr "Der Entwurf konnte nicht gespeichert werden."
@@ -1099,104 +1099,104 @@ msgstr "Der Entwurf konnte nicht gespeichert werden."
 msgid "That post is scheduled."
 msgstr "Der Beitrag ist eingeplant."
 
-#: lib/abuuba_web/live/compose_component.ex:1164
+#: lib/abuuba_web/live/compose_component.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr "Zwei Antworten sind gleich. Mach sie unterschiedlich."
 
-#: lib/abuuba_web/live/compose_component.ex:312
+#: lib/abuuba_web/live/compose_component.ex:313
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr "Du hast zu viele Entwürfe für einen weiteren. Verwirf erst einen."
 
-#: lib/abuuba_web/live/compose_component.ex:1448
+#: lib/abuuba_web/live/compose_component.ex:1449
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr "ein leerer Beitrag"
 
-#: lib/abuuba_web/live/compose_component.ex:688
+#: lib/abuuba_web/live/compose_component.ex:689
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr "deine eigene Zeit, mindestens %{count} Minuten ab jetzt"
 
-#: lib/abuuba_web/live/compose_component.ex:1127
+#: lib/abuuba_web/live/compose_component.ex:1128
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr "Ein Bild geht ohne Beschreibung raus. Schick noch einmal ab, um es trotzdem zu veröffentlichen."
 
-#: lib/abuuba_web/live/compose_component.ex:496
+#: lib/abuuba_web/live/compose_component.ex:497
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr "Bild, Video oder Ton hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:591
+#: lib/abuuba_web/live/compose_component.ex:592
 #, elixir-autogen, elixir-format
 msgid "Add a still"
 msgstr "Standbild hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:541
+#: lib/abuuba_web/live/compose_component.ex:542
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr "Klick auf den wichtigsten Teil"
 
-#: lib/abuuba_web/live/compose_component.ex:558
-#: lib/abuuba_web/live/compose_component.ex:566
+#: lib/abuuba_web/live/compose_component.ex:559
+#: lib/abuuba_web/live/compose_component.ex:567
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr "Beschreibe das für Leute, die es nicht sehen können"
 
-#: lib/abuuba_web/live/compose_component.ex:580
+#: lib/abuuba_web/live/compose_component.ex:581
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr "Nach vorne"
 
-#: lib/abuuba_web/live/compose_component.ex:595
+#: lib/abuuba_web/live/compose_component.ex:596
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr "Standbild auswählen"
 
-#: lib/abuuba_web/live/compose_component.ex:553
+#: lib/abuuba_web/live/compose_component.ex:554
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr "Bildmittelpunkt festlegen"
 
-#: lib/abuuba_web/live/compose_component.ex:521
+#: lib/abuuba_web/live/compose_component.ex:522
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr "Abbrechen"
 
-#: lib/abuuba_web/live/compose_component.ex:606
+#: lib/abuuba_web/live/compose_component.ex:607
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:251
-#: lib/abuuba_web/live/compose_component.ex:1444
+#: lib/abuuba_web/live/compose_component.ex:252
+#: lib/abuuba_web/live/compose_component.ex:1445
 #, elixir-autogen, elixir-format
 msgid "That file could not be uploaded."
 msgstr "Die Datei konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/compose_component.ex:1441
+#: lib/abuuba_web/live/compose_component.ex:1442
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/compose_component.ex:238
+#: lib/abuuba_web/live/compose_component.ex:239
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr "Mehr als %{count} Bilder trägt ein Beitrag nicht."
 
-#: lib/abuuba_web/live/compose_component.ex:1442
+#: lib/abuuba_web/live/compose_component.ex:1443
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr "Das sind mehr Dateien, als ein Beitrag tragen kann."
 
-#: lib/abuuba_web/live/compose_component.ex:1443
+#: lib/abuuba_web/live/compose_component.ex:1444
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr "Dieser Server nimmt keine Dateien dieser Art."
 
-#: lib/abuuba_web/live/compose_component.ex:500
+#: lib/abuuba_web/live/compose_component.ex:501
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr "oder zieh eine ins Feld oder füg sie ein"
@@ -1206,12 +1206,12 @@ msgstr "oder zieh eine ins Feld oder füg sie ein"
 msgid "%{name} on %{server}"
 msgstr "%{name} auf %{server}"
 
-#: lib/abuuba_web/live/profile_live.ex:292
+#: lib/abuuba_web/live/profile_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr "Eine Notiz, die nur du liest"
 
-#: lib/abuuba_web/live/profile_live.ex:189
+#: lib/abuuba_web/live/profile_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr "Blockieren"
@@ -1233,29 +1233,29 @@ msgstr "Zum neuen Konto"
 msgid "Look for more replies on the other server"
 msgstr "Auf dem anderen Server nach weiteren Antworten suchen"
 
-#: lib/abuuba_web/live/profile_live.ex:836
+#: lib/abuuba_web/live/profile_live.ex:865
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr "Medien"
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr "Stummschalten"
 
-#: lib/abuuba_web/live/profile_live.ex:363
+#: lib/abuuba_web/live/profile_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr "Hier ist noch nichts."
 
-#: lib/abuuba_web/live/profile_live.ex:338
-#: lib/abuuba_web/live/profile_live.ex:339
+#: lib/abuuba_web/live/profile_live.ex:347
+#: lib/abuuba_web/live/profile_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr "Angeheftet"
 
-#: lib/abuuba_web/live/explore_live.ex:288
-#: lib/abuuba_web/live/profile_live.ex:834
+#: lib/abuuba_web/live/explore_live.ex:304
+#: lib/abuuba_web/live/profile_live.ex:863
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:122
 #: lib/abuuba_web/live/search_live.ex:264
@@ -1263,13 +1263,13 @@ msgstr "Angeheftet"
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/abuuba_web/live/profile_live.ex:835
+#: lib/abuuba_web/live/profile_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr "Beiträge und Antworten"
 
 #: lib/abuuba_web/live/admin_live.ex:929
-#: lib/abuuba_web/live/profile_live.ex:296
+#: lib/abuuba_web/live/profile_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr "Notiz speichern"
@@ -1284,19 +1284,19 @@ msgstr "Der Server war nicht erreichbar, mehr gibt es also nicht."
 msgid "This account has moved to %{handle}."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
-#: lib/abuuba_web/live/profile_live.ex:189
-#: lib/abuuba_web/live/settings_live.ex:824
+#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/settings_live.ex:825
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr "Blockierung aufheben"
 
-#: lib/abuuba_web/live/profile_live.ex:155
+#: lib/abuuba_web/live/profile_live.ex:164
 #: lib/abuuba_web/live/tag_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Entfolgen"
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr "Stummschaltung aufheben"
@@ -1306,7 +1306,7 @@ msgstr "Stummschaltung aufheben"
 msgid "Verified"
 msgstr "Bestätigt"
 
-#: lib/abuuba_web/live/profile_live.ex:300
+#: lib/abuuba_web/live/profile_live.ex:309
 #: lib/abuuba_web/live/search_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "What to show"
@@ -1504,9 +1504,9 @@ msgid "Follow requests"
 msgstr "Folgeanfragen"
 
 #: lib/abuuba_web/live/notifications_live.ex:443
-#: lib/abuuba_web/live/profile_live.ex:838
-#: lib/abuuba_web/live/settings_live.ex:2095
-#: lib/abuuba_web/live/settings_live.ex:2227
+#: lib/abuuba_web/live/profile_live.ex:867
+#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folge ich"
@@ -1573,22 +1573,22 @@ msgstr "Private Erwähnungen aus dem Nichts"
 #: lib/abuuba_web/live/admin_live.ex:1572
 #: lib/abuuba_web/live/admin_live.ex:2148
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:255
-#: lib/abuuba_web/live/settings_live.ex:292
-#: lib/abuuba_web/live/settings_live.ex:386
-#: lib/abuuba_web/live/settings_live.ex:423
-#: lib/abuuba_web/live/settings_live.ex:487
-#: lib/abuuba_web/live/settings_live.ex:594
-#: lib/abuuba_web/live/settings_live.ex:639
-#: lib/abuuba_web/live/settings_live.ex:672
-#: lib/abuuba_web/live/settings_live.ex:994
+#: lib/abuuba_web/live/profile_live.ex:264
+#: lib/abuuba_web/live/settings_live.ex:293
+#: lib/abuuba_web/live/settings_live.ex:387
+#: lib/abuuba_web/live/settings_live.ex:424
+#: lib/abuuba_web/live/settings_live.ex:488
+#: lib/abuuba_web/live/settings_live.ex:595
+#: lib/abuuba_web/live/settings_live.ex:640
+#: lib/abuuba_web/live/settings_live.ex:673
+#: lib/abuuba_web/live/settings_live.ex:995
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Speichern"
 
 #: lib/abuuba_web/live/admin_live.ex:237
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:134
+#: lib/abuuba_web/live/settings_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr "Gespeichert."
@@ -1647,7 +1647,7 @@ msgstr "Ein Name, ein #Tag oder ein paar Wörter"
 msgid "Everything"
 msgstr "Alles"
 
-#: lib/abuuba_web/live/explore_live.ex:289
+#: lib/abuuba_web/live/explore_live.ex:305
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:113
 #: lib/abuuba_web/live/search_live.ex:263
@@ -1680,7 +1680,7 @@ msgstr "Hier hat noch niemand öffentlich etwas veröffentlicht."
 msgid "Nobody has posted under this tag yet."
 msgstr "Unter diesem Tag hat noch niemand etwas veröffentlicht."
 
-#: lib/abuuba_web/live/explore_live.ex:119
+#: lib/abuuba_web/live/explore_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht haben."
@@ -1690,7 +1690,7 @@ msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht habe
 msgid "Nothing matched that."
 msgstr "Dazu gab es keine Treffer."
 
-#: lib/abuuba_web/live/explore_live.ex:290
+#: lib/abuuba_web/live/explore_live.ex:306
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:103
 #: lib/abuuba_web/live/search_live.ex:262
@@ -1703,19 +1703,19 @@ msgstr "Leute"
 msgid "Recently, from people here"
 msgstr "Neulich, von Leuten hier"
 
-#: lib/abuuba_web/live/about_live.ex:115
+#: lib/abuuba_web/live/about_live.ex:116
 #: lib/abuuba_web/live/landing_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Registration is closed here, but any other server on the network will do."
 msgstr "Die Registrierung ist hier geschlossen, aber jeder andere Server im Netzwerk tut es auch."
 
-#: lib/abuuba_web/live/about_live.ex:109
+#: lib/abuuba_web/live/about_live.ex:110
 #: lib/abuuba_web/live/landing_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "Registration is open: anybody may sign up."
 msgstr "Die Registrierung ist offen: jeder darf sich anmelden."
 
-#: lib/abuuba_web/live/about_live.ex:112
+#: lib/abuuba_web/live/about_live.ex:113
 #: lib/abuuba_web/live/landing_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Registration needs approval: you sign up and an admin reads your request."
@@ -1760,220 +1760,220 @@ msgstr "Beiträge nach einem Datum"
 msgid "posts older than a date"
 msgstr "Beiträge vor einem Datum"
 
-#: lib/abuuba_web/live/settings_live.ex:889
+#: lib/abuuba_web/live/settings_live.ex:890
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr "Ein neues Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:232
+#: lib/abuuba_web/live/settings_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Über dich"
 
 #: lib/abuuba_web/live/admin_live.ex:3370
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Konto"
 
-#: lib/abuuba_web/live/settings_live.ex:288
+#: lib/abuuba_web/live/settings_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Add a field"
 msgstr "Feld hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:805
+#: lib/abuuba_web/live/settings_live.ex:806
 #, elixir-autogen, elixir-format
 msgid "Add a filter"
 msgstr "Filter hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2264
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr "Gilt nur für deine öffentlichen Beiträge."
 
-#: lib/abuuba_web/live/settings_live.ex:2097
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2123
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr "Apps, die in dein Konto gelassen wurden."
 
-#: lib/abuuba_web/live/settings_live.ex:945
+#: lib/abuuba_web/live/settings_live.ex:946
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr "Apps, bei denen du angemeldet bist. Eine wieder hinauszunehmen meldet sie sofort ab."
 
-#: lib/abuuba_web/live/settings_live.ex:2258
+#: lib/abuuba_web/live/settings_live.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr "Vor jedem Follow fragen"
 
-#: lib/abuuba_web/live/settings_live.ex:893
+#: lib/abuuba_web/live/settings_live.ex:894
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr "Passwort ändern"
 
 #: lib/abuuba_web/live/admin_live.ex:983
-#: lib/abuuba_web/live/settings_live.ex:752
+#: lib/abuuba_web/live/settings_live.ex:753
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:221
+#: lib/abuuba_web/live/settings_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr "Anzeigename"
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr "Medien nicht von selbst abspielen"
 
-#: lib/abuuba_web/live/settings_live.ex:1598
+#: lib/abuuba_web/live/settings_live.ex:1599
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr "Jede Zeile muss eine Webadresse sein, eine pro Zeile."
 
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/settings_live.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr "Jeder Follow wird zu einer Anfrage, die du beantwortest."
 
-#: lib/abuuba_web/live/settings_live.ex:2120
+#: lib/abuuba_web/live/settings_live.ex:2121
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr "Allen, denen du folgst, und ein Weg, damit aufzuhören."
 
-#: lib/abuuba_web/live/settings_live.ex:199
+#: lib/abuuba_web/live/settings_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr "Alles zu deinem Konto ist hier. Wähl einen Bereich."
 
-#: lib/abuuba_web/live/settings_live.ex:237
+#: lib/abuuba_web/live/settings_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr "Felder"
 
-#: lib/abuuba_web/live/settings_live.ex:2094
-#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2095
+#: lib/abuuba_web/live/settings_live.ex:2234
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2316
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr "Hinter einer Warnung zusammenklappen"
 
-#: lib/abuuba_web/live/settings_live.ex:2316
+#: lib/abuuba_web/live/settings_live.ex:2317
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr "Ganz ausblenden"
 
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr "Verbergen, wem ich folge und wer mir folgt"
 
-#: lib/abuuba_web/live/settings_live.ex:2272
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr "Mehr Kontrast"
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr "Wie sich die Oberfläche verhält und liest."
 
-#: lib/abuuba_web/live/settings_live.ex:252
+#: lib/abuuba_web/live/settings_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:2263
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr "Suchmaschinen meine Beiträge indexieren lassen"
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr "Mich im Verzeichnis listen"
 
-#: lib/abuuba_web/live/settings_live.ex:2267
+#: lib/abuuba_web/live/settings_live.ex:2268
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr "Markiert das Konto als Bot, worauf manche Leute filtern."
 
-#: lib/abuuba_web/live/settings_live.ex:270
+#: lib/abuuba_web/live/settings_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/abuuba_web/live/settings_live.ex:974
+#: lib/abuuba_web/live/settings_live.ex:975
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr "Es wurde keine App hereingelassen."
 
-#: lib/abuuba_web/live/settings_live.ex:988
+#: lib/abuuba_web/live/settings_live.ex:989
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr "Eine Webadresse pro Zeile. Ein Konto hier zu nennen erlaubt dir später den Umzug dorthin, und es muss dieses hier zurücknennen."
 
-#: lib/abuuba_web/live/settings_live.ex:447
+#: lib/abuuba_web/live/settings_live.ex:448
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr "Nur die genannten Leute fehlt mit Absicht: als Voreinstellung wird jeder Beitrag, den du zu ändern vergisst, zu einer Nachricht an niemanden."
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr "Deine anderen Konten und der Umzug zwischen ihnen."
 
-#: lib/abuuba_web/live/settings_live.ex:2279
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr "Überschreibt deine Systemeinstellung, wenn sie für dich falsch ist."
 
-#: lib/abuuba_web/live/settings_live.ex:2089
+#: lib/abuuba_web/live/settings_live.ex:2090
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Überblick"
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr "Öffentliche Timelines"
 
-#: lib/abuuba_web/live/settings_live.ex:2271
+#: lib/abuuba_web/live/settings_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr "Bewegung reduzieren"
@@ -1984,165 +1984,165 @@ msgstr "Bewegung reduzieren"
 #: lib/abuuba_web/live/admin_live.ex:1862
 #: lib/abuuba_web/live/admin_live.ex:2186
 #: lib/abuuba_web/live/conversations_live.ex:111
-#: lib/abuuba_web/live/settings_live.ex:278
-#: lib/abuuba_web/live/settings_live.ex:313
+#: lib/abuuba_web/live/settings_live.ex:279
+#: lib/abuuba_web/live/settings_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2097
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr "Sicherheit"
 
-#: lib/abuuba_web/live/settings_live.ex:906
+#: lib/abuuba_web/live/settings_live.ex:907
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr "Überall abmelden"
 
-#: lib/abuuba_web/live/settings_live.ex:902
+#: lib/abuuba_web/live/settings_live.ex:903
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr "Überall abmelden beendet jede Sitzung, auch diese."
 
-#: lib/abuuba_web/live/settings_live.ex:2282
+#: lib/abuuba_web/live/settings_live.ex:2283
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr "Hält das erste Absenden an, wenn ein Bild keine Beschreibung hat."
 
-#: lib/abuuba_web/live/settings_live.ex:968
+#: lib/abuuba_web/live/settings_live.ex:969
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr "Wieder hinausnehmen"
 
 #: lib/abuuba_web/live/admin_live.ex:3748
-#: lib/abuuba_web/live/settings_live.ex:2085
+#: lib/abuuba_web/live/settings_live.ex:2086
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr "Das konnte nicht gespeichert werden. Prüf, was du eingegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1573
+#: lib/abuuba_web/live/settings_live.ex:1574
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr "Das aktuelle Passwort stimmt nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:466
+#: lib/abuuba_web/live/settings_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr "Die Sprache, in der du meistens schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr "Die Listen sind nicht mehr öffentlich; die Follows selbst funktionieren weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:2266
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr "Dieses Konto veröffentlicht automatisch"
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr "Threads"
 
-#: lib/abuuba_web/live/settings_live.ex:847
+#: lib/abuuba_web/live/settings_live.ex:848
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr "Hak alle an, denen du nicht mehr folgen willst, und drück dann einmal den Knopf."
 
-#: lib/abuuba_web/live/settings_live.ex:872
+#: lib/abuuba_web/live/settings_live.ex:873
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr "Den angehakten entfolgen"
 
-#: lib/abuuba_web/live/settings_live.ex:239
+#: lib/abuuba_web/live/settings_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr "Bis zu vier Zeilen auf deinem Profil. Die Reihenfolge hier ist die Reihenfolge dort."
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr "Die Schrift meines Systems verwenden"
 
-#: lib/abuuba_web/live/settings_live.ex:259
+#: lib/abuuba_web/live/settings_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr "Wert"
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr "Mich auf fehlende Beschreibungen hinweisen"
 
-#: lib/abuuba_web/live/settings_live.ex:797
+#: lib/abuuba_web/live/settings_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr "Was er tut"
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2118
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr "Womit das Schreibfeld beginnt."
 
 #: lib/abuuba_web/live/admin_live.ex:2162
-#: lib/abuuba_web/live/settings_live.ex:759
+#: lib/abuuba_web/live/settings_live.ex:760
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr "Wie er heißen soll"
 
-#: lib/abuuba_web/live/settings_live.ex:764
+#: lib/abuuba_web/live/settings_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr "Wo er gilt"
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2119
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr "Wer dich finden kann und wer fragen muss, um zu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:453
+#: lib/abuuba_web/live/settings_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr "Wer neue Beiträge zitieren darf"
 
-#: lib/abuuba_web/live/settings_live.ex:434
+#: lib/abuuba_web/live/settings_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr "An wen neue Beiträge gehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr "Wörter und Wendungen, die du lieber nicht siehst."
 
-#: lib/abuuba_web/live/settings_live.ex:868
+#: lib/abuuba_web/live/settings_live.ex:869
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr "Du folgst noch niemandem."
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr "Dein Konto erscheint auf der öffentlichen Verzeichnisseite dieses Servers."
 
-#: lib/abuuba_web/live/settings_live.ex:884
+#: lib/abuuba_web/live/settings_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr "Dein aktuelles Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr "Dein Name, was du über dich sagst, deine Felder."
 
-#: lib/abuuba_web/live/settings_live.ex:985
+#: lib/abuuba_web/live/settings_live.ex:986
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr "Deine anderen Konten"
 
-#: lib/abuuba_web/live/settings_live.ex:2121
+#: lib/abuuba_web/live/settings_live.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr "Dein Passwort, Zwei-Faktor und das Abmelden."
@@ -2152,19 +2152,19 @@ msgstr "Dein Passwort, Zwei-Faktor und das Abmelden."
 msgid "A handle looks like name@server."
 msgstr "Ein Handle sieht aus wie name@server."
 
-#: lib/abuuba_web/live/about_live.ex:43
+#: lib/abuuba_web/live/about_live.ex:44
 #, elixir-autogen, elixir-format
 msgid "A server on the fediverse, running %{software}."
 msgstr "Ein Server im Fediverse, betrieben mit %{software}."
 
-#: lib/abuuba_web/live/about_live.ex:22
+#: lib/abuuba_web/live/about_live.ex:23
 #: lib/abuuba_web/live/admin_live.ex:619
-#: lib/abuuba_web/live/document_live.ex:114
+#: lib/abuuba_web/live/document_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr "Über"
 
-#: lib/abuuba_web/live/document_live.ex:105
+#: lib/abuuba_web/live/document_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "About this server"
 msgstr "Über diesen Server"
@@ -2174,12 +2174,12 @@ msgstr "Über diesen Server"
 msgid "Do this from your own server"
 msgstr "Mach das von deinem eigenen Server aus"
 
-#: lib/abuuba_web/live/about_live.ex:78
+#: lib/abuuba_web/live/about_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Getting in touch"
 msgstr "Kontakt"
 
-#: lib/abuuba_web/live/document_live.ex:82
+#: lib/abuuba_web/live/document_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "In effect since %{date}"
 msgstr "In Kraft seit %{date}"
@@ -2189,9 +2189,9 @@ msgstr "In Kraft seit %{date}"
 msgid "No password is asked for and nothing is done on your behalf: you are simply sent to your own server's search with this address filled in."
 msgstr "Es wird kein Passwort abgefragt und nichts in deinem Namen getan: du wirst nur zur Suche deines eigenen Servers geschickt, mit dieser Adresse eingetragen."
 
-#: lib/abuuba_web/live/about_live.ex:91
+#: lib/abuuba_web/live/about_live.ex:92
 #: lib/abuuba_web/live/admin_live.ex:1944
-#: lib/abuuba_web/live/document_live.ex:113
+#: lib/abuuba_web/live/document_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
 msgstr "Datenschutzerklärung"
@@ -2206,7 +2206,7 @@ msgstr "Auf %{server} lesen"
 msgid "Share"
 msgstr "Teilen"
 
-#: lib/abuuba_web/live/about_live.ex:61
+#: lib/abuuba_web/live/about_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Signing up"
 msgstr "Registrierung"
@@ -2226,9 +2226,9 @@ msgstr "Bring mich nach Hause"
 msgid "Take me to my server"
 msgstr "Bring mich zu meinem Server"
 
-#: lib/abuuba_web/live/about_live.ex:90
+#: lib/abuuba_web/live/about_live.ex:91
 #: lib/abuuba_web/live/admin_live.ex:2191
-#: lib/abuuba_web/live/document_live.ex:112
+#: lib/abuuba_web/live/document_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr "Nutzungsbedingungen"
@@ -2238,27 +2238,27 @@ msgstr "Nutzungsbedingungen"
 msgid "That is this server. Use the buttons on the post itself once you are signed in."
 msgstr "Das ist dieser Server. Nutz die Knöpfe am Beitrag selbst, sobald du angemeldet bist."
 
-#: lib/abuuba_web/live/about_live.ex:51
+#: lib/abuuba_web/live/about_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "The numbers"
 msgstr "Die Zahlen"
 
-#: lib/abuuba_web/live/about_live.ex:66
+#: lib/abuuba_web/live/about_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "The rules"
 msgstr "Die Regeln"
 
-#: lib/abuuba_web/live/about_live.ex:88
+#: lib/abuuba_web/live/about_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "The small print"
 msgstr "Das Kleingedruckte"
 
-#: lib/abuuba_web/live/document_live.ex:88
+#: lib/abuuba_web/live/document_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "This has not been written yet. Whoever runs this server can add it in the admin settings."
 msgstr "Das wurde noch nicht geschrieben. Wer diesen Server betreibt, kann es in den Administrationseinstellungen ergänzen."
 
-#: lib/abuuba_web/live/about_live.ex:83
+#: lib/abuuba_web/live/about_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Whoever runs this server has not published an address yet."
 msgstr "Wer diesen Server betreibt, hat noch keine Adresse veröffentlicht."
@@ -2273,135 +2273,135 @@ msgstr "Dein Konto liegt woanders, also passieren Folgen, Antworten und Teilen d
 msgid "Your handle"
 msgstr "Dein Handle"
 
-#: lib/abuuba_web/live/about_live.ex:101
+#: lib/abuuba_web/live/about_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "people"
 msgstr "Leute"
 
-#: lib/abuuba_web/live/about_live.ex:105
+#: lib/abuuba_web/live/about_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "people active this half-year"
 msgstr "Leute in diesem Halbjahr aktiv"
 
-#: lib/abuuba_web/live/about_live.ex:104
+#: lib/abuuba_web/live/about_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "people active this month"
 msgstr "Leute in diesem Monat aktiv"
 
-#: lib/abuuba_web/live/about_live.ex:102
+#: lib/abuuba_web/live/about_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "posts"
 msgstr "Beiträge"
 
-#: lib/abuuba_web/live/about_live.ex:103
+#: lib/abuuba_web/live/about_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "servers known"
 msgstr "bekannte Server"
 
-#: lib/abuuba_web/live/settings_live.ex:1850
+#: lib/abuuba_web/live/settings_live.ex:1851
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr "Eine Verwarnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr "Alles, was eine Moderatorin oder ein Moderator hier über dein Konto entschieden hat."
 
-#: lib/abuuba_web/live/settings_live.ex:1194
+#: lib/abuuba_web/live/settings_live.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr "Einspruch einlegen"
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr "Moderation"
 
-#: lib/abuuba_web/live/settings_live.ex:1224
+#: lib/abuuba_web/live/settings_live.ex:1225
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr "Hier ist nichts. Niemand aus der Moderation hat etwas gegen dein Konto unternommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1834
+#: lib/abuuba_web/live/settings_live.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr "Schreib bitte etwas dazu, warum du das für falsch hältst."
 
-#: lib/abuuba_web/live/settings_live.ex:1191
+#: lib/abuuba_web/live/settings_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr "Warum hältst du das für falsch?"
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr "Einige deiner Beiträge wurden gelöscht"
 
-#: lib/abuuba_web/live/settings_live.ex:1198
-#: lib/abuuba_web/live/settings_live.ex:1830
+#: lib/abuuba_web/live/settings_live.ex:1199
+#: lib/abuuba_web/live/settings_live.ex:1831
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr "Die Frist für einen Einspruch ist abgelaufen."
 
-#: lib/abuuba_web/live/settings_live.ex:1169
+#: lib/abuuba_web/live/settings_live.ex:1170
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr "Was die Moderation hier über dein Konto entschieden hat und was dir dazu gesagt wurde."
 
-#: lib/abuuba_web/live/settings_live.ex:1845
+#: lib/abuuba_web/live/settings_live.ex:1846
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr "Du hast Einspruch eingelegt, er wurde abgelehnt."
 
-#: lib/abuuba_web/live/settings_live.ex:1844
+#: lib/abuuba_web/live/settings_live.ex:1845
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr "Du hast Einspruch eingelegt, ihm wurde stattgegeben."
 
-#: lib/abuuba_web/live/settings_live.ex:1846
+#: lib/abuuba_web/live/settings_live.ex:1847
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr "Du hast Einspruch eingelegt. Entschieden ist noch nichts."
 
-#: lib/abuuba_web/live/settings_live.ex:1851
+#: lib/abuuba_web/live/settings_live.ex:1852
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr "Dein Konto wurde deaktiviert"
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1855
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr "Dein Konto wurde eingeschränkt"
 
-#: lib/abuuba_web/live/settings_live.ex:1855
+#: lib/abuuba_web/live/settings_live.ex:1856
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr "Dein Konto wurde gesperrt"
 
-#: lib/abuuba_web/live/settings_live.ex:1852
+#: lib/abuuba_web/live/settings_live.ex:1853
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr "Deine Beiträge wurden als sensibel markiert"
 
-#: lib/abuuba_web/live/settings_live.ex:1177
+#: lib/abuuba_web/live/settings_live.ex:1178
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr "inzwischen aufgehoben"
 
-#: lib/abuuba_web/live/settings_live.ex:1215
+#: lib/abuuba_web/live/settings_live.ex:1216
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] "%{count} Verbindung verloren"
 msgstr[1] "%{count} Verbindungen verloren"
 
-#: lib/abuuba_web/live/settings_live.ex:1204
+#: lib/abuuba_web/live/settings_live.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr "Verbindungen, die dich die Entscheidungen dieses Servers gekostet haben"
 
-#: lib/abuuba_web/live/settings_live.ex:1206
+#: lib/abuuba_web/live/settings_live.ex:1207
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr "Wenn dieser Server die Verbindung zu einem anderen abbricht, gehen die Folgebeziehungen zwischen dir und den Leuten dort verloren. Von hier aus lassen sie sich nicht wiederherstellen, weil die andere Seite nicht mehr erreichbar ist."
@@ -2697,7 +2697,7 @@ msgstr "Das ist keine Adresse."
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3328
-#: lib/abuuba_web/live/settings_live.ex:1626
+#: lib/abuuba_web/live/settings_live.ex:1627
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr "Das kann dein Konto nicht."
@@ -2787,7 +2787,7 @@ msgstr "gesperrt"
 msgid "the server"
 msgstr "der Server"
 
-#: lib/abuuba_web/components/status_component.ex:305
+#: lib/abuuba_web/components/status_component.ex:307
 #: lib/abuuba_web/live/admin_live.ex:1075
 #, elixir-autogen, elixir-format
 msgid "%{count} person"
@@ -2836,12 +2836,12 @@ msgstr "Was gerade im Trend liegt"
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr "Worüber gerade mehr Leute als sonst schreiben, danach alles Übrige, das Neueste zuerst."
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr "%{uses} von %{max} genutzt"
 
-#: lib/abuuba_web/live/settings_live.ex:1240
+#: lib/abuuba_web/live/settings_live.ex:1241
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr "Ein Code, mit dem sich jemand anmelden kann, auch wenn Anmeldungen geschlossen sind. Lass die Anzahl leer für beliebig viele."
@@ -2856,7 +2856,7 @@ msgstr "Eine Ankündigung braucht einen Text."
 msgid "Announcements"
 msgstr "Ankündigungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr "Codes, mit denen sich Bekannte von dir anmelden können."
@@ -2866,7 +2866,7 @@ msgstr "Codes, mit denen sich Bekannte von dir anmelden können."
 msgid "Each version is kept with the day it takes effect, so somebody can still read what they agreed to."
 msgstr "Jede Fassung wird mit dem Tag aufbewahrt, an dem sie gilt, damit man nachlesen kann, wozu man zugestimmt hat."
 
-#: lib/abuuba_web/live/document_live.ex:94
+#: lib/abuuba_web/live/document_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Earlier versions"
 msgstr "Frühere Fassungen"
@@ -2881,7 +2881,7 @@ msgstr "Darüber wurden bereits alle informiert."
 msgid "Goes up"
 msgstr "Erscheint"
 
-#: lib/abuuba_web/live/settings_live.ex:1251
+#: lib/abuuba_web/live/settings_live.ex:1252
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr "Wie viele Personen"
@@ -2891,17 +2891,17 @@ msgstr "Wie viele Personen"
 msgid "In effect from"
 msgstr "Gültig ab"
 
-#: lib/abuuba_web/live/document_live.ex:98
+#: lib/abuuba_web/live/document_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "In effect from %{date}"
 msgstr "Gültig ab %{date}"
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr "Einladungen"
 
-#: lib/abuuba_web/live/settings_live.ex:1235
+#: lib/abuuba_web/live/settings_live.ex:1236
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
@@ -2911,7 +2911,7 @@ msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
 msgid "Leave this empty to publish it now."
 msgstr "Leer lassen, um sofort zu veröffentlichen."
 
-#: lib/abuuba_web/live/settings_live.ex:1258
+#: lib/abuuba_web/live/settings_live.ex:1259
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr "Erstellen"
@@ -2941,7 +2941,7 @@ msgstr "Veröffentlicht"
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr "Etwas, das hier alle lesen sollten. Mit einer Uhrzeit veröffentlicht es sich selbst, sodass ein Hinweis auf Sonntag schon am Donnerstag geschrieben werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1272
+#: lib/abuuba_web/live/settings_live.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr "Zurücknehmen"
@@ -2956,12 +2956,12 @@ msgstr "Alle informieren"
 msgid "Terms need some text and a day they take effect."
 msgstr "Nutzungsbedingungen brauchen einen Text und einen Tag, ab dem sie gelten."
 
-#: lib/abuuba_web/live/settings_live.ex:1256
+#: lib/abuuba_web/live/settings_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr "Sie folgen dir"
 
-#: lib/abuuba_web/live/settings_live.ex:1247
+#: lib/abuuba_web/live/settings_live.ex:1248
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr "Wofür sie ist"
@@ -2982,7 +2982,7 @@ msgstr "Wann es veröffentlicht wird"
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr "Du meldest dich auf eine Einladung hin an, eine Freigabe brauchst du deshalb nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:1278
+#: lib/abuuba_web/live/settings_live.ex:1279
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr "Du hast noch keine erstellt."
@@ -2992,7 +2992,7 @@ msgstr "Du hast noch keine erstellt."
 msgid "everybody was told"
 msgstr "alle wurden informiert"
 
-#: lib/abuuba_web/live/settings_live.ex:2080
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3101,14 +3101,14 @@ msgstr "irgendwo"
 msgid "approval only"
 msgstr "nur mit Freigabe"
 
-#: lib/abuuba_web/components/status_component.ex:337
+#: lib/abuuba_web/components/status_component.ex:339
 #, elixir-autogen, elixir-format
 msgid "by %{name}"
 msgstr "von %{name}"
 
-#: lib/abuuba_web/live/explore_live.ex:204
+#: lib/abuuba_web/live/explore_live.ex:208
 #: lib/abuuba_web/live/home_live.ex:337
-#: lib/abuuba_web/live/profile_live.ex:518
+#: lib/abuuba_web/live/profile_live.ex:529
 #: lib/abuuba_web/live/search_live.ex:195
 #: lib/abuuba_web/live/status_live.ex:184
 #: lib/abuuba_web/live/tag_live.ex:153
@@ -3116,12 +3116,12 @@ msgstr "von %{name}"
 msgid "That could not be translated just now."
 msgstr "Das ließ sich gerade nicht übersetzen."
 
-#: lib/abuuba_web/components/status_component.ex:444
+#: lib/abuuba_web/components/status_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
 
-#: lib/abuuba_web/components/status_component.ex:129
+#: lib/abuuba_web/components/status_component.ex:131
 #, elixir-autogen, elixir-format
 msgid "Translated by %{provider}. Reload the page for the original."
 msgstr "Übersetzt von %{provider}. Lade die Seite neu für das Original."
@@ -3131,275 +3131,275 @@ msgstr "Übersetzt von %{provider}. Lade die Seite neu für das Original."
 msgid "This account has been disabled. Contact the moderators."
 msgstr "Dieses Konto wurde deaktiviert. Wende dich an die Moderation."
 
-#: lib/abuuba_web/live/settings_live.ex:1979
+#: lib/abuuba_web/live/settings_live.ex:1980
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr "%{count} konnten nicht übernommen werden"
 
-#: lib/abuuba_web/live/settings_live.ex:1970
+#: lib/abuuba_web/live/settings_live.ex:1971
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr "%{done} von %{total} gelesen, %{imported} übernommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1886
+#: lib/abuuba_web/live/settings_live.ex:1887
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr "Boosts und Umfragen. Ein Boost verweist auf den Beitrag einer anderen Person, den das Archiv nicht enthält, und die Stimmen einer Umfrage wären hier nicht mehr richtig."
 
-#: lib/abuuba_web/live/settings_live.ex:2043
+#: lib/abuuba_web/live/settings_live.ex:2044
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr "Wähle zuerst ein Archiv aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1867
+#: lib/abuuba_web/live/settings_live.ex:1868
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr "Jeder Fediverse-Server gibt dir ein ZIP mit allem, was du geschrieben hast. Lade es hier hoch, und deine Beiträge kommen zurück, mit ihren Bildern und ihrem ursprünglichen Datum."
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr "Fertig."
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
 
-#: lib/abuuba_web/live/settings_live.ex:1892
+#: lib/abuuba_web/live/settings_live.ex:1893
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr "Importierte Beiträge tauchen in keiner Timeline auf und gehen nicht ins Netzwerk. Sie stehen in deinem Profil, in der Reihenfolge, in der du sie geschrieben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:2058
+#: lib/abuuba_web/live/settings_live.ex:2059
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr "Ein Archiv auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr "Ein Archiv deiner Beiträge von einem anderen Server wieder einlesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2066
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr "Dein Archiv wird gelesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2068
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr "Das Archiv konnte nicht gelesen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2039
+#: lib/abuuba_web/live/settings_live.ex:2040
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr "Das konnte nicht gelesen werden. Lade das Archiv hoch, das dir dein alter Server gegeben hat."
 
-#: lib/abuuba_web/live/settings_live.ex:2054
-#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2055
+#: lib/abuuba_web/live/settings_live.ex:2060
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr "Das konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/settings_live.ex:2057
+#: lib/abuuba_web/live/settings_live.ex:2058
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr "Das ist keine Archivdatei."
 
-#: lib/abuuba_web/live/settings_live.ex:1876
+#: lib/abuuba_web/live/settings_live.ex:1877
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr "Die alten Adressen. Deine Beiträge lagen auf einer anderen Domain und können dort nicht wieder liegen, also bleibt jeder Link darauf tot."
 
-#: lib/abuuba_web/live/settings_live.ex:2064
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr "Wartet auf den Start."
 
-#: lib/abuuba_web/live/settings_live.ex:1873
+#: lib/abuuba_web/live/settings_live.ex:1874
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr "Was nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:1881
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr "Deine Follower. Ein Follow ist eine Abmachung zwischen zwei Servern, und einer davon ist weg; sie müssen diesem Konto neu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:2070
+#: lib/abuuba_web/live/settings_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr "ein Boost, der nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2072
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr "eine Umfrage, die nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr "kein Datum, also kein Platz dafür"
 
-#: lib/abuuba_web/live/settings_live.ex:2076
+#: lib/abuuba_web/live/settings_live.ex:2077
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr "die Datei ist kein Archiv"
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr "der Beitrag wurde nicht gefunden"
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2076
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr "dieser Server hat ihn nicht angenommen"
 
-#: lib/abuuba_web/live/settings_live.ex:1043
+#: lib/abuuba_web/live/settings_live.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr "Alle annehmen"
 
-#: lib/abuuba_web/live/settings_live.ex:1925
+#: lib/abuuba_web/live/settings_live.ex:1926
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr "Dazu hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:1038
+#: lib/abuuba_web/live/settings_live.ex:1039
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr "Nach einem Umzug kommen alle, die dir gefolgt sind, auf einmal an. Das nimmt sie alle an, was dieselbe Antwort ist, die du ihnen schon gegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1943
+#: lib/abuuba_web/live/settings_live.ex:1944
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr "Ein Archiv deiner Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:1048
+#: lib/abuuba_web/live/settings_live.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr "Für den Export deiner Daten und das Löschen des Kontos steht die Arbeit noch aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1036
+#: lib/abuuba_web/live/settings_live.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr "Wartende Folgeanfragen"
 
-#: lib/abuuba_web/live/settings_live.ex:1005
+#: lib/abuuba_web/live/settings_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr "Ich bin zurück"
 
-#: lib/abuuba_web/live/settings_live.ex:1956
+#: lib/abuuba_web/live/settings_live.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr "Archiv importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:1934
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr "Liste importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1062
-#: lib/abuuba_web/live/settings_live.ex:1905
-#: lib/abuuba_web/live/settings_live.ex:2230
+#: lib/abuuba_web/live/settings_live.ex:1063
+#: lib/abuuba_web/live/settings_live.ex:1906
+#: lib/abuuba_web/live/settings_live.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr "Listen"
 
-#: lib/abuuba_web/live/settings_live.ex:1032
+#: lib/abuuba_web/live/settings_live.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr "Umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:1016
+#: lib/abuuba_web/live/settings_live.ex:1017
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr "Zu einem anderen Konto umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2029
+#: lib/abuuba_web/live/settings_live.ex:2030
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr "Unter dieser Adresse war niemand zu finden."
 
-#: lib/abuuba_web/live/settings_live.ex:1000
+#: lib/abuuba_web/live/settings_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr "Anderen Servern wird gesagt, dass sie stattdessen dem neuen Konto folgen sollen. Wer dir von diesem Server aus folgt, ist bereits umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1929
+#: lib/abuuba_web/live/settings_live.ex:1930
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr "Durch die Datei ersetzen"
 
-#: lib/abuuba_web/live/settings_live.ex:2019
+#: lib/abuuba_web/live/settings_live.ex:2020
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr "Dieses Konto nennt dieses hier nicht als eines von deinen. Trage die Adresse dieses Kontos zuerst dort bei den Aliassen ein."
 
-#: lib/abuuba_web/live/settings_live.ex:2030
+#: lib/abuuba_web/live/settings_live.ex:2031
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr "Das ist dieses Konto."
 
-#: lib/abuuba_web/live/settings_live.ex:1907
+#: lib/abuuba_web/live/settings_live.ex:1908
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr "Die CSV-Dateien, die dir dein alter Server gibt: Follows, Blocks, Stummschaltungen, Domain-Blocks, Listen, Lesezeichen, Filter. Lade sie einzeln hoch, unter dem Namen, unter dem sie kamen."
 
-#: lib/abuuba_web/live/settings_live.ex:1026
+#: lib/abuuba_web/live/settings_live.ex:1027
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr "Das andere Konto muss dieses hier zuerst in seinen eigenen Aliassen nennen. Deine Follower hier ziehen mit um, und alle anderen Server werden benachrichtigt; ein Konto kann nur alle %{days} Tage umziehen."
 
-#: lib/abuuba_web/live/settings_live.ex:998
+#: lib/abuuba_web/live/settings_live.ex:999
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1922
+#: lib/abuuba_web/live/settings_live.ex:1923
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr "Was mit dem passieren soll, was schon da ist"
 
-#: lib/abuuba_web/live/settings_live.ex:2025
+#: lib/abuuba_web/live/settings_live.ex:2026
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr "Du bist vor Kurzem umgezogen. Ein Konto kann nur alle %{days} Tage umziehen."
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:672
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:673
 #, elixir-autogen, elixir-format
 msgid "No such post here."
 msgstr "So einen Beitrag gibt es hier nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:242
+#: lib/abuuba_web/live/settings_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr "Ein Link bekommt einen Haken, sobald die Seite, auf die er zeigt, mit rel=\"me\" auf dein Profil zurückverweist. Wir schauen etwa einmal pro Woche wieder nach."
 
-#: lib/abuuba_web/live/settings_live.ex:780
+#: lib/abuuba_web/live/settings_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr "Ein Wort pro Zeile. Ein Beitrag passt, wenn eines davon darin vorkommt."
 
-#: lib/abuuba_web/live/settings_live.ex:793
+#: lib/abuuba_web/live/settings_live.ex:794
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr "Nur ganze Wörter, damit „Katze“ nicht auf „Katzenklo“ passt"
 
-#: lib/abuuba_web/live/settings_live.ex:777
+#: lib/abuuba_web/live/settings_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr "Wonach gesucht wird"
 
-#: lib/abuuba_web/live/settings_live.ex:1512
+#: lib/abuuba_web/live/settings_live.ex:1513
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr "Ein Filter braucht mindestens ein Wort, nach dem er suchen soll."
@@ -3409,54 +3409,54 @@ msgstr "Ein Filter braucht mindestens ein Wort, nach dem er suchen soll."
 msgid "Why they want to join:"
 msgstr "Warum die Person mitmachen möchte:"
 
-#: lib/abuuba_web/live/settings_live.ex:305
+#: lib/abuuba_web/live/settings_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] "%{count} Beitrag"
 msgstr[1] "%{count} Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:322
+#: lib/abuuba_web/live/settings_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr "Ein Hashtag, ohne das #"
 
-#: lib/abuuba_web/live/settings_live.ex:325
+#: lib/abuuba_web/live/settings_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Feature it"
 msgstr "Hervorheben"
 
-#: lib/abuuba_web/live/settings_live.ex:296
+#: lib/abuuba_web/live/settings_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr "Hervorgehobene Hashtags"
 
-#: lib/abuuba_web/live/settings_live.ex:298
+#: lib/abuuba_web/live/settings_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr "Stehen auf deinem Profil als Abkürzung zu dem, worüber du schreibst."
 
-#: lib/abuuba_web/live/settings_live.ex:1495
+#: lib/abuuba_web/live/settings_live.ex:1496
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr "Das ist kein Hashtag, den man benutzen kann."
 
-#: lib/abuuba_web/live/settings_live.ex:329
+#: lib/abuuba_web/live/settings_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr "Du schreibst oft über:"
 
-#: lib/abuuba_web/live/settings_live.ex:1489
+#: lib/abuuba_web/live/settings_live.ex:1490
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr "Ein Profil kann %{count} Hashtags tragen. Nimm zuerst einen weg."
 
-#: lib/abuuba_web/live/settings_live.ex:480
+#: lib/abuuba_web/live/settings_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr "Sagen, aus welcher App du schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:482
+#: lib/abuuba_web/live/settings_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr "Steht für alle anderen unter deinen Beiträgen. An deinen eigenen siehst du es immer."
@@ -3513,57 +3513,57 @@ msgstr "Sammlung"
 msgid "Nobody is on this list yet."
 msgstr "Auf dieser Liste steht noch niemand."
 
-#: lib/abuuba_web/live/annual_report_live.ex:116
+#: lib/abuuba_web/live/annual_report_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "%{count} posts in %{year}"
 msgstr "%{count} Beiträge in %{year}"
 
-#: lib/abuuba_web/live/annual_report_live.ex:45
+#: lib/abuuba_web/live/annual_report_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "%{name}'s year"
 msgstr "Das Jahr von %{name}"
 
-#: lib/abuuba_web/live/annual_report_live.ex:108
+#: lib/abuuba_web/live/annual_report_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Asked a lot of questions."
 msgstr "Hat viele Fragen gestellt."
 
-#: lib/abuuba_web/live/annual_report_live.ex:80
+#: lib/abuuba_web/live/annual_report_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Counted from public posts only."
 msgstr "Gezählt wurden nur öffentliche Beiträge."
 
-#: lib/abuuba_web/live/annual_report_live.ex:107
+#: lib/abuuba_web/live/annual_report_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Mostly here to pass on what other people said."
 msgstr "Vor allem hier, um weiterzugeben, was andere gesagt haben."
 
-#: lib/abuuba_web/live/annual_report_live.ex:63
+#: lib/abuuba_web/live/annual_report_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "New followers"
 msgstr "Neue Follower"
 
-#: lib/abuuba_web/live/annual_report_live.ex:59
+#: lib/abuuba_web/live/annual_report_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Posts this year"
 msgstr "Beiträge in diesem Jahr"
 
-#: lib/abuuba_web/live/annual_report_live.ex:106
+#: lib/abuuba_web/live/annual_report_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Read a lot more than they wrote."
 msgstr "Hat sehr viel mehr gelesen als geschrieben."
 
-#: lib/abuuba_web/live/annual_report_live.ex:109
+#: lib/abuuba_web/live/annual_report_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "Spent the year in other people's threads."
 msgstr "Hat das Jahr in den Threads anderer verbracht."
 
-#: lib/abuuba_web/live/annual_report_live.ex:69
+#: lib/abuuba_web/live/annual_report_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Written about most"
 msgstr "Worüber am meisten geschrieben wurde"
 
-#: lib/abuuba_web/live/annual_report_live.ex:110
+#: lib/abuuba_web/live/annual_report_live.ex:111
 #, elixir-autogen, elixir-format
 msgid "Wrote things other people replied to."
 msgstr "Hat Dinge geschrieben, auf die andere geantwortet haben."
@@ -3604,7 +3604,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr "Jede Person muss es zusätzlich für sich selbst einschalten, und jede Adresse muss bestätigen, bevor irgendetwas dorthin geht."
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:643
+#: lib/abuuba_web/live/settings_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Email updates"
 msgstr "Neuigkeiten per E-Mail"
@@ -3619,7 +3619,7 @@ msgstr "Neuigkeiten per E-Mail von %{name}"
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr "Wenn du das nicht warst, kannst du diese Nachricht ignorieren. An diese Adresse geht dann nichts weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:661
+#: lib/abuuba_web/live/settings_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr "Leute dürfen meine Neuigkeiten per E-Mail abonnieren"
@@ -3629,7 +3629,7 @@ msgstr "Leute dürfen meine Neuigkeiten per E-Mail abonnieren"
 msgid "No, remove my address"
 msgstr "Nein, meine Adresse löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:663
+#: lib/abuuba_web/live/settings_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3682,7 +3682,7 @@ msgstr "jemand hat diese Adresse angegeben, um Neuigkeiten von %{name} auf %{sit
 msgid "Let people collect email addresses for updates"
 msgstr "Erlaube es, E-Mail-Adressen für Neuigkeiten zu sammeln"
 
-#: lib/abuuba_web/live/settings_live.ex:645
+#: lib/abuuba_web/live/settings_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr "Wer hier kein Konto möchte, kann stattdessen eine E-Mail-Adresse angeben. Die Adresse bestätigt selbst und kann die Neuigkeiten aus jeder Nachricht heraus wieder abbestellen. Verschickt wird noch nichts; das hier sammelt die Liste."
@@ -3830,75 +3830,75 @@ msgstr "jemand hat für dein Konto auf %{site} ein neues Passwort angefordert. W
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr "das Passwort deines Kontos auf %{site} wurde gerade geändert, und überall, wo du angemeldet warst, wurdest du abgemeldet."
 
-#: lib/abuuba_web/live/settings_live.ex:1075
+#: lib/abuuba_web/live/settings_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr "Eine Kopie von allem"
 
-#: lib/abuuba_web/live/settings_live.ex:2237
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr "Wird gebaut"
 
-#: lib/abuuba_web/live/settings_live.ex:808
-#: lib/abuuba_web/live/settings_live.ex:2231
+#: lib/abuuba_web/live/settings_live.ex:809
+#: lib/abuuba_web/live/settings_live.ex:2232
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr "Blockierte Server"
 
 #: lib/abuuba_web/live/admin_live.ex:1301
 #: lib/abuuba_web/live/admin_live.ex:1316
-#: lib/abuuba_web/live/settings_live.ex:2228
+#: lib/abuuba_web/live/settings_live.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr "Blockierte"
 
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:2233
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/abuuba_web/live/settings_live.ex:1117
+#: lib/abuuba_web/live/settings_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr "Bau mir eine Kopie"
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr "Hat nicht geklappt"
 
-#: lib/abuuba_web/live/settings_live.ex:1100
+#: lib/abuuba_web/live/settings_live.ex:1101
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr "Herunterladen"
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2103
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr "Exportieren"
 
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2230
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr "Stummgeschaltete"
 
-#: lib/abuuba_web/live/settings_live.ex:1064
+#: lib/abuuba_web/live/settings_live.ex:1065
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr "Je eine Datei, im Format, das der Import dieses Servers liest. Ein Export von hier ist ein Import anderswo."
 
-#: lib/abuuba_web/live/settings_live.ex:1385
+#: lib/abuuba_web/live/settings_live.ex:1386
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr "Eine wird gerade schon gebaut."
 
-#: lib/abuuba_web/live/settings_live.ex:1082
+#: lib/abuuba_web/live/settings_live.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr "Bilder und Videos sind nicht in der Datei. Sie enthält ihre Adressen, die funktionieren, solange dieser Server läuft."
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2239
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr "Fertig"
@@ -3918,13 +3918,13 @@ msgstr "Die Datei wird nach %{days} Tagen gelöscht, weil sie dein ganzes Konto 
 msgid "There is nothing of that kind to export."
 msgstr "So etwas gibt es hier nicht zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:2236
+#: lib/abuuba_web/live/settings_live.ex:2237
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr "Wartet auf den Start"
 
-#: lib/abuuba_web/live/settings_live.ex:1106
-#: lib/abuuba_web/live/settings_live.ex:1391
+#: lib/abuuba_web/live/settings_live.ex:1107
+#: lib/abuuba_web/live/settings_live.ex:1392
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr "Ab %{date} kannst du eine neue anfordern."
@@ -3934,7 +3934,7 @@ msgstr "Ab %{date} kannst du eine neue anfordern."
 msgid "Your archive is ready"
 msgstr "Deine Kopie ist fertig"
 
-#: lib/abuuba_web/live/settings_live.ex:1077
+#: lib/abuuba_web/live/settings_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wird im Hintergrund gebaut; wir schicken dir eine E-Mail, wenn sie fertig ist."
@@ -3944,67 +3944,67 @@ msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wi
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr "die Kopie deines Kontos auf %{site}, die du angefordert hast, ist fertig. Hier herunterladen:"
 
-#: lib/abuuba_web/live/settings_live.ex:1156
+#: lib/abuuba_web/live/settings_live.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr "Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1154
+#: lib/abuuba_web/live/settings_live.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr "Das Konto endgültig schließen? Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1120
+#: lib/abuuba_web/live/settings_live.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr "Dieses Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1059
+#: lib/abuuba_web/live/settings_live.ex:1060
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr "Alles hier gehört dir, und das Konto zu schließen ist deine Entscheidung."
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr "Eine Kopie von allem mitnehmen, oder das Konto endgültig schließen."
 
-#: lib/abuuba_web/live/settings_live.ex:1137
+#: lib/abuuba_web/live/settings_live.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr "Hol dir vorher deine Kopie. Danach gibt es nichts mehr zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:1418
+#: lib/abuuba_web/live/settings_live.ex:1419
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr "Das hat nicht geklappt. Es wurde nichts gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:1415
+#: lib/abuuba_web/live/settings_live.ex:1416
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr "Das ist nicht dein Passwort."
 
-#: lib/abuuba_web/live/settings_live.ex:1127
+#: lib/abuuba_web/live/settings_live.ex:1128
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr "Das Konto verschwindet sofort. Die Datensätze werden kurz danach gelöscht, damit die Nachricht an die anderen Server noch signiert und verschickt werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1411
+#: lib/abuuba_web/live/settings_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr "Das Konto ist geschlossen. Danke, dass du hier warst."
 
-#: lib/abuuba_web/live/settings_live.ex:1142
+#: lib/abuuba_web/live/settings_live.ex:1143
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr "Dein Passwort, damit sicher ist, dass du es bist"
 
-#: lib/abuuba_web/live/settings_live.ex:1122
+#: lib/abuuba_web/live/settings_live.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr "Deine Beiträge, Folge-Beziehungen, Listen, Filter, Lesezeichen und Einstellungen werden gelöscht, und andere Server werden aufgefordert, ihre Kopien zu löschen. Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1132
+#: lib/abuuba_web/live/settings_live.ex:1133
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr "Dein Benutzername bleibt und niemand kann ihn je bekommen, damit alte Links und Erwähnungen von dir nie auf jemand anderen zeigen."
@@ -4014,7 +4014,7 @@ msgstr "Dein Benutzername bleibt und niemand kann ihn je bekommen, damit alte Li
 msgid "A post"
 msgstr "Ein Beitrag"
 
-#: lib/abuuba_web/live/profile_live.ex:390
+#: lib/abuuba_web/live/profile_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "Nobody yet."
 msgstr "Noch niemand."
@@ -4024,7 +4024,7 @@ msgstr "Noch niemand."
 msgid "Public posts tagged #%{tag}"
 msgstr "Öffentliche Beiträge mit #%{tag}"
 
-#: lib/abuuba_web/live/profile_live.ex:367
+#: lib/abuuba_web/live/profile_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr "Dieses Konto behält für sich, wem es folgt und wer ihm folgt."
@@ -4050,99 +4050,99 @@ msgstr "Diese Einladung kennen wir nicht."
 msgid "You can still sign up without one."
 msgstr "Du kannst dich trotzdem ohne eine anmelden."
 
-#: lib/abuuba_web/live/settings_live.ex:1447
+#: lib/abuuba_web/live/settings_live.ex:1448
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr "Ein Alter muss mindestens 7 Tage betragen, und die Anzahlen dürfen nicht negativ sein."
 
-#: lib/abuuba_web/live/settings_live.ex:912
+#: lib/abuuba_web/live/settings_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr "Gescheiterte Versuche stehen hier ebenfalls. Dass jemand anderes dein Passwort probiert, sollte man früh mitbekommen, und nichts sonst würde es dir sagen."
 
-#: lib/abuuba_web/live/settings_live.ex:521
+#: lib/abuuba_web/live/settings_live.ex:522
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr "Meine alten Beiträge löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:530
+#: lib/abuuba_web/live/settings_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr "Beiträge löschen, die älter sind als, in Tagen"
 
-#: lib/abuuba_web/live/settings_live.ex:549
+#: lib/abuuba_web/live/settings_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr "Angeheftete Beiträge behalten"
 
-#: lib/abuuba_web/live/settings_live.ex:576
+#: lib/abuuba_web/live/settings_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr "Beiträge behalten, die mindestens so oft geboostet wurden"
 
-#: lib/abuuba_web/live/settings_live.ex:565
+#: lib/abuuba_web/live/settings_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr "Beiträge behalten, die mindestens so oft favorisiert wurden"
 
-#: lib/abuuba_web/live/settings_live.ex:561
+#: lib/abuuba_web/live/settings_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr "Beiträge mit Bildern oder Video behalten"
 
-#: lib/abuuba_web/live/settings_live.ex:935
+#: lib/abuuba_web/live/settings_live.ex:936
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr "Wird %{days} Tage aufgehoben und dann gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:518
+#: lib/abuuba_web/live/settings_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "Nothing pinned."
 msgstr "Nichts angeheftet."
 
-#: lib/abuuba_web/live/settings_live.ex:931
+#: lib/abuuba_web/live/settings_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr "Noch nichts aufgezeichnet."
 
-#: lib/abuuba_web/live/settings_live.ex:523
+#: lib/abuuba_web/live/settings_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr "Aus, solange du es nicht einschaltest. Lass das Alter leer, um es wieder auszuschalten; bis du eines setzt, wird nichts gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:587
+#: lib/abuuba_web/live/settings_live.ex:588
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] "Ein Beitrag passt gerade auf diese Einstellungen."
 msgstr[1] "%{count} Beiträge passen gerade auf diese Einstellungen."
 
-#: lib/abuuba_web/live/settings_live.ex:498
+#: lib/abuuba_web/live/settings_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Pinned posts"
 msgstr "Angeheftete Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:910
+#: lib/abuuba_web/live/settings_live.ex:911
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr "Letzte Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:920
+#: lib/abuuba_web/live/settings_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr "Abgelehnt"
 
-#: lib/abuuba_web/live/settings_live.ex:920
+#: lib/abuuba_web/live/settings_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr "Angemeldet"
 
-#: lib/abuuba_web/live/settings_live.ex:512
+#: lib/abuuba_web/live/settings_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr "Lösen"
 
-#: lib/abuuba_web/live/settings_live.ex:500
+#: lib/abuuba_web/live/settings_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr "Was oben auf deinem Profil steht. Angeheftet wird vom Beitrag aus."
@@ -4954,124 +4954,124 @@ msgid_plural "%{count} signed up"
 msgstr[0] "eine Anmeldung"
 msgstr[1] "%{count} Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2218
+#: lib/abuuba_web/live/settings_live.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr "Profilbild"
 
-#: lib/abuuba_web/live/settings_live.ex:2219
+#: lib/abuuba_web/live/settings_live.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr "Titelbild"
 
-#: lib/abuuba_web/live/settings_live.ex:344
+#: lib/abuuba_web/live/settings_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr "JPEG, PNG, GIF oder WebP, bis %{size}. Größere werden schon vor dem Hochladen abgelehnt und nicht erst danach, und was du schickst, wird hier verkleinert, damit niemand ein ganzes Foto lädt, um es bei vierzig Pixeln zu sehen."
 
 #: lib/abuuba_web/live/admin_live.ex:550
-#: lib/abuuba_web/live/settings_live.ex:362
+#: lib/abuuba_web/live/settings_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "None yet."
 msgstr "Noch keins."
 
-#: lib/abuuba_web/live/settings_live.ex:2053
+#: lib/abuuba_web/live/settings_live.ex:2054
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr "Ein Bild auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:342
+#: lib/abuuba_web/live/settings_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr "Bilder"
 
-#: lib/abuuba_web/live/settings_live.ex:394
+#: lib/abuuba_web/live/settings_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "Take it off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2051
-#: lib/abuuba_web/live/settings_live.ex:2212
+#: lib/abuuba_web/live/settings_live.ex:2052
+#: lib/abuuba_web/live/settings_live.ex:2213
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr "Damit kann dieser Server nichts anfangen. Versuch es mit JPEG, PNG, GIF oder WebP."
 
-#: lib/abuuba_web/live/settings_live.ex:2207
-#: lib/abuuba_web/live/settings_live.ex:2214
+#: lib/abuuba_web/live/settings_live.ex:2208
+#: lib/abuuba_web/live/settings_live.ex:2215
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr "Dieses Bild konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2048
+#: lib/abuuba_web/live/settings_live.ex:2049
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr "Dieses Bild ist zu groß. Die Grenze steht eine Zeile weiter oben."
 
-#: lib/abuuba_web/live/profile_live.ex:164
+#: lib/abuuba_web/live/profile_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr "Auf meinem Profil hervorheben"
 
-#: lib/abuuba_web/live/profile_live.ex:313
-#: lib/abuuba_web/live/profile_live.ex:317
+#: lib/abuuba_web/live/profile_live.ex:322
+#: lib/abuuba_web/live/profile_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Featured accounts"
 msgstr "Hervorgehobene Konten"
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr "Nicht mehr hervorheben"
 
-#: lib/abuuba_web/live/profile_live.ex:544
+#: lib/abuuba_web/live/profile_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr "Schau in dieses Postfach: Dort liegt eine Nachricht mit der Bitte um Bestätigung."
 
-#: lib/abuuba_web/live/profile_live.ex:267
+#: lib/abuuba_web/live/profile_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr "Neuigkeiten von %{name} per E-Mail"
 
-#: lib/abuuba_web/live/settings_live.ex:678
+#: lib/abuuba_web/live/settings_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr "Geht an jede bestätigte Adresse, mit einem Link, der die Neuigkeiten beendet. Bis zu %{count} Nachrichten am Tag."
 
-#: lib/abuuba_web/live/profile_live.ex:270
+#: lib/abuuba_web/live/profile_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr "Kein Konto nötig. Wir schreiben einmal an die Adresse, um zu prüfen, ob sie dir gehört, und in jeder Nachricht steht ein Link, der die Neuigkeiten beendet."
 
-#: lib/abuuba_web/live/settings_live.ex:703
+#: lib/abuuba_web/live/settings_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Send it"
 msgstr "Abschicken"
 
-#: lib/abuuba_web/live/profile_live.ex:286
+#: lib/abuuba_web/live/profile_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr "Neuigkeiten schicken"
 
-#: lib/abuuba_web/live/settings_live.ex:712
+#: lib/abuuba_web/live/settings_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] "Am %{date} an eine Adresse geschickt."
 msgstr[1] "Am %{date} an %{count} Adressen geschickt."
 
-#: lib/abuuba_web/live/settings_live.ex:689
-#: lib/abuuba_web/live/settings_live.ex:1780
+#: lib/abuuba_web/live/settings_live.ex:690
+#: lib/abuuba_web/live/settings_live.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Betreff"
 
-#: lib/abuuba_web/live/profile_live.ex:547
+#: lib/abuuba_web/live/profile_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr "Das sieht nicht nach einer gültigen E-Mail-Adresse aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1366
+#: lib/abuuba_web/live/settings_live.ex:1367
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr "Diese Liste ist nicht offen."
@@ -5081,17 +5081,17 @@ msgstr "Diese Liste ist nicht offen."
 msgid "To stop them, open this link:"
 msgstr "Zum Beenden diesen Link öffnen:"
 
-#: lib/abuuba_web/live/profile_live.ex:534
+#: lib/abuuba_web/live/profile_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr "Gerade zu viele Versuche von hier. Bitte später noch einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:696
+#: lib/abuuba_web/live/settings_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr "Was du ihnen sagen möchtest"
 
-#: lib/abuuba_web/live/settings_live.ex:676
+#: lib/abuuba_web/live/settings_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr "An sie schreiben"
@@ -5101,22 +5101,22 @@ msgstr "An sie schreiben"
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr "Du bekommst das, weil du auf %{site} um Neuigkeiten von %{name} gebeten hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1371
+#: lib/abuuba_web/live/settings_live.ex:1372
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr "Du hast heute schon so viele Nachrichten geschickt, wie du kannst."
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr "du@example.com"
 
-#: lib/abuuba_web/live/settings_live.ex:1781
+#: lib/abuuba_web/live/settings_live.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
 
-#: lib/abuuba_web/live/settings_live.ex:719
+#: lib/abuuba_web/live/settings_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr "Unterwegs."
@@ -5402,7 +5402,7 @@ msgstr "Deine Unterhaltungen als gelesen markieren"
 msgid "Mute and unmute people for you"
 msgstr "Leute für dich stummschalten und wieder lautstellen"
 
-#: lib/abuuba_web/live/settings_live.ex:958
+#: lib/abuuba_web/live/settings_live.ex:959
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr "Nichts. Sie sieht nur, dass du angemeldet bist, sonst nichts."
@@ -5447,12 +5447,12 @@ msgstr "Deine Listen lesen"
 msgid "Search as you"
 msgstr "In deinem Namen suchen"
 
-#: lib/abuuba_web/components/status_component.ex:63
+#: lib/abuuba_web/components/status_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "Filtered: %{title}"
 msgstr "Gefiltert: %{title}"
 
-#: lib/abuuba_web/components/status_component.ex:65
+#: lib/abuuba_web/components/status_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
@@ -5550,42 +5550,42 @@ msgstr "Das Bild wird noch hochgeladen. Gleich noch einmal versuchen."
 msgid "not offered"
 msgstr "nicht angeboten"
 
-#: lib/abuuba_web/live/profile_live.ex:236
+#: lib/abuuba_web/live/profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr "Keine auszuwählen heißt: alles, was sie schreiben."
 
-#: lib/abuuba_web/live/profile_live.ex:234
+#: lib/abuuba_web/live/profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr "Nur diese Sprachen"
 
-#: lib/abuuba_web/live/profile_live.ex:213
+#: lib/abuuba_web/live/profile_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr "Ihre Weitergaben anderer Leute"
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr "Was du von ihnen siehst"
 
-#: lib/abuuba_web/components/status_component.ex:462
+#: lib/abuuba_web/components/status_component.ex:464
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Mehr"
 
-#: lib/abuuba_web/components/status_component.ex:474
+#: lib/abuuba_web/components/status_component.ex:476
 #, elixir-autogen, elixir-format
 msgid "Mute this conversation"
 msgstr "Diese Unterhaltung stummschalten"
 
-#: lib/abuuba_web/components/status_component.ex:481
+#: lib/abuuba_web/components/status_component.ex:483
 #, elixir-autogen, elixir-format
 msgid "Stops its notifications and takes it out of your timeline. Nobody is told."
 msgstr "Beendet die Benachrichtigungen und nimmt sie aus deiner Timeline. Niemand erfährt es."
 
-#: lib/abuuba_web/components/status_component.ex:473
+#: lib/abuuba_web/components/status_component.ex:475
 #, elixir-autogen, elixir-format
 msgid "Unmute this conversation"
 msgstr "Stummschaltung dieser Unterhaltung aufheben"
@@ -5595,7 +5595,7 @@ msgstr "Stummschaltung dieser Unterhaltung aufheben"
 msgid "Posts from people you watch"
 msgstr "Beiträge von Leuten, die du beobachtest"
 
-#: lib/abuuba_web/live/profile_live.ex:228
+#: lib/abuuba_web/live/profile_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr "Sag mir Bescheid, wenn sie etwas posten"
@@ -5754,22 +5754,22 @@ msgstr "Niemand: der Server sagt es nicht"
 msgid "Who may read the blocklist"
 msgstr "Wer die Sperrliste lesen darf"
 
-#: lib/abuuba_web/live/settings_live.ex:633
+#: lib/abuuba_web/live/settings_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr "Eine Domain pro Zeile. Wird hier ein Link auf eine dieser Seiten geteilt, weist die Vorschau dich als Urheberin oder Urheber aus. Eine Seite, die du nicht eingetragen hast, kann dich nicht für sich beanspruchen, egal was in ihrer Seitenquelle steht."
 
-#: lib/abuuba_web/live/settings_live.ex:625
+#: lib/abuuba_web/live/settings_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr "Seiten, die mich als Autorin oder Autor nennen dürfen"
 
-#: lib/abuuba_web/live/settings_live.ex:837
+#: lib/abuuba_web/live/settings_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Block a server"
 msgstr "Server blockieren"
 
-#: lib/abuuba_web/live/settings_live.ex:810
+#: lib/abuuba_web/live/settings_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht deine Timelines, deine Suche, deine Threads oder deine Benachrichtigungen. Folge-Beziehungen in beide Richtungen werden aufgelöst, genau wie beim Blockieren einer einzelnen Person."
@@ -5779,8 +5779,8 @@ msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht d
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr "Zu viele Anmeldungen von hier im Moment. Bitte versuche es später noch einmal."
 
-#: lib/abuuba_web/live/explore_live.ex:144
-#: lib/abuuba_web/live/profile_live.ex:585
+#: lib/abuuba_web/live/explore_live.ex:148
+#: lib/abuuba_web/live/profile_live.ex:596
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr "Zu viele Follows für heute. Versuche es morgen noch einmal."
@@ -5844,3 +5844,18 @@ msgstr "Stattgeben und rückgängig machen"
 #, elixir-autogen, elixir-format
 msgid "Warned"
 msgstr "Verwarnt"
+
+#: lib/abuuba_web/live/profile_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Cancel follow request"
+msgstr "Folgeanfrage zurückziehen"
+
+#: lib/abuuba_web/live/explore_live.ex:117
+#, elixir-autogen, elixir-format
+msgid "Requested"
+msgstr "Angefragt"
+
+#: lib/abuuba_web/live/profile_live.ex:606
+#, elixir-autogen, elixir-format
+msgid "This account approves its followers. Your request is waiting for an answer."
+msgstr "Dieses Konto bestätigt seine Follower selbst. Deine Anfrage wartet auf eine Antwort."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,21 +11,21 @@
 msgid ""
 msgstr ""
 
-#: lib/abuuba_web/formats.ex:69
+#: lib/abuuba_web/formats.ex:103
 #, elixir-autogen, elixir-format
 msgid "1 day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/formats.ex:68
+#: lib/abuuba_web/formats.ex:102
 #, elixir-autogen, elixir-format
 msgid "1 hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/formats.ex:67
+#: lib/abuuba_web/formats.ex:101
 #, elixir-autogen, elixir-format
 msgid "1 minute ago"
 msgid_plural "%{count} minutes ago"
@@ -49,7 +49,7 @@ msgid "Change"
 msgstr ""
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:735
+#: lib/abuuba_web/live/compose_component.ex:736
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -74,7 +74,7 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/abuuba_web/formats.ex:66
+#: lib/abuuba_web/formats.ex:100
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:898
+#: lib/abuuba_web/live/settings_live.ex:899
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:21
 #: lib/abuuba_web/live/two_factor_settings_live.ex:80
@@ -466,8 +466,8 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1739
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:409
-#: lib/abuuba_web/live/compose_component.ex:422
+#: lib/abuuba_web/live/compose_component.ex:410
+#: lib/abuuba_web/live/compose_component.ex:423
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -624,14 +624,14 @@ msgstr ""
 msgid "Upload files as you"
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:666
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:667
 #: lib/abuuba_web/controllers/well_known_controller.ex:42
 #: lib/abuuba_web/controllers/well_known_controller.ex:48
 #, elixir-autogen, elixir-format
 msgid "No such account here."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:586
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:587
 #: lib/abuuba_web/controllers/well_known_controller.ex:64
 #, elixir-autogen, elixir-format
 msgid "That account is gone."
@@ -642,12 +642,12 @@ msgstr ""
 msgid "That is not a resource we understand."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:684
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:685
 #, elixir-autogen, elixir-format
 msgid "A server may only ask about its own followers."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:678
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:679
 #, elixir-autogen, elixir-format
 msgid "That request has to be signed."
 msgstr ""
@@ -662,7 +662,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
 #: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -689,14 +689,14 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:117
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:118
+#: lib/abuuba_web/live/settings_live.ex:2112
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -718,39 +718,39 @@ msgid_plural "%{count} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/components/status_component.ex:298
+#: lib/abuuba_web/components/status_component.ex:300
 #, elixir-autogen, elixir-format
 msgid "%{count} vote"
 msgid_plural "%{count} votes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/components/status_component.ex:152
+#: lib/abuuba_web/components/status_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "%{name} boosted"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:237
+#: lib/abuuba_web/components/status_component.ex:239
 #, elixir-autogen, elixir-format
 msgid "Attachment"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:419
+#: lib/abuuba_web/components/status_component.ex:421
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:396
+#: lib/abuuba_web/components/status_component.ex:398
 #, elixir-autogen, elixir-format
 msgid "Boost"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:307
+#: lib/abuuba_web/components/status_component.ex:309
 #, elixir-autogen, elixir-format
 msgid "Closed"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:408
+#: lib/abuuba_web/components/status_component.ex:410
 #, elixir-autogen, elixir-format
 msgid "Favourite"
 msgstr ""
@@ -760,13 +760,13 @@ msgstr ""
 msgid "Follow some people and their posts will appear here."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:265
-#: lib/abuuba_web/live/compose_component.ex:615
+#: lib/abuuba_web/components/status_component.ex:267
+#: lib/abuuba_web/live/compose_component.ex:616
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:384
+#: lib/abuuba_web/components/status_component.ex:386
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
@@ -776,7 +776,7 @@ msgstr ""
 msgid "That vote could not be counted."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:275
+#: lib/abuuba_web/components/status_component.ex:277
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr ""
@@ -786,308 +786,308 @@ msgstr ""
 msgid "You have reached the end."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:283
+#: lib/abuuba_web/components/status_component.ex:285
 #, elixir-autogen, elixir-format
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1681
+#: lib/abuuba_web/live/compose_component.ex:1682
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1679
+#: lib/abuuba_web/live/compose_component.ex:1680
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1682
+#: lib/abuuba_web/live/compose_component.ex:1683
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1678
+#: lib/abuuba_web/live/compose_component.ex:1679
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1678
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1680
+#: lib/abuuba_web/live/compose_component.ex:1681
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/compose_component.ex:1684
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1155
+#: lib/abuuba_web/live/compose_component.ex:1156
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:650
+#: lib/abuuba_web/live/compose_component.ex:651
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:721
+#: lib/abuuba_web/live/compose_component.ex:722
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:662
+#: lib/abuuba_web/live/compose_component.ex:663
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1698
-#: lib/abuuba_web/live/settings_live.ex:2291
-#, elixir-autogen, elixir-format
-msgid "Anyone"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1689
-#: lib/abuuba_web/live/settings_live.ex:2286
-#, elixir-autogen, elixir-format
-msgid "Anyone, and listed everywhere"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1690
-#: lib/abuuba_web/live/settings_live.ex:2287
-#, elixir-autogen, elixir-format
-msgid "Anyone, but not in public timelines"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:626
-#, elixir-autogen, elixir-format
-msgid "Choice %{number}"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:450
-#: lib/abuuba_web/live/compose_component.ex:711
-#, elixir-autogen, elixir-format
-msgid "Content warning"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:812
-#, elixir-autogen, elixir-format
-msgid "Ctrl + Enter posts"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:445
-#, elixir-autogen, elixir-format
-msgid "Do not reply to this person"
-msgstr ""
-
-#: lib/abuuba_web/components/status_component.ex:430
-#: lib/abuuba_web/live/admin_live.ex:1759
-#, elixir-autogen, elixir-format
-msgid "Edit"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:415
-#, elixir-autogen, elixir-format
-msgid "Editing a post"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:666
-#, elixir-autogen, elixir-format
-msgid "Ends after"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1691
-#: lib/abuuba_web/live/profile_live.ex:837
-#, elixir-autogen, elixir-format
-msgid "Followers"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1692
-#, elixir-autogen, elixir-format
-msgid "Mentioned people"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3419
-#: lib/abuuba_web/live/compose_component.ex:1700
-#: lib/abuuba_web/live/settings_live.ex:2293
-#, elixir-autogen, elixir-format
-msgid "Nobody"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1691
-#: lib/abuuba_web/live/settings_live.ex:2288
-#, elixir-autogen, elixir-format
-msgid "Only the people who follow you"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1692
-#, elixir-autogen, elixir-format
-msgid "Only the people you name"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1699
 #: lib/abuuba_web/live/settings_live.ex:2292
 #, elixir-autogen, elixir-format
+msgid "Anyone"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/settings_live.ex:2287
+#, elixir-autogen, elixir-format
+msgid "Anyone, and listed everywhere"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1691
+#: lib/abuuba_web/live/settings_live.ex:2288
+#, elixir-autogen, elixir-format
+msgid "Anyone, but not in public timelines"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:627
+#, elixir-autogen, elixir-format
+msgid "Choice %{number}"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:451
+#: lib/abuuba_web/live/compose_component.ex:712
+#, elixir-autogen, elixir-format
+msgid "Content warning"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:813
+#, elixir-autogen, elixir-format
+msgid "Ctrl + Enter posts"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:446
+#, elixir-autogen, elixir-format
+msgid "Do not reply to this person"
+msgstr ""
+
+#: lib/abuuba_web/components/status_component.ex:432
+#: lib/abuuba_web/live/admin_live.ex:1759
+#, elixir-autogen, elixir-format
+msgid "Edit"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:416
+#, elixir-autogen, elixir-format
+msgid "Editing a post"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:667
+#, elixir-autogen, elixir-format
+msgid "Ends after"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1692
+#: lib/abuuba_web/live/profile_live.ex:866
+#, elixir-autogen, elixir-format
+msgid "Followers"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1693
+#, elixir-autogen, elixir-format
+msgid "Mentioned people"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3419
+#: lib/abuuba_web/live/compose_component.ex:1701
+#: lib/abuuba_web/live/settings_live.ex:2294
+#, elixir-autogen, elixir-format
+msgid "Nobody"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1692
+#: lib/abuuba_web/live/settings_live.ex:2289
+#, elixir-autogen, elixir-format
+msgid "Only the people who follow you"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1693
+#, elixir-autogen, elixir-format
+msgid "Only the people you name"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1700
+#: lib/abuuba_web/live/settings_live.ex:2293
+#, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1455
+#: lib/abuuba_web/live/compose_component.ex:1456
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:695
+#: lib/abuuba_web/live/compose_component.ex:696
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1689
-#: lib/abuuba_web/live/compose_component.ex:1707
+#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1708
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1691
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:731
+#: lib/abuuba_web/live/compose_component.ex:732
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:638
+#: lib/abuuba_web/live/compose_component.ex:639
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:402
+#: lib/abuuba_web/live/compose_component.ex:403
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1453
+#: lib/abuuba_web/live/compose_component.ex:1454
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3380
-#: lib/abuuba_web/live/compose_component.ex:477
+#: lib/abuuba_web/live/compose_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1117
+#: lib/abuuba_web/live/compose_component.ex:1118
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1179
-#: lib/abuuba_web/live/compose_component.ex:1214
-#: lib/abuuba_web/live/compose_component.ex:1409
+#: lib/abuuba_web/live/compose_component.ex:1180
+#: lib/abuuba_web/live/compose_component.ex:1215
+#: lib/abuuba_web/live/compose_component.ex:1410
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:461
-#: lib/abuuba_web/live/compose_component.ex:467
+#: lib/abuuba_web/live/compose_component.ex:462
+#: lib/abuuba_web/live/compose_component.ex:468
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:455
+#: lib/abuuba_web/live/compose_component.ex:456
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:771
+#: lib/abuuba_web/live/compose_component.ex:772
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:751
+#: lib/abuuba_web/live/compose_component.ex:752
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1113
+#: lib/abuuba_web/live/compose_component.ex:1114
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1211
+#: lib/abuuba_web/live/compose_component.ex:1212
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1651
+#: lib/abuuba_web/live/compose_component.ex:1652
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:818
+#: lib/abuuba_web/live/compose_component.ex:819
 #, elixir-autogen, elixir-format
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:850
+#: lib/abuuba_web/live/compose_component.ex:851
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:1159
+#: lib/abuuba_web/live/compose_component.ex:1160
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:881
+#: lib/abuuba_web/live/compose_component.ex:882
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:842
+#: lib/abuuba_web/live/compose_component.ex:843
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:681
+#: lib/abuuba_web/live/compose_component.ex:682
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:832
-#: lib/abuuba_web/live/compose_component.ex:871
+#: lib/abuuba_web/live/compose_component.ex:833
+#: lib/abuuba_web/live/compose_component.ex:872
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1130
-#: lib/abuuba_web/live/compose_component.ex:1400
+#: lib/abuuba_web/live/compose_component.ex:1131
+#: lib/abuuba_web/live/compose_component.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:803
+#: lib/abuuba_web/live/compose_component.ex:804
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1454
+#: lib/abuuba_web/live/compose_component.ex:1455
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:316
+#: lib/abuuba_web/live/compose_component.ex:317
 #, elixir-autogen, elixir-format
 msgid "That draft could not be saved."
 msgstr ""
@@ -1097,104 +1097,104 @@ msgstr ""
 msgid "That post is scheduled."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1164
+#: lib/abuuba_web/live/compose_component.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:312
+#: lib/abuuba_web/live/compose_component.ex:313
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1448
+#: lib/abuuba_web/live/compose_component.ex:1449
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:688
+#: lib/abuuba_web/live/compose_component.ex:689
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1127
+#: lib/abuuba_web/live/compose_component.ex:1128
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:496
+#: lib/abuuba_web/live/compose_component.ex:497
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:591
+#: lib/abuuba_web/live/compose_component.ex:592
 #, elixir-autogen, elixir-format
 msgid "Add a still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:541
+#: lib/abuuba_web/live/compose_component.ex:542
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:558
-#: lib/abuuba_web/live/compose_component.ex:566
+#: lib/abuuba_web/live/compose_component.ex:559
+#: lib/abuuba_web/live/compose_component.ex:567
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:580
+#: lib/abuuba_web/live/compose_component.ex:581
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:595
+#: lib/abuuba_web/live/compose_component.ex:596
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:553
+#: lib/abuuba_web/live/compose_component.ex:554
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:521
+#: lib/abuuba_web/live/compose_component.ex:522
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:606
+#: lib/abuuba_web/live/compose_component.ex:607
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:251
-#: lib/abuuba_web/live/compose_component.ex:1444
+#: lib/abuuba_web/live/compose_component.ex:252
+#: lib/abuuba_web/live/compose_component.ex:1445
 #, elixir-autogen, elixir-format
 msgid "That file could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1441
+#: lib/abuuba_web/live/compose_component.ex:1442
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:238
+#: lib/abuuba_web/live/compose_component.ex:239
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1442
+#: lib/abuuba_web/live/compose_component.ex:1443
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1443
+#: lib/abuuba_web/live/compose_component.ex:1444
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:500
+#: lib/abuuba_web/live/compose_component.ex:501
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr ""
@@ -1204,12 +1204,12 @@ msgstr ""
 msgid "%{name} on %{server}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:292
+#: lib/abuuba_web/live/profile_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:189
+#: lib/abuuba_web/live/profile_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
@@ -1231,29 +1231,29 @@ msgstr ""
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:836
+#: lib/abuuba_web/live/profile_live.ex:865
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:363
+#: lib/abuuba_web/live/profile_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:338
-#: lib/abuuba_web/live/profile_live.ex:339
+#: lib/abuuba_web/live/profile_live.ex:347
+#: lib/abuuba_web/live/profile_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:288
-#: lib/abuuba_web/live/profile_live.ex:834
+#: lib/abuuba_web/live/explore_live.ex:304
+#: lib/abuuba_web/live/profile_live.ex:863
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:122
 #: lib/abuuba_web/live/search_live.ex:264
@@ -1261,13 +1261,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:835
+#: lib/abuuba_web/live/profile_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:929
-#: lib/abuuba_web/live/profile_live.ex:296
+#: lib/abuuba_web/live/profile_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr ""
@@ -1282,19 +1282,19 @@ msgstr ""
 msgid "This account has moved to %{handle}."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:189
-#: lib/abuuba_web/live/settings_live.ex:824
+#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/settings_live.ex:825
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:155
+#: lib/abuuba_web/live/profile_live.ex:164
 #: lib/abuuba_web/live/tag_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:300
+#: lib/abuuba_web/live/profile_live.ex:309
 #: lib/abuuba_web/live/search_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "What to show"
@@ -1502,9 +1502,9 @@ msgid "Follow requests"
 msgstr ""
 
 #: lib/abuuba_web/live/notifications_live.ex:443
-#: lib/abuuba_web/live/profile_live.ex:838
-#: lib/abuuba_web/live/settings_live.ex:2095
-#: lib/abuuba_web/live/settings_live.ex:2227
+#: lib/abuuba_web/live/profile_live.ex:867
+#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -1571,22 +1571,22 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1572
 #: lib/abuuba_web/live/admin_live.ex:2148
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:255
-#: lib/abuuba_web/live/settings_live.ex:292
-#: lib/abuuba_web/live/settings_live.ex:386
-#: lib/abuuba_web/live/settings_live.ex:423
-#: lib/abuuba_web/live/settings_live.ex:487
-#: lib/abuuba_web/live/settings_live.ex:594
-#: lib/abuuba_web/live/settings_live.ex:639
-#: lib/abuuba_web/live/settings_live.ex:672
-#: lib/abuuba_web/live/settings_live.ex:994
+#: lib/abuuba_web/live/profile_live.ex:264
+#: lib/abuuba_web/live/settings_live.ex:293
+#: lib/abuuba_web/live/settings_live.ex:387
+#: lib/abuuba_web/live/settings_live.ex:424
+#: lib/abuuba_web/live/settings_live.ex:488
+#: lib/abuuba_web/live/settings_live.ex:595
+#: lib/abuuba_web/live/settings_live.ex:640
+#: lib/abuuba_web/live/settings_live.ex:673
+#: lib/abuuba_web/live/settings_live.ex:995
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:237
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:134
+#: lib/abuuba_web/live/settings_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:289
+#: lib/abuuba_web/live/explore_live.ex:305
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:113
 #: lib/abuuba_web/live/search_live.ex:263
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:119
+#: lib/abuuba_web/live/explore_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:290
+#: lib/abuuba_web/live/explore_live.ex:306
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:103
 #: lib/abuuba_web/live/search_live.ex:262
@@ -1701,19 +1701,19 @@ msgstr ""
 msgid "Recently, from people here"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:115
+#: lib/abuuba_web/live/about_live.ex:116
 #: lib/abuuba_web/live/landing_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Registration is closed here, but any other server on the network will do."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:109
+#: lib/abuuba_web/live/about_live.ex:110
 #: lib/abuuba_web/live/landing_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "Registration is open: anybody may sign up."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:112
+#: lib/abuuba_web/live/about_live.ex:113
 #: lib/abuuba_web/live/landing_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Registration needs approval: you sign up and an admin reads your request."
@@ -1758,220 +1758,220 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:889
+#: lib/abuuba_web/live/settings_live.ex:890
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:232
+#: lib/abuuba_web/live/settings_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3370
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:288
+#: lib/abuuba_web/live/settings_live.ex:289
 #, elixir-autogen, elixir-format
 msgid "Add a field"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:805
+#: lib/abuuba_web/live/settings_live.ex:806
 #, elixir-autogen, elixir-format
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2264
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2097
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2123
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:945
+#: lib/abuuba_web/live/settings_live.ex:946
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2258
+#: lib/abuuba_web/live/settings_live.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:893
+#: lib/abuuba_web/live/settings_live.ex:894
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:983
-#: lib/abuuba_web/live/settings_live.ex:752
+#: lib/abuuba_web/live/settings_live.ex:753
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:221
+#: lib/abuuba_web/live/settings_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1598
+#: lib/abuuba_web/live/settings_live.ex:1599
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/settings_live.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2120
+#: lib/abuuba_web/live/settings_live.ex:2121
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:199
+#: lib/abuuba_web/live/settings_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:237
+#: lib/abuuba_web/live/settings_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2094
-#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2095
+#: lib/abuuba_web/live/settings_live.ex:2234
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2316
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2316
+#: lib/abuuba_web/live/settings_live.ex:2317
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2272
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:252
+#: lib/abuuba_web/live/settings_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:2263
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2267
+#: lib/abuuba_web/live/settings_live.ex:2268
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:270
+#: lib/abuuba_web/live/settings_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:974
+#: lib/abuuba_web/live/settings_live.ex:975
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:988
+#: lib/abuuba_web/live/settings_live.ex:989
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:447
+#: lib/abuuba_web/live/settings_live.ex:448
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2279
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2089
+#: lib/abuuba_web/live/settings_live.ex:2090
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2271
+#: lib/abuuba_web/live/settings_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1982,165 +1982,165 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1862
 #: lib/abuuba_web/live/admin_live.ex:2186
 #: lib/abuuba_web/live/conversations_live.ex:111
-#: lib/abuuba_web/live/settings_live.ex:278
-#: lib/abuuba_web/live/settings_live.ex:313
+#: lib/abuuba_web/live/settings_live.ex:279
+#: lib/abuuba_web/live/settings_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2097
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:906
+#: lib/abuuba_web/live/settings_live.ex:907
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:902
+#: lib/abuuba_web/live/settings_live.ex:903
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2282
+#: lib/abuuba_web/live/settings_live.ex:2283
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:968
+#: lib/abuuba_web/live/settings_live.ex:969
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3748
-#: lib/abuuba_web/live/settings_live.ex:2085
+#: lib/abuuba_web/live/settings_live.ex:2086
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1573
+#: lib/abuuba_web/live/settings_live.ex:1574
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:466
+#: lib/abuuba_web/live/settings_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2266
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:847
+#: lib/abuuba_web/live/settings_live.ex:848
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:872
+#: lib/abuuba_web/live/settings_live.ex:873
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:239
+#: lib/abuuba_web/live/settings_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:259
+#: lib/abuuba_web/live/settings_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:797
+#: lib/abuuba_web/live/settings_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2118
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2162
-#: lib/abuuba_web/live/settings_live.ex:759
+#: lib/abuuba_web/live/settings_live.ex:760
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:764
+#: lib/abuuba_web/live/settings_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2119
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:453
+#: lib/abuuba_web/live/settings_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:434
+#: lib/abuuba_web/live/settings_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:868
+#: lib/abuuba_web/live/settings_live.ex:869
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:884
+#: lib/abuuba_web/live/settings_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:985
+#: lib/abuuba_web/live/settings_live.ex:986
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2121
+#: lib/abuuba_web/live/settings_live.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2150,19 +2150,19 @@ msgstr ""
 msgid "A handle looks like name@server."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:43
+#: lib/abuuba_web/live/about_live.ex:44
 #, elixir-autogen, elixir-format
 msgid "A server on the fediverse, running %{software}."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:22
+#: lib/abuuba_web/live/about_live.ex:23
 #: lib/abuuba_web/live/admin_live.ex:619
-#: lib/abuuba_web/live/document_live.ex:114
+#: lib/abuuba_web/live/document_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "About"
 msgstr ""
 
-#: lib/abuuba_web/live/document_live.ex:105
+#: lib/abuuba_web/live/document_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "About this server"
 msgstr ""
@@ -2172,12 +2172,12 @@ msgstr ""
 msgid "Do this from your own server"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:78
+#: lib/abuuba_web/live/about_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Getting in touch"
 msgstr ""
 
-#: lib/abuuba_web/live/document_live.ex:82
+#: lib/abuuba_web/live/document_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "In effect since %{date}"
 msgstr ""
@@ -2187,9 +2187,9 @@ msgstr ""
 msgid "No password is asked for and nothing is done on your behalf: you are simply sent to your own server's search with this address filled in."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:91
+#: lib/abuuba_web/live/about_live.ex:92
 #: lib/abuuba_web/live/admin_live.ex:1944
-#: lib/abuuba_web/live/document_live.ex:113
+#: lib/abuuba_web/live/document_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
 msgstr ""
@@ -2204,7 +2204,7 @@ msgstr ""
 msgid "Share"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:61
+#: lib/abuuba_web/live/about_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Signing up"
 msgstr ""
@@ -2224,9 +2224,9 @@ msgstr ""
 msgid "Take me to my server"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:90
+#: lib/abuuba_web/live/about_live.ex:91
 #: lib/abuuba_web/live/admin_live.ex:2191
-#: lib/abuuba_web/live/document_live.ex:112
+#: lib/abuuba_web/live/document_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr ""
@@ -2236,27 +2236,27 @@ msgstr ""
 msgid "That is this server. Use the buttons on the post itself once you are signed in."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:51
+#: lib/abuuba_web/live/about_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "The numbers"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:66
+#: lib/abuuba_web/live/about_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "The rules"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:88
+#: lib/abuuba_web/live/about_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "The small print"
 msgstr ""
 
-#: lib/abuuba_web/live/document_live.ex:88
+#: lib/abuuba_web/live/document_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "This has not been written yet. Whoever runs this server can add it in the admin settings."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:83
+#: lib/abuuba_web/live/about_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Whoever runs this server has not published an address yet."
 msgstr ""
@@ -2271,135 +2271,135 @@ msgstr ""
 msgid "Your handle"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:101
+#: lib/abuuba_web/live/about_live.ex:102
 #, elixir-autogen, elixir-format
 msgid "people"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:105
+#: lib/abuuba_web/live/about_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "people active this half-year"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:104
+#: lib/abuuba_web/live/about_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "people active this month"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:102
+#: lib/abuuba_web/live/about_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "posts"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:103
+#: lib/abuuba_web/live/about_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1850
+#: lib/abuuba_web/live/settings_live.ex:1851
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1194
+#: lib/abuuba_web/live/settings_live.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1224
+#: lib/abuuba_web/live/settings_live.ex:1225
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1834
+#: lib/abuuba_web/live/settings_live.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1191
+#: lib/abuuba_web/live/settings_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1198
-#: lib/abuuba_web/live/settings_live.ex:1830
+#: lib/abuuba_web/live/settings_live.ex:1199
+#: lib/abuuba_web/live/settings_live.ex:1831
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1169
+#: lib/abuuba_web/live/settings_live.ex:1170
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1845
+#: lib/abuuba_web/live/settings_live.ex:1846
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1844
+#: lib/abuuba_web/live/settings_live.ex:1845
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1846
+#: lib/abuuba_web/live/settings_live.ex:1847
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1851
+#: lib/abuuba_web/live/settings_live.ex:1852
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1855
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1855
+#: lib/abuuba_web/live/settings_live.ex:1856
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1852
+#: lib/abuuba_web/live/settings_live.ex:1853
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1177
+#: lib/abuuba_web/live/settings_live.ex:1178
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1215
+#: lib/abuuba_web/live/settings_live.ex:1216
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1204
+#: lib/abuuba_web/live/settings_live.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1206
+#: lib/abuuba_web/live/settings_live.ex:1207
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3328
-#: lib/abuuba_web/live/settings_live.ex:1626
+#: lib/abuuba_web/live/settings_live.ex:1627
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
@@ -2785,7 +2785,7 @@ msgstr ""
 msgid "the server"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:305
+#: lib/abuuba_web/components/status_component.ex:307
 #: lib/abuuba_web/live/admin_live.ex:1075
 #, elixir-autogen, elixir-format
 msgid "%{count} person"
@@ -2834,12 +2834,12 @@ msgstr ""
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1240
+#: lib/abuuba_web/live/settings_live.ex:1241
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
@@ -2854,7 +2854,7 @@ msgstr ""
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Each version is kept with the day it takes effect, so somebody can still read what they agreed to."
 msgstr ""
 
-#: lib/abuuba_web/live/document_live.ex:94
+#: lib/abuuba_web/live/document_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Earlier versions"
 msgstr ""
@@ -2879,7 +2879,7 @@ msgstr ""
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1251
+#: lib/abuuba_web/live/settings_live.ex:1252
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
@@ -2889,17 +2889,17 @@ msgstr ""
 msgid "In effect from"
 msgstr ""
 
-#: lib/abuuba_web/live/document_live.ex:98
+#: lib/abuuba_web/live/document_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1235
+#: lib/abuuba_web/live/settings_live.ex:1236
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
@@ -2909,7 +2909,7 @@ msgstr ""
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1258
+#: lib/abuuba_web/live/settings_live.ex:1259
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
@@ -2939,7 +2939,7 @@ msgstr ""
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1272
+#: lib/abuuba_web/live/settings_live.ex:1273
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr ""
@@ -2954,12 +2954,12 @@ msgstr ""
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1256
+#: lib/abuuba_web/live/settings_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1247
+#: lib/abuuba_web/live/settings_live.ex:1248
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr ""
@@ -2980,7 +2980,7 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1278
+#: lib/abuuba_web/live/settings_live.ex:1279
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2080
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3099,14 +3099,14 @@ msgstr ""
 msgid "approval only"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:337
+#: lib/abuuba_web/components/status_component.ex:339
 #, elixir-autogen, elixir-format
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:204
+#: lib/abuuba_web/live/explore_live.ex:208
 #: lib/abuuba_web/live/home_live.ex:337
-#: lib/abuuba_web/live/profile_live.ex:518
+#: lib/abuuba_web/live/profile_live.ex:529
 #: lib/abuuba_web/live/search_live.ex:195
 #: lib/abuuba_web/live/status_live.ex:184
 #: lib/abuuba_web/live/tag_live.ex:153
@@ -3114,12 +3114,12 @@ msgstr ""
 msgid "That could not be translated just now."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:444
+#: lib/abuuba_web/components/status_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:129
+#: lib/abuuba_web/components/status_component.ex:131
 #, elixir-autogen, elixir-format
 msgid "Translated by %{provider}. Reload the page for the original."
 msgstr ""
@@ -3129,275 +3129,275 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1979
+#: lib/abuuba_web/live/settings_live.ex:1980
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1970
+#: lib/abuuba_web/live/settings_live.ex:1971
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1886
+#: lib/abuuba_web/live/settings_live.ex:1887
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2043
+#: lib/abuuba_web/live/settings_live.ex:2044
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1867
+#: lib/abuuba_web/live/settings_live.ex:1868
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1892
+#: lib/abuuba_web/live/settings_live.ex:1893
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2058
+#: lib/abuuba_web/live/settings_live.ex:2059
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2066
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2068
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2039
+#: lib/abuuba_web/live/settings_live.ex:2040
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2054
-#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2055
+#: lib/abuuba_web/live/settings_live.ex:2060
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2057
+#: lib/abuuba_web/live/settings_live.ex:2058
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1876
+#: lib/abuuba_web/live/settings_live.ex:1877
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2064
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1873
+#: lib/abuuba_web/live/settings_live.ex:1874
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1881
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2070
+#: lib/abuuba_web/live/settings_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2072
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2076
+#: lib/abuuba_web/live/settings_live.ex:2077
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2076
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1043
+#: lib/abuuba_web/live/settings_live.ex:1044
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1925
+#: lib/abuuba_web/live/settings_live.ex:1926
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1038
+#: lib/abuuba_web/live/settings_live.ex:1039
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1943
+#: lib/abuuba_web/live/settings_live.ex:1944
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1048
+#: lib/abuuba_web/live/settings_live.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1036
+#: lib/abuuba_web/live/settings_live.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1005
+#: lib/abuuba_web/live/settings_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1956
+#: lib/abuuba_web/live/settings_live.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:1934
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1062
-#: lib/abuuba_web/live/settings_live.ex:1905
-#: lib/abuuba_web/live/settings_live.ex:2230
+#: lib/abuuba_web/live/settings_live.ex:1063
+#: lib/abuuba_web/live/settings_live.ex:1906
+#: lib/abuuba_web/live/settings_live.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1032
+#: lib/abuuba_web/live/settings_live.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1016
+#: lib/abuuba_web/live/settings_live.ex:1017
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2029
+#: lib/abuuba_web/live/settings_live.ex:2030
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1000
+#: lib/abuuba_web/live/settings_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1929
+#: lib/abuuba_web/live/settings_live.ex:1930
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2019
+#: lib/abuuba_web/live/settings_live.ex:2020
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2030
+#: lib/abuuba_web/live/settings_live.ex:2031
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1907
+#: lib/abuuba_web/live/settings_live.ex:1908
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1026
+#: lib/abuuba_web/live/settings_live.ex:1027
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:998
+#: lib/abuuba_web/live/settings_live.ex:999
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1922
+#: lib/abuuba_web/live/settings_live.ex:1923
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2025
+#: lib/abuuba_web/live/settings_live.ex:2026
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:672
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:673
 #, elixir-autogen, elixir-format
 msgid "No such post here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:242
+#: lib/abuuba_web/live/settings_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:780
+#: lib/abuuba_web/live/settings_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:793
+#: lib/abuuba_web/live/settings_live.ex:794
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:777
+#: lib/abuuba_web/live/settings_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1512
+#: lib/abuuba_web/live/settings_live.ex:1513
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
@@ -3407,54 +3407,54 @@ msgstr ""
 msgid "Why they want to join:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:305
+#: lib/abuuba_web/live/settings_live.ex:306
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:322
+#: lib/abuuba_web/live/settings_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:325
+#: lib/abuuba_web/live/settings_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Feature it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:296
+#: lib/abuuba_web/live/settings_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:298
+#: lib/abuuba_web/live/settings_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1495
+#: lib/abuuba_web/live/settings_live.ex:1496
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:329
+#: lib/abuuba_web/live/settings_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1489
+#: lib/abuuba_web/live/settings_live.ex:1490
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:480
+#: lib/abuuba_web/live/settings_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:482
+#: lib/abuuba_web/live/settings_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
@@ -3511,57 +3511,57 @@ msgstr ""
 msgid "Nobody is on this list yet."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:116
+#: lib/abuuba_web/live/annual_report_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "%{count} posts in %{year}"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:45
+#: lib/abuuba_web/live/annual_report_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "%{name}'s year"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:108
+#: lib/abuuba_web/live/annual_report_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Asked a lot of questions."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:80
+#: lib/abuuba_web/live/annual_report_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Counted from public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:107
+#: lib/abuuba_web/live/annual_report_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Mostly here to pass on what other people said."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:63
+#: lib/abuuba_web/live/annual_report_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "New followers"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:59
+#: lib/abuuba_web/live/annual_report_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Posts this year"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:106
+#: lib/abuuba_web/live/annual_report_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Read a lot more than they wrote."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:109
+#: lib/abuuba_web/live/annual_report_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "Spent the year in other people's threads."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:69
+#: lib/abuuba_web/live/annual_report_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Written about most"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:110
+#: lib/abuuba_web/live/annual_report_live.ex:111
 #, elixir-autogen, elixir-format
 msgid "Wrote things other people replied to."
 msgstr ""
@@ -3602,7 +3602,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr ""
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:643
+#: lib/abuuba_web/live/settings_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Email updates"
 msgstr ""
@@ -3617,7 +3617,7 @@ msgstr ""
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:661
+#: lib/abuuba_web/live/settings_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr ""
@@ -3627,7 +3627,7 @@ msgstr ""
 msgid "No, remove my address"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:663
+#: lib/abuuba_web/live/settings_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3680,7 +3680,7 @@ msgstr ""
 msgid "Let people collect email addresses for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:645
+#: lib/abuuba_web/live/settings_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr ""
@@ -3828,75 +3828,75 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1075
+#: lib/abuuba_web/live/settings_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2237
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:808
-#: lib/abuuba_web/live/settings_live.ex:2231
+#: lib/abuuba_web/live/settings_live.ex:809
+#: lib/abuuba_web/live/settings_live.ex:2232
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1301
 #: lib/abuuba_web/live/admin_live.ex:1316
-#: lib/abuuba_web/live/settings_live.ex:2228
+#: lib/abuuba_web/live/settings_live.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:2233
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1117
+#: lib/abuuba_web/live/settings_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1100
+#: lib/abuuba_web/live/settings_live.ex:1101
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2103
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2230
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1064
+#: lib/abuuba_web/live/settings_live.ex:1065
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1385
+#: lib/abuuba_web/live/settings_live.ex:1386
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1082
+#: lib/abuuba_web/live/settings_live.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2239
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3916,13 +3916,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2236
+#: lib/abuuba_web/live/settings_live.ex:2237
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1106
-#: lib/abuuba_web/live/settings_live.ex:1391
+#: lib/abuuba_web/live/settings_live.ex:1107
+#: lib/abuuba_web/live/settings_live.ex:1392
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3932,7 +3932,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1077
+#: lib/abuuba_web/live/settings_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3942,67 +3942,67 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1156
+#: lib/abuuba_web/live/settings_live.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1154
+#: lib/abuuba_web/live/settings_live.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1120
+#: lib/abuuba_web/live/settings_live.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1059
+#: lib/abuuba_web/live/settings_live.ex:1060
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1137
+#: lib/abuuba_web/live/settings_live.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1418
+#: lib/abuuba_web/live/settings_live.ex:1419
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1415
+#: lib/abuuba_web/live/settings_live.ex:1416
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1127
+#: lib/abuuba_web/live/settings_live.ex:1128
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1411
+#: lib/abuuba_web/live/settings_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1142
+#: lib/abuuba_web/live/settings_live.ex:1143
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1122
+#: lib/abuuba_web/live/settings_live.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1132
+#: lib/abuuba_web/live/settings_live.ex:1133
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
@@ -4012,7 +4012,7 @@ msgstr ""
 msgid "A post"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:390
+#: lib/abuuba_web/live/profile_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "Nobody yet."
 msgstr ""
@@ -4022,7 +4022,7 @@ msgstr ""
 msgid "Public posts tagged #%{tag}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:367
+#: lib/abuuba_web/live/profile_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr ""
@@ -4048,99 +4048,99 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1447
+#: lib/abuuba_web/live/settings_live.ex:1448
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:912
+#: lib/abuuba_web/live/settings_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:521
+#: lib/abuuba_web/live/settings_live.ex:522
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:530
+#: lib/abuuba_web/live/settings_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:549
+#: lib/abuuba_web/live/settings_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:576
+#: lib/abuuba_web/live/settings_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:565
+#: lib/abuuba_web/live/settings_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:561
+#: lib/abuuba_web/live/settings_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:935
+#: lib/abuuba_web/live/settings_live.ex:936
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:518
+#: lib/abuuba_web/live/settings_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:931
+#: lib/abuuba_web/live/settings_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:523
+#: lib/abuuba_web/live/settings_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:587
+#: lib/abuuba_web/live/settings_live.ex:588
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:498
+#: lib/abuuba_web/live/settings_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:910
+#: lib/abuuba_web/live/settings_live.ex:911
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:920
+#: lib/abuuba_web/live/settings_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:920
+#: lib/abuuba_web/live/settings_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:512
+#: lib/abuuba_web/live/settings_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:500
+#: lib/abuuba_web/live/settings_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr ""
@@ -4952,124 +4952,124 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2218
+#: lib/abuuba_web/live/settings_live.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2219
+#: lib/abuuba_web/live/settings_live.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:344
+#: lib/abuuba_web/live/settings_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:550
-#: lib/abuuba_web/live/settings_live.ex:362
+#: lib/abuuba_web/live/settings_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2053
+#: lib/abuuba_web/live/settings_live.ex:2054
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:342
+#: lib/abuuba_web/live/settings_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:394
+#: lib/abuuba_web/live/settings_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2051
-#: lib/abuuba_web/live/settings_live.ex:2212
+#: lib/abuuba_web/live/settings_live.ex:2052
+#: lib/abuuba_web/live/settings_live.ex:2213
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2207
-#: lib/abuuba_web/live/settings_live.ex:2214
+#: lib/abuuba_web/live/settings_live.ex:2208
+#: lib/abuuba_web/live/settings_live.ex:2215
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2048
+#: lib/abuuba_web/live/settings_live.ex:2049
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:164
+#: lib/abuuba_web/live/profile_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:313
-#: lib/abuuba_web/live/profile_live.ex:317
+#: lib/abuuba_web/live/profile_live.ex:322
+#: lib/abuuba_web/live/profile_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Featured accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:544
+#: lib/abuuba_web/live/profile_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:267
+#: lib/abuuba_web/live/profile_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:678
+#: lib/abuuba_web/live/settings_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:270
+#: lib/abuuba_web/live/profile_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:703
+#: lib/abuuba_web/live/settings_live.ex:704
 #, elixir-autogen, elixir-format
 msgid "Send it"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:286
+#: lib/abuuba_web/live/profile_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:712
+#: lib/abuuba_web/live/settings_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:689
-#: lib/abuuba_web/live/settings_live.ex:1780
+#: lib/abuuba_web/live/settings_live.ex:690
+#: lib/abuuba_web/live/settings_live.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:547
+#: lib/abuuba_web/live/profile_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1366
+#: lib/abuuba_web/live/settings_live.ex:1367
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5079,17 +5079,17 @@ msgstr ""
 msgid "To stop them, open this link:"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:534
+#: lib/abuuba_web/live/profile_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:696
+#: lib/abuuba_web/live/settings_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:676
+#: lib/abuuba_web/live/settings_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr ""
@@ -5099,22 +5099,22 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1371
+#: lib/abuuba_web/live/settings_live.ex:1372
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1781
+#: lib/abuuba_web/live/settings_live.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:719
+#: lib/abuuba_web/live/settings_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr ""
@@ -5400,7 +5400,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:958
+#: lib/abuuba_web/live/settings_live.ex:959
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5445,12 +5445,12 @@ msgstr ""
 msgid "Search as you"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:63
+#: lib/abuuba_web/components/status_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "Filtered: %{title}"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:65
+#: lib/abuuba_web/components/status_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -5548,42 +5548,42 @@ msgstr ""
 msgid "not offered"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:236
+#: lib/abuuba_web/live/profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:234
+#: lib/abuuba_web/live/profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:213
+#: lib/abuuba_web/live/profile_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:462
+#: lib/abuuba_web/components/status_component.ex:464
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:474
+#: lib/abuuba_web/components/status_component.ex:476
 #, elixir-autogen, elixir-format
 msgid "Mute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:481
+#: lib/abuuba_web/components/status_component.ex:483
 #, elixir-autogen, elixir-format
 msgid "Stops its notifications and takes it out of your timeline. Nobody is told."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:473
+#: lib/abuuba_web/components/status_component.ex:475
 #, elixir-autogen, elixir-format
 msgid "Unmute this conversation"
 msgstr ""
@@ -5593,7 +5593,7 @@ msgstr ""
 msgid "Posts from people you watch"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:228
+#: lib/abuuba_web/live/profile_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr ""
@@ -5752,22 +5752,22 @@ msgstr ""
 msgid "Who may read the blocklist"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:633
+#: lib/abuuba_web/live/settings_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:625
+#: lib/abuuba_web/live/settings_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:837
+#: lib/abuuba_web/live/settings_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Block a server"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:810
+#: lib/abuuba_web/live/settings_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr ""
@@ -5777,8 +5777,8 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:144
-#: lib/abuuba_web/live/profile_live.ex:585
+#: lib/abuuba_web/live/explore_live.ex:148
+#: lib/abuuba_web/live/profile_live.ex:596
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
@@ -5841,4 +5841,19 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:3360
 #, elixir-autogen, elixir-format
 msgid "Warned"
+msgstr ""
+
+#: lib/abuuba_web/live/profile_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Cancel follow request"
+msgstr ""
+
+#: lib/abuuba_web/live/explore_live.ex:117
+#, elixir-autogen, elixir-format
+msgid "Requested"
+msgstr ""
+
+#: lib/abuuba_web/live/profile_live.ex:606
+#, elixir-autogen, elixir-format
+msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -11,21 +11,21 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/abuuba_web/formats.ex:69
+#: lib/abuuba_web/formats.ex:103
 #, elixir-autogen, elixir-format
 msgid "1 day ago"
 msgid_plural "%{count} days ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/formats.ex:68
+#: lib/abuuba_web/formats.ex:102
 #, elixir-autogen, elixir-format
 msgid "1 hour ago"
 msgid_plural "%{count} hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/formats.ex:67
+#: lib/abuuba_web/formats.ex:101
 #, elixir-autogen, elixir-format
 msgid "1 minute ago"
 msgid_plural "%{count} minutes ago"
@@ -49,7 +49,7 @@ msgid "Change"
 msgstr ""
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:735
+#: lib/abuuba_web/live/compose_component.ex:736
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -74,7 +74,7 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/abuuba_web/formats.ex:66
+#: lib/abuuba_web/formats.ex:100
 #, elixir-autogen, elixir-format
 msgid "just now"
 msgstr ""
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:898
+#: lib/abuuba_web/live/settings_live.ex:899
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:21
 #: lib/abuuba_web/live/two_factor_settings_live.ex:80
@@ -466,8 +466,8 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1739
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:409
-#: lib/abuuba_web/live/compose_component.ex:422
+#: lib/abuuba_web/live/compose_component.ex:410
+#: lib/abuuba_web/live/compose_component.ex:423
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -624,14 +624,14 @@ msgstr ""
 msgid "Upload files as you"
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:666
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:667
 #: lib/abuuba_web/controllers/well_known_controller.ex:42
 #: lib/abuuba_web/controllers/well_known_controller.ex:48
 #, elixir-autogen, elixir-format
 msgid "No such account here."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:586
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:587
 #: lib/abuuba_web/controllers/well_known_controller.ex:64
 #, elixir-autogen, elixir-format
 msgid "That account is gone."
@@ -642,12 +642,12 @@ msgstr ""
 msgid "That is not a resource we understand."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:684
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:685
 #, elixir-autogen, elixir-format
 msgid "A server may only ask about its own followers."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:678
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:679
 #, elixir-autogen, elixir-format
 msgid "That request has to be signed."
 msgstr ""
@@ -662,7 +662,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
 #: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -689,14 +689,14 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:117
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:118
+#: lib/abuuba_web/live/settings_live.ex:2112
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -718,39 +718,39 @@ msgid_plural "%{count} new posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/components/status_component.ex:298
+#: lib/abuuba_web/components/status_component.ex:300
 #, elixir-autogen, elixir-format
 msgid "%{count} vote"
 msgid_plural "%{count} votes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/components/status_component.ex:152
+#: lib/abuuba_web/components/status_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "%{name} boosted"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:237
+#: lib/abuuba_web/components/status_component.ex:239
 #, elixir-autogen, elixir-format
 msgid "Attachment"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:419
+#: lib/abuuba_web/components/status_component.ex:421
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:396
+#: lib/abuuba_web/components/status_component.ex:398
 #, elixir-autogen, elixir-format
 msgid "Boost"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:307
+#: lib/abuuba_web/components/status_component.ex:309
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Closed"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:408
+#: lib/abuuba_web/components/status_component.ex:410
 #, elixir-autogen, elixir-format
 msgid "Favourite"
 msgstr ""
@@ -760,13 +760,13 @@ msgstr ""
 msgid "Follow some people and their posts will appear here."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:265
-#: lib/abuuba_web/live/compose_component.ex:615
+#: lib/abuuba_web/components/status_component.ex:267
+#: lib/abuuba_web/live/compose_component.ex:616
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:384
+#: lib/abuuba_web/components/status_component.ex:386
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
@@ -776,7 +776,7 @@ msgstr ""
 msgid "That vote could not be counted."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:275
+#: lib/abuuba_web/components/status_component.ex:277
 #, elixir-autogen, elixir-format
 msgid "Vote"
 msgstr ""
@@ -786,308 +786,308 @@ msgstr ""
 msgid "You have reached the end."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:283
+#: lib/abuuba_web/components/status_component.ex:285
 #, elixir-autogen, elixir-format
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1681
+#: lib/abuuba_web/live/compose_component.ex:1682
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1679
+#: lib/abuuba_web/live/compose_component.ex:1680
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1682
+#: lib/abuuba_web/live/compose_component.ex:1683
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1678
+#: lib/abuuba_web/live/compose_component.ex:1679
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1678
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1680
+#: lib/abuuba_web/live/compose_component.ex:1681
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/compose_component.ex:1684
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1155
+#: lib/abuuba_web/live/compose_component.ex:1156
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:650
+#: lib/abuuba_web/live/compose_component.ex:651
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:721
+#: lib/abuuba_web/live/compose_component.ex:722
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:662
+#: lib/abuuba_web/live/compose_component.ex:663
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1698
-#: lib/abuuba_web/live/settings_live.ex:2291
-#, elixir-autogen, elixir-format
-msgid "Anyone"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1689
-#: lib/abuuba_web/live/settings_live.ex:2286
-#, elixir-autogen, elixir-format
-msgid "Anyone, and listed everywhere"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1690
-#: lib/abuuba_web/live/settings_live.ex:2287
-#, elixir-autogen, elixir-format
-msgid "Anyone, but not in public timelines"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:626
-#, elixir-autogen, elixir-format
-msgid "Choice %{number}"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:450
-#: lib/abuuba_web/live/compose_component.ex:711
-#, elixir-autogen, elixir-format
-msgid "Content warning"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:812
-#, elixir-autogen, elixir-format
-msgid "Ctrl + Enter posts"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:445
-#, elixir-autogen, elixir-format
-msgid "Do not reply to this person"
-msgstr ""
-
-#: lib/abuuba_web/components/status_component.ex:430
-#: lib/abuuba_web/live/admin_live.ex:1759
-#, elixir-autogen, elixir-format
-msgid "Edit"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:415
-#, elixir-autogen, elixir-format
-msgid "Editing a post"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:666
-#, elixir-autogen, elixir-format
-msgid "Ends after"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1691
-#: lib/abuuba_web/live/profile_live.ex:837
-#, elixir-autogen, elixir-format
-msgid "Followers"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1692
-#, elixir-autogen, elixir-format
-msgid "Mentioned people"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3419
-#: lib/abuuba_web/live/compose_component.ex:1700
-#: lib/abuuba_web/live/settings_live.ex:2293
-#, elixir-autogen, elixir-format
-msgid "Nobody"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1691
-#: lib/abuuba_web/live/settings_live.ex:2288
-#, elixir-autogen, elixir-format
-msgid "Only the people who follow you"
-msgstr ""
-
-#: lib/abuuba_web/live/compose_component.ex:1692
-#, elixir-autogen, elixir-format
-msgid "Only the people you name"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1699
 #: lib/abuuba_web/live/settings_live.ex:2292
 #, elixir-autogen, elixir-format
+msgid "Anyone"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/settings_live.ex:2287
+#, elixir-autogen, elixir-format
+msgid "Anyone, and listed everywhere"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1691
+#: lib/abuuba_web/live/settings_live.ex:2288
+#, elixir-autogen, elixir-format
+msgid "Anyone, but not in public timelines"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:627
+#, elixir-autogen, elixir-format
+msgid "Choice %{number}"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:451
+#: lib/abuuba_web/live/compose_component.ex:712
+#, elixir-autogen, elixir-format
+msgid "Content warning"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:813
+#, elixir-autogen, elixir-format
+msgid "Ctrl + Enter posts"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:446
+#, elixir-autogen, elixir-format
+msgid "Do not reply to this person"
+msgstr ""
+
+#: lib/abuuba_web/components/status_component.ex:432
+#: lib/abuuba_web/live/admin_live.ex:1759
+#, elixir-autogen, elixir-format
+msgid "Edit"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:416
+#, elixir-autogen, elixir-format
+msgid "Editing a post"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:667
+#, elixir-autogen, elixir-format
+msgid "Ends after"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1692
+#: lib/abuuba_web/live/profile_live.ex:866
+#, elixir-autogen, elixir-format
+msgid "Followers"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1693
+#, elixir-autogen, elixir-format
+msgid "Mentioned people"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3419
+#: lib/abuuba_web/live/compose_component.ex:1701
+#: lib/abuuba_web/live/settings_live.ex:2294
+#, elixir-autogen, elixir-format
+msgid "Nobody"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1692
+#: lib/abuuba_web/live/settings_live.ex:2289
+#, elixir-autogen, elixir-format
+msgid "Only the people who follow you"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1693
+#, elixir-autogen, elixir-format
+msgid "Only the people you name"
+msgstr ""
+
+#: lib/abuuba_web/live/compose_component.ex:1700
+#: lib/abuuba_web/live/settings_live.ex:2293
+#, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1455
+#: lib/abuuba_web/live/compose_component.ex:1456
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:695
+#: lib/abuuba_web/live/compose_component.ex:696
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1689
-#: lib/abuuba_web/live/compose_component.ex:1707
+#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1708
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1691
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:731
+#: lib/abuuba_web/live/compose_component.ex:732
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:638
+#: lib/abuuba_web/live/compose_component.ex:639
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:402
+#: lib/abuuba_web/live/compose_component.ex:403
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1453
+#: lib/abuuba_web/live/compose_component.ex:1454
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3380
-#: lib/abuuba_web/live/compose_component.ex:477
+#: lib/abuuba_web/live/compose_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1117
+#: lib/abuuba_web/live/compose_component.ex:1118
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1179
-#: lib/abuuba_web/live/compose_component.ex:1214
-#: lib/abuuba_web/live/compose_component.ex:1409
+#: lib/abuuba_web/live/compose_component.ex:1180
+#: lib/abuuba_web/live/compose_component.ex:1215
+#: lib/abuuba_web/live/compose_component.ex:1410
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:461
-#: lib/abuuba_web/live/compose_component.ex:467
+#: lib/abuuba_web/live/compose_component.ex:462
+#: lib/abuuba_web/live/compose_component.ex:468
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:455
+#: lib/abuuba_web/live/compose_component.ex:456
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:771
+#: lib/abuuba_web/live/compose_component.ex:772
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:751
+#: lib/abuuba_web/live/compose_component.ex:752
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1113
+#: lib/abuuba_web/live/compose_component.ex:1114
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1211
+#: lib/abuuba_web/live/compose_component.ex:1212
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1651
+#: lib/abuuba_web/live/compose_component.ex:1652
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:818
+#: lib/abuuba_web/live/compose_component.ex:819
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:850
+#: lib/abuuba_web/live/compose_component.ex:851
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:1159
+#: lib/abuuba_web/live/compose_component.ex:1160
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:881
+#: lib/abuuba_web/live/compose_component.ex:882
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:842
+#: lib/abuuba_web/live/compose_component.ex:843
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:681
+#: lib/abuuba_web/live/compose_component.ex:682
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:832
-#: lib/abuuba_web/live/compose_component.ex:871
+#: lib/abuuba_web/live/compose_component.ex:833
+#: lib/abuuba_web/live/compose_component.ex:872
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1130
-#: lib/abuuba_web/live/compose_component.ex:1400
+#: lib/abuuba_web/live/compose_component.ex:1131
+#: lib/abuuba_web/live/compose_component.ex:1401
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:803
+#: lib/abuuba_web/live/compose_component.ex:804
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1454
+#: lib/abuuba_web/live/compose_component.ex:1455
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:316
+#: lib/abuuba_web/live/compose_component.ex:317
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That draft could not be saved."
 msgstr ""
@@ -1097,104 +1097,104 @@ msgstr ""
 msgid "That post is scheduled."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1164
+#: lib/abuuba_web/live/compose_component.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:312
+#: lib/abuuba_web/live/compose_component.ex:313
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1448
+#: lib/abuuba_web/live/compose_component.ex:1449
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:688
+#: lib/abuuba_web/live/compose_component.ex:689
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1127
+#: lib/abuuba_web/live/compose_component.ex:1128
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:496
+#: lib/abuuba_web/live/compose_component.ex:497
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:591
+#: lib/abuuba_web/live/compose_component.ex:592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:541
+#: lib/abuuba_web/live/compose_component.ex:542
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:558
-#: lib/abuuba_web/live/compose_component.ex:566
+#: lib/abuuba_web/live/compose_component.ex:559
+#: lib/abuuba_web/live/compose_component.ex:567
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:580
+#: lib/abuuba_web/live/compose_component.ex:581
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:595
+#: lib/abuuba_web/live/compose_component.ex:596
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:553
+#: lib/abuuba_web/live/compose_component.ex:554
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:521
+#: lib/abuuba_web/live/compose_component.ex:522
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:606
+#: lib/abuuba_web/live/compose_component.ex:607
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:251
-#: lib/abuuba_web/live/compose_component.ex:1444
+#: lib/abuuba_web/live/compose_component.ex:252
+#: lib/abuuba_web/live/compose_component.ex:1445
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1441
+#: lib/abuuba_web/live/compose_component.ex:1442
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:238
+#: lib/abuuba_web/live/compose_component.ex:239
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1442
+#: lib/abuuba_web/live/compose_component.ex:1443
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1443
+#: lib/abuuba_web/live/compose_component.ex:1444
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:500
+#: lib/abuuba_web/live/compose_component.ex:501
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr ""
@@ -1204,12 +1204,12 @@ msgstr ""
 msgid "%{name} on %{server}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:292
+#: lib/abuuba_web/live/profile_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:189
+#: lib/abuuba_web/live/profile_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
@@ -1231,29 +1231,29 @@ msgstr ""
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:836
+#: lib/abuuba_web/live/profile_live.ex:865
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:363
+#: lib/abuuba_web/live/profile_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:338
-#: lib/abuuba_web/live/profile_live.ex:339
+#: lib/abuuba_web/live/profile_live.ex:347
+#: lib/abuuba_web/live/profile_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:288
-#: lib/abuuba_web/live/profile_live.ex:834
+#: lib/abuuba_web/live/explore_live.ex:304
+#: lib/abuuba_web/live/profile_live.ex:863
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:122
 #: lib/abuuba_web/live/search_live.ex:264
@@ -1261,13 +1261,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:835
+#: lib/abuuba_web/live/profile_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:929
-#: lib/abuuba_web/live/profile_live.ex:296
+#: lib/abuuba_web/live/profile_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr ""
@@ -1282,19 +1282,19 @@ msgstr ""
 msgid "This account has moved to %{handle}."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:189
-#: lib/abuuba_web/live/settings_live.ex:824
+#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/settings_live.ex:825
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:155
+#: lib/abuuba_web/live/profile_live.ex:164
 #: lib/abuuba_web/live/tag_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:300
+#: lib/abuuba_web/live/profile_live.ex:309
 #: lib/abuuba_web/live/search_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "What to show"
@@ -1502,9 +1502,9 @@ msgid "Follow requests"
 msgstr ""
 
 #: lib/abuuba_web/live/notifications_live.ex:443
-#: lib/abuuba_web/live/profile_live.ex:838
-#: lib/abuuba_web/live/settings_live.ex:2095
-#: lib/abuuba_web/live/settings_live.ex:2227
+#: lib/abuuba_web/live/profile_live.ex:867
+#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2228
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows"
 msgstr ""
@@ -1571,22 +1571,22 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1572
 #: lib/abuuba_web/live/admin_live.ex:2148
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:255
-#: lib/abuuba_web/live/settings_live.ex:292
-#: lib/abuuba_web/live/settings_live.ex:386
-#: lib/abuuba_web/live/settings_live.ex:423
-#: lib/abuuba_web/live/settings_live.ex:487
-#: lib/abuuba_web/live/settings_live.ex:594
-#: lib/abuuba_web/live/settings_live.ex:639
-#: lib/abuuba_web/live/settings_live.ex:672
-#: lib/abuuba_web/live/settings_live.ex:994
+#: lib/abuuba_web/live/profile_live.ex:264
+#: lib/abuuba_web/live/settings_live.ex:293
+#: lib/abuuba_web/live/settings_live.ex:387
+#: lib/abuuba_web/live/settings_live.ex:424
+#: lib/abuuba_web/live/settings_live.ex:488
+#: lib/abuuba_web/live/settings_live.ex:595
+#: lib/abuuba_web/live/settings_live.ex:640
+#: lib/abuuba_web/live/settings_live.ex:673
+#: lib/abuuba_web/live/settings_live.ex:995
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:237
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:134
+#: lib/abuuba_web/live/settings_live.ex:135
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:289
+#: lib/abuuba_web/live/explore_live.ex:305
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:113
 #: lib/abuuba_web/live/search_live.ex:263
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:119
+#: lib/abuuba_web/live/explore_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:290
+#: lib/abuuba_web/live/explore_live.ex:306
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:103
 #: lib/abuuba_web/live/search_live.ex:262
@@ -1701,19 +1701,19 @@ msgstr ""
 msgid "Recently, from people here"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:115
+#: lib/abuuba_web/live/about_live.ex:116
 #: lib/abuuba_web/live/landing_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Registration is closed here, but any other server on the network will do."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:109
+#: lib/abuuba_web/live/about_live.ex:110
 #: lib/abuuba_web/live/landing_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "Registration is open: anybody may sign up."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:112
+#: lib/abuuba_web/live/about_live.ex:113
 #: lib/abuuba_web/live/landing_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Registration needs approval: you sign up and an admin reads your request."
@@ -1758,220 +1758,220 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:889
+#: lib/abuuba_web/live/settings_live.ex:890
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:232
+#: lib/abuuba_web/live/settings_live.ex:233
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3370
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:288
+#: lib/abuuba_web/live/settings_live.ex:289
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a field"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:805
+#: lib/abuuba_web/live/settings_live.ex:806
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2264
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2097
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2123
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:945
+#: lib/abuuba_web/live/settings_live.ex:946
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2258
+#: lib/abuuba_web/live/settings_live.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:893
+#: lib/abuuba_web/live/settings_live.ex:894
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:983
-#: lib/abuuba_web/live/settings_live.ex:752
+#: lib/abuuba_web/live/settings_live.ex:753
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:221
+#: lib/abuuba_web/live/settings_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1598
+#: lib/abuuba_web/live/settings_live.ex:1599
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/settings_live.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2120
+#: lib/abuuba_web/live/settings_live.ex:2121
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:199
+#: lib/abuuba_web/live/settings_live.ex:200
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:237
+#: lib/abuuba_web/live/settings_live.ex:238
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2094
-#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2095
+#: lib/abuuba_web/live/settings_live.ex:2234
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2316
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2316
+#: lib/abuuba_web/live/settings_live.ex:2317
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2272
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:252
+#: lib/abuuba_web/live/settings_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:2263
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2267
+#: lib/abuuba_web/live/settings_live.ex:2268
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:270
+#: lib/abuuba_web/live/settings_live.ex:271
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:974
+#: lib/abuuba_web/live/settings_live.ex:975
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:988
+#: lib/abuuba_web/live/settings_live.ex:989
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:447
+#: lib/abuuba_web/live/settings_live.ex:448
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2279
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2089
+#: lib/abuuba_web/live/settings_live.ex:2090
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2271
+#: lib/abuuba_web/live/settings_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1982,165 +1982,165 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1862
 #: lib/abuuba_web/live/admin_live.ex:2186
 #: lib/abuuba_web/live/conversations_live.ex:111
-#: lib/abuuba_web/live/settings_live.ex:278
-#: lib/abuuba_web/live/settings_live.ex:313
+#: lib/abuuba_web/live/settings_live.ex:279
+#: lib/abuuba_web/live/settings_live.ex:314
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2097
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:906
+#: lib/abuuba_web/live/settings_live.ex:907
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:902
+#: lib/abuuba_web/live/settings_live.ex:903
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2282
+#: lib/abuuba_web/live/settings_live.ex:2283
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:968
+#: lib/abuuba_web/live/settings_live.ex:969
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3748
-#: lib/abuuba_web/live/settings_live.ex:2085
+#: lib/abuuba_web/live/settings_live.ex:2086
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1573
+#: lib/abuuba_web/live/settings_live.ex:1574
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:466
+#: lib/abuuba_web/live/settings_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2266
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:847
+#: lib/abuuba_web/live/settings_live.ex:848
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:872
+#: lib/abuuba_web/live/settings_live.ex:873
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:239
+#: lib/abuuba_web/live/settings_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:259
+#: lib/abuuba_web/live/settings_live.ex:260
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:797
+#: lib/abuuba_web/live/settings_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2118
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2162
-#: lib/abuuba_web/live/settings_live.ex:759
+#: lib/abuuba_web/live/settings_live.ex:760
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:764
+#: lib/abuuba_web/live/settings_live.ex:765
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2119
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:453
+#: lib/abuuba_web/live/settings_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:434
+#: lib/abuuba_web/live/settings_live.ex:435
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:868
+#: lib/abuuba_web/live/settings_live.ex:869
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:884
+#: lib/abuuba_web/live/settings_live.ex:885
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:985
+#: lib/abuuba_web/live/settings_live.ex:986
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2121
+#: lib/abuuba_web/live/settings_live.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2150,19 +2150,19 @@ msgstr ""
 msgid "A handle looks like name@server."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:43
+#: lib/abuuba_web/live/about_live.ex:44
 #, elixir-autogen, elixir-format
 msgid "A server on the fediverse, running %{software}."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:22
+#: lib/abuuba_web/live/about_live.ex:23
 #: lib/abuuba_web/live/admin_live.ex:619
-#: lib/abuuba_web/live/document_live.ex:114
+#: lib/abuuba_web/live/document_live.ex:134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "About"
 msgstr ""
 
-#: lib/abuuba_web/live/document_live.ex:105
+#: lib/abuuba_web/live/document_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "About this server"
 msgstr ""
@@ -2172,12 +2172,12 @@ msgstr ""
 msgid "Do this from your own server"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:78
+#: lib/abuuba_web/live/about_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Getting in touch"
 msgstr ""
 
-#: lib/abuuba_web/live/document_live.ex:82
+#: lib/abuuba_web/live/document_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "In effect since %{date}"
 msgstr ""
@@ -2187,9 +2187,9 @@ msgstr ""
 msgid "No password is asked for and nothing is done on your behalf: you are simply sent to your own server's search with this address filled in."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:91
+#: lib/abuuba_web/live/about_live.ex:92
 #: lib/abuuba_web/live/admin_live.ex:1944
-#: lib/abuuba_web/live/document_live.ex:113
+#: lib/abuuba_web/live/document_live.ex:133
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Privacy policy"
 msgstr ""
@@ -2204,7 +2204,7 @@ msgstr ""
 msgid "Share"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:61
+#: lib/abuuba_web/live/about_live.ex:62
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signing up"
 msgstr ""
@@ -2224,9 +2224,9 @@ msgstr ""
 msgid "Take me to my server"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:90
+#: lib/abuuba_web/live/about_live.ex:91
 #: lib/abuuba_web/live/admin_live.ex:2191
-#: lib/abuuba_web/live/document_live.ex:112
+#: lib/abuuba_web/live/document_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr ""
@@ -2236,27 +2236,27 @@ msgstr ""
 msgid "That is this server. Use the buttons on the post itself once you are signed in."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:51
+#: lib/abuuba_web/live/about_live.ex:52
 #, elixir-autogen, elixir-format
 msgid "The numbers"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:66
+#: lib/abuuba_web/live/about_live.ex:67
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The rules"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:88
+#: lib/abuuba_web/live/about_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "The small print"
 msgstr ""
 
-#: lib/abuuba_web/live/document_live.ex:88
+#: lib/abuuba_web/live/document_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "This has not been written yet. Whoever runs this server can add it in the admin settings."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:83
+#: lib/abuuba_web/live/about_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Whoever runs this server has not published an address yet."
 msgstr ""
@@ -2271,135 +2271,135 @@ msgstr ""
 msgid "Your handle"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:101
+#: lib/abuuba_web/live/about_live.ex:102
 #, elixir-autogen, elixir-format, fuzzy
 msgid "people"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:105
+#: lib/abuuba_web/live/about_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "people active this half-year"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:104
+#: lib/abuuba_web/live/about_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "people active this month"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:102
+#: lib/abuuba_web/live/about_live.ex:103
 #, elixir-autogen, elixir-format, fuzzy
 msgid "posts"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:103
+#: lib/abuuba_web/live/about_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1850
+#: lib/abuuba_web/live/settings_live.ex:1851
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1194
+#: lib/abuuba_web/live/settings_live.ex:1195
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1224
+#: lib/abuuba_web/live/settings_live.ex:1225
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1834
+#: lib/abuuba_web/live/settings_live.ex:1835
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1191
+#: lib/abuuba_web/live/settings_live.ex:1192
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1198
-#: lib/abuuba_web/live/settings_live.ex:1830
+#: lib/abuuba_web/live/settings_live.ex:1199
+#: lib/abuuba_web/live/settings_live.ex:1831
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1169
+#: lib/abuuba_web/live/settings_live.ex:1170
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1845
+#: lib/abuuba_web/live/settings_live.ex:1846
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1844
+#: lib/abuuba_web/live/settings_live.ex:1845
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1846
+#: lib/abuuba_web/live/settings_live.ex:1847
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1851
+#: lib/abuuba_web/live/settings_live.ex:1852
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1855
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1855
+#: lib/abuuba_web/live/settings_live.ex:1856
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1852
+#: lib/abuuba_web/live/settings_live.ex:1853
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1177
+#: lib/abuuba_web/live/settings_live.ex:1178
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1215
+#: lib/abuuba_web/live/settings_live.ex:1216
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1204
+#: lib/abuuba_web/live/settings_live.ex:1205
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1206
+#: lib/abuuba_web/live/settings_live.ex:1207
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
@@ -2695,7 +2695,7 @@ msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3328
-#: lib/abuuba_web/live/settings_live.ex:1626
+#: lib/abuuba_web/live/settings_live.ex:1627
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
@@ -2785,7 +2785,7 @@ msgstr ""
 msgid "the server"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:305
+#: lib/abuuba_web/components/status_component.ex:307
 #: lib/abuuba_web/live/admin_live.ex:1075
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} person"
@@ -2834,12 +2834,12 @@ msgstr ""
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1240
+#: lib/abuuba_web/live/settings_live.ex:1241
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
@@ -2854,7 +2854,7 @@ msgstr ""
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Each version is kept with the day it takes effect, so somebody can still read what they agreed to."
 msgstr ""
 
-#: lib/abuuba_web/live/document_live.ex:94
+#: lib/abuuba_web/live/document_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Earlier versions"
 msgstr ""
@@ -2879,7 +2879,7 @@ msgstr ""
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1251
+#: lib/abuuba_web/live/settings_live.ex:1252
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
@@ -2889,17 +2889,17 @@ msgstr ""
 msgid "In effect from"
 msgstr ""
 
-#: lib/abuuba_web/live/document_live.ex:98
+#: lib/abuuba_web/live/document_live.ex:118
 #, elixir-autogen, elixir-format, fuzzy
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1235
+#: lib/abuuba_web/live/settings_live.ex:1236
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
@@ -2909,7 +2909,7 @@ msgstr ""
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1258
+#: lib/abuuba_web/live/settings_live.ex:1259
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
@@ -2939,7 +2939,7 @@ msgstr ""
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1272
+#: lib/abuuba_web/live/settings_live.ex:1273
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take it back"
 msgstr ""
@@ -2954,12 +2954,12 @@ msgstr ""
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1256
+#: lib/abuuba_web/live/settings_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1247
+#: lib/abuuba_web/live/settings_live.ex:1248
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What it is for"
 msgstr ""
@@ -2980,7 +2980,7 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1278
+#: lib/abuuba_web/live/settings_live.ex:1279
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2080
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3099,14 +3099,14 @@ msgstr ""
 msgid "approval only"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:337
+#: lib/abuuba_web/components/status_component.ex:339
 #, elixir-autogen, elixir-format
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:204
+#: lib/abuuba_web/live/explore_live.ex:208
 #: lib/abuuba_web/live/home_live.ex:337
-#: lib/abuuba_web/live/profile_live.ex:518
+#: lib/abuuba_web/live/profile_live.ex:529
 #: lib/abuuba_web/live/search_live.ex:195
 #: lib/abuuba_web/live/status_live.ex:184
 #: lib/abuuba_web/live/tag_live.ex:153
@@ -3114,12 +3114,12 @@ msgstr ""
 msgid "That could not be translated just now."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:444
+#: lib/abuuba_web/components/status_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:129
+#: lib/abuuba_web/components/status_component.ex:131
 #, elixir-autogen, elixir-format
 msgid "Translated by %{provider}. Reload the page for the original."
 msgstr ""
@@ -3129,275 +3129,275 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr "This account has been disabled. Contact the moderators."
 
-#: lib/abuuba_web/live/settings_live.ex:1979
+#: lib/abuuba_web/live/settings_live.ex:1980
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1970
+#: lib/abuuba_web/live/settings_live.ex:1971
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1886
+#: lib/abuuba_web/live/settings_live.ex:1887
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2043
+#: lib/abuuba_web/live/settings_live.ex:2044
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1867
+#: lib/abuuba_web/live/settings_live.ex:1868
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1892
+#: lib/abuuba_web/live/settings_live.ex:1893
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2058
+#: lib/abuuba_web/live/settings_live.ex:2059
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2066
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2068
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2039
+#: lib/abuuba_web/live/settings_live.ex:2040
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2054
-#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2055
+#: lib/abuuba_web/live/settings_live.ex:2060
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2057
+#: lib/abuuba_web/live/settings_live.ex:2058
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1876
+#: lib/abuuba_web/live/settings_live.ex:1877
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2064
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1873
+#: lib/abuuba_web/live/settings_live.ex:1874
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1881
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2070
+#: lib/abuuba_web/live/settings_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2072
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2076
+#: lib/abuuba_web/live/settings_live.ex:2077
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format, fuzzy
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2076
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1043
+#: lib/abuuba_web/live/settings_live.ex:1044
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1925
+#: lib/abuuba_web/live/settings_live.ex:1926
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1038
+#: lib/abuuba_web/live/settings_live.ex:1039
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1943
+#: lib/abuuba_web/live/settings_live.ex:1944
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1048
+#: lib/abuuba_web/live/settings_live.ex:1049
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1036
+#: lib/abuuba_web/live/settings_live.ex:1037
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1005
+#: lib/abuuba_web/live/settings_live.ex:1006
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1956
+#: lib/abuuba_web/live/settings_live.ex:1957
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:1934
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1062
-#: lib/abuuba_web/live/settings_live.ex:1905
-#: lib/abuuba_web/live/settings_live.ex:2230
+#: lib/abuuba_web/live/settings_live.ex:1063
+#: lib/abuuba_web/live/settings_live.ex:1906
+#: lib/abuuba_web/live/settings_live.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1032
+#: lib/abuuba_web/live/settings_live.ex:1033
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1016
+#: lib/abuuba_web/live/settings_live.ex:1017
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2029
+#: lib/abuuba_web/live/settings_live.ex:2030
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1000
+#: lib/abuuba_web/live/settings_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1929
+#: lib/abuuba_web/live/settings_live.ex:1930
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2019
+#: lib/abuuba_web/live/settings_live.ex:2020
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2030
+#: lib/abuuba_web/live/settings_live.ex:2031
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1907
+#: lib/abuuba_web/live/settings_live.ex:1908
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1026
+#: lib/abuuba_web/live/settings_live.ex:1027
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:998
+#: lib/abuuba_web/live/settings_live.ex:999
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1922
+#: lib/abuuba_web/live/settings_live.ex:1923
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2025
+#: lib/abuuba_web/live/settings_live.ex:2026
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:672
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:673
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No such post here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:242
+#: lib/abuuba_web/live/settings_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:780
+#: lib/abuuba_web/live/settings_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:793
+#: lib/abuuba_web/live/settings_live.ex:794
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:777
+#: lib/abuuba_web/live/settings_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1512
+#: lib/abuuba_web/live/settings_live.ex:1513
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
@@ -3407,54 +3407,54 @@ msgstr ""
 msgid "Why they want to join:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:305
+#: lib/abuuba_web/live/settings_live.ex:306
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:322
+#: lib/abuuba_web/live/settings_live.ex:323
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:325
+#: lib/abuuba_web/live/settings_live.ex:326
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feature it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:296
+#: lib/abuuba_web/live/settings_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:298
+#: lib/abuuba_web/live/settings_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1495
+#: lib/abuuba_web/live/settings_live.ex:1496
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:329
+#: lib/abuuba_web/live/settings_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1489
+#: lib/abuuba_web/live/settings_live.ex:1490
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:480
+#: lib/abuuba_web/live/settings_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:482
+#: lib/abuuba_web/live/settings_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
@@ -3511,57 +3511,57 @@ msgstr ""
 msgid "Nobody is on this list yet."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:116
+#: lib/abuuba_web/live/annual_report_live.ex:117
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} posts in %{year}"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:45
+#: lib/abuuba_web/live/annual_report_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "%{name}'s year"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:108
+#: lib/abuuba_web/live/annual_report_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Asked a lot of questions."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:80
+#: lib/abuuba_web/live/annual_report_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Counted from public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:107
+#: lib/abuuba_web/live/annual_report_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Mostly here to pass on what other people said."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:63
+#: lib/abuuba_web/live/annual_report_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "New followers"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:59
+#: lib/abuuba_web/live/annual_report_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Posts this year"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:106
+#: lib/abuuba_web/live/annual_report_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Read a lot more than they wrote."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:109
+#: lib/abuuba_web/live/annual_report_live.ex:110
 #, elixir-autogen, elixir-format
 msgid "Spent the year in other people's threads."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:69
+#: lib/abuuba_web/live/annual_report_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Written about most"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:110
+#: lib/abuuba_web/live/annual_report_live.ex:111
 #, elixir-autogen, elixir-format
 msgid "Wrote things other people replied to."
 msgstr ""
@@ -3602,7 +3602,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr ""
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:643
+#: lib/abuuba_web/live/settings_live.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email updates"
 msgstr ""
@@ -3617,7 +3617,7 @@ msgstr ""
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:661
+#: lib/abuuba_web/live/settings_live.ex:662
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr ""
@@ -3627,7 +3627,7 @@ msgstr ""
 msgid "No, remove my address"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:663
+#: lib/abuuba_web/live/settings_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3680,7 +3680,7 @@ msgstr ""
 msgid "Let people collect email addresses for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:645
+#: lib/abuuba_web/live/settings_live.ex:646
 #, elixir-autogen, elixir-format, fuzzy
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr ""
@@ -3828,75 +3828,75 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1075
+#: lib/abuuba_web/live/settings_live.ex:1076
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2237
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:808
-#: lib/abuuba_web/live/settings_live.ex:2231
+#: lib/abuuba_web/live/settings_live.ex:809
+#: lib/abuuba_web/live/settings_live.ex:2232
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1301
 #: lib/abuuba_web/live/admin_live.ex:1316
-#: lib/abuuba_web/live/settings_live.ex:2228
+#: lib/abuuba_web/live/settings_live.ex:2229
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:2233
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1117
+#: lib/abuuba_web/live/settings_live.ex:1118
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1100
+#: lib/abuuba_web/live/settings_live.ex:1101
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2103
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2230
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1064
+#: lib/abuuba_web/live/settings_live.ex:1065
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1385
+#: lib/abuuba_web/live/settings_live.ex:1386
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1082
+#: lib/abuuba_web/live/settings_live.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2239
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3916,13 +3916,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2236
+#: lib/abuuba_web/live/settings_live.ex:2237
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1106
-#: lib/abuuba_web/live/settings_live.ex:1391
+#: lib/abuuba_web/live/settings_live.ex:1107
+#: lib/abuuba_web/live/settings_live.ex:1392
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3932,7 +3932,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1077
+#: lib/abuuba_web/live/settings_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3942,67 +3942,67 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1156
+#: lib/abuuba_web/live/settings_live.ex:1157
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1154
+#: lib/abuuba_web/live/settings_live.ex:1155
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1120
+#: lib/abuuba_web/live/settings_live.ex:1121
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1059
+#: lib/abuuba_web/live/settings_live.ex:1060
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2135
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1137
+#: lib/abuuba_web/live/settings_live.ex:1138
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1418
+#: lib/abuuba_web/live/settings_live.ex:1419
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1415
+#: lib/abuuba_web/live/settings_live.ex:1416
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1127
+#: lib/abuuba_web/live/settings_live.ex:1128
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1411
+#: lib/abuuba_web/live/settings_live.ex:1412
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1142
+#: lib/abuuba_web/live/settings_live.ex:1143
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1122
+#: lib/abuuba_web/live/settings_live.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1132
+#: lib/abuuba_web/live/settings_live.ex:1133
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
@@ -4012,7 +4012,7 @@ msgstr ""
 msgid "A post"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:390
+#: lib/abuuba_web/live/profile_live.ex:399
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nobody yet."
 msgstr ""
@@ -4022,7 +4022,7 @@ msgstr ""
 msgid "Public posts tagged #%{tag}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:367
+#: lib/abuuba_web/live/profile_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr ""
@@ -4048,99 +4048,99 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1447
+#: lib/abuuba_web/live/settings_live.ex:1448
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:912
+#: lib/abuuba_web/live/settings_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:521
+#: lib/abuuba_web/live/settings_live.ex:522
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:530
+#: lib/abuuba_web/live/settings_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:549
+#: lib/abuuba_web/live/settings_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:576
+#: lib/abuuba_web/live/settings_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:565
+#: lib/abuuba_web/live/settings_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:561
+#: lib/abuuba_web/live/settings_live.ex:562
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:935
+#: lib/abuuba_web/live/settings_live.ex:936
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:518
+#: lib/abuuba_web/live/settings_live.ex:519
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:931
+#: lib/abuuba_web/live/settings_live.ex:932
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:523
+#: lib/abuuba_web/live/settings_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:587
+#: lib/abuuba_web/live/settings_live.ex:588
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:498
+#: lib/abuuba_web/live/settings_live.ex:499
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:910
+#: lib/abuuba_web/live/settings_live.ex:911
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:920
+#: lib/abuuba_web/live/settings_live.ex:921
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:920
+#: lib/abuuba_web/live/settings_live.ex:921
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signed in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:512
+#: lib/abuuba_web/live/settings_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:500
+#: lib/abuuba_web/live/settings_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr ""
@@ -4952,124 +4952,124 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2218
+#: lib/abuuba_web/live/settings_live.ex:2219
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2219
+#: lib/abuuba_web/live/settings_live.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:344
+#: lib/abuuba_web/live/settings_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:550
-#: lib/abuuba_web/live/settings_live.ex:362
+#: lib/abuuba_web/live/settings_live.ex:363
 #, elixir-autogen, elixir-format, fuzzy
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2053
+#: lib/abuuba_web/live/settings_live.ex:2054
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One picture at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:342
+#: lib/abuuba_web/live/settings_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:394
+#: lib/abuuba_web/live/settings_live.ex:395
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2051
-#: lib/abuuba_web/live/settings_live.ex:2212
+#: lib/abuuba_web/live/settings_live.ex:2052
+#: lib/abuuba_web/live/settings_live.ex:2213
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2207
-#: lib/abuuba_web/live/settings_live.ex:2214
+#: lib/abuuba_web/live/settings_live.ex:2208
+#: lib/abuuba_web/live/settings_live.ex:2215
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2048
+#: lib/abuuba_web/live/settings_live.ex:2049
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:164
+#: lib/abuuba_web/live/profile_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:313
-#: lib/abuuba_web/live/profile_live.ex:317
+#: lib/abuuba_web/live/profile_live.ex:322
+#: lib/abuuba_web/live/profile_live.ex:326
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Featured accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:544
+#: lib/abuuba_web/live/profile_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:267
+#: lib/abuuba_web/live/profile_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:678
+#: lib/abuuba_web/live/settings_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:270
+#: lib/abuuba_web/live/profile_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:703
+#: lib/abuuba_web/live/settings_live.ex:704
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send it"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:286
+#: lib/abuuba_web/live/profile_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:712
+#: lib/abuuba_web/live/settings_live.ex:713
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:689
-#: lib/abuuba_web/live/settings_live.ex:1780
+#: lib/abuuba_web/live/settings_live.ex:690
+#: lib/abuuba_web/live/settings_live.ex:1781
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:547
+#: lib/abuuba_web/live/profile_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1366
+#: lib/abuuba_web/live/settings_live.ex:1367
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5079,17 +5079,17 @@ msgstr ""
 msgid "To stop them, open this link:"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:534
+#: lib/abuuba_web/live/profile_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:696
+#: lib/abuuba_web/live/settings_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:676
+#: lib/abuuba_web/live/settings_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr ""
@@ -5099,22 +5099,22 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1371
+#: lib/abuuba_web/live/settings_live.ex:1372
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1781
+#: lib/abuuba_web/live/settings_live.ex:1782
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:719
+#: lib/abuuba_web/live/settings_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr ""
@@ -5400,7 +5400,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:958
+#: lib/abuuba_web/live/settings_live.ex:959
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5445,12 +5445,12 @@ msgstr ""
 msgid "Search as you"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:63
+#: lib/abuuba_web/components/status_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "Filtered: %{title}"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:65
+#: lib/abuuba_web/components/status_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "Show anyway"
 msgstr ""
@@ -5548,42 +5548,42 @@ msgstr ""
 msgid "not offered"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:236
+#: lib/abuuba_web/live/profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:234
+#: lib/abuuba_web/live/profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:213
+#: lib/abuuba_web/live/profile_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:462
+#: lib/abuuba_web/components/status_component.ex:464
 #, elixir-autogen, elixir-format, fuzzy
 msgid "More"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:474
+#: lib/abuuba_web/components/status_component.ex:476
 #, elixir-autogen, elixir-format
 msgid "Mute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:481
+#: lib/abuuba_web/components/status_component.ex:483
 #, elixir-autogen, elixir-format
 msgid "Stops its notifications and takes it out of your timeline. Nobody is told."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:473
+#: lib/abuuba_web/components/status_component.ex:475
 #, elixir-autogen, elixir-format
 msgid "Unmute this conversation"
 msgstr ""
@@ -5593,7 +5593,7 @@ msgstr ""
 msgid "Posts from people you watch"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:228
+#: lib/abuuba_web/live/profile_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr ""
@@ -5752,22 +5752,22 @@ msgstr ""
 msgid "Who may read the blocklist"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:633
+#: lib/abuuba_web/live/settings_live.ex:634
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:625
+#: lib/abuuba_web/live/settings_live.ex:626
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:837
+#: lib/abuuba_web/live/settings_live.ex:838
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Block a server"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:810
+#: lib/abuuba_web/live/settings_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr ""
@@ -5777,8 +5777,8 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:144
-#: lib/abuuba_web/live/profile_live.ex:585
+#: lib/abuuba_web/live/explore_live.ex:148
+#: lib/abuuba_web/live/profile_live.ex:596
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
@@ -5841,4 +5841,19 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:3360
 #, elixir-autogen, elixir-format
 msgid "Warned"
+msgstr ""
+
+#: lib/abuuba_web/live/profile_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Cancel follow request"
+msgstr ""
+
+#: lib/abuuba_web/live/explore_live.ex:117
+#, elixir-autogen, elixir-format
+msgid "Requested"
+msgstr ""
+
+#: lib/abuuba_web/live/profile_live.ex:606
+#, elixir-autogen, elixir-format
+msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr ""

--- a/test/abuuba/federation/outbox_test.exs
+++ b/test/abuuba/federation/outbox_test.exs
@@ -235,6 +235,20 @@ defmodule Abuuba.Federation.OutboxTest do
       assert [%{"type" => "Undo", "object" => %{"type" => "Follow"}}] = queued_activities()
     end
 
+    # Their server is holding a pending request of its own. Deleting the row
+    # here and saying nothing leaves it waiting for an answer to a question
+    # that has been taken back.
+    test "withdrawing a request tells their server it is gone" do
+      asker = account_fixture()
+      target = watcher("locked")
+      {:ok, _request} = Relationships.request_follow(asker, target)
+      Repo.delete_all(Oban.Job)
+
+      :ok = Relationships.unfollow(asker, target)
+
+      assert [%{"type" => "Undo", "object" => %{"type" => "Follow"}}] = queued_activities()
+    end
+
     test "accepting a request tells the asker they are in" do
       target = account_fixture(%{locked: true})
       asker = watcher("asker")

--- a/test/abuuba/imports/csv_rows_test.exs
+++ b/test/abuuba/imports/csv_rows_test.exs
@@ -55,6 +55,17 @@ defmodule Abuuba.Imports.CSVRowsTest do
       assert Relationships.following?(account, other)
     end
 
+    test "asks the ones who approve their followers", %{account: account, root: root} do
+      locked = account_fixture(%{locked: true})
+      contents = "Account address\n#{handle(locked)}\n"
+
+      finished = run!(account, root, "following_accounts.csv", contents)
+
+      assert finished.imported == 1
+      refute Relationships.following?(account, locked)
+      assert Relationships.get_follow_request(account, locked)
+    end
+
     test "keeping what the file said about boosts", %{account: account, other: other, root: root} do
       contents = "Account address,Show boosts,Notify on new posts\n#{handle(other)},false,true\n"
 

--- a/test/abuuba/relationships_test.exs
+++ b/test/abuuba/relationships_test.exs
@@ -4,7 +4,11 @@ defmodule Abuuba.RelationshipsTest do
   import Abuuba.AccountsFixtures
   import Abuuba.StatusesFixtures
 
+  alias Abuuba.Accounts
+  alias Abuuba.Notifications
   alias Abuuba.Relationships
+  alias Abuuba.Relationships.Follow
+  alias Abuuba.Relationships.FollowRequest
   alias Abuuba.Relationships.Mute
   alias Abuuba.Stats
   alias Abuuba.Statuses
@@ -162,6 +166,80 @@ defmodule Abuuba.RelationshipsTest do
 
       assert {:error, changeset} = Relationships.request_follow(alice, bob)
       assert errors_on(changeset).account_id != []
+    end
+
+    test "is withdrawn by the person who asked", %{alice: alice, bob: bob} do
+      {:ok, _} = Relationships.request_follow(alice, bob)
+
+      assert :ok = Relationships.unfollow(alice, bob)
+
+      assert Relationships.get_follow_request(alice, bob) == nil
+      refute Relationships.following?(alice, bob)
+    end
+
+    test "withdrawing takes the notification asking about it", %{alice: alice, bob: bob} do
+      {:ok, _} = Relationships.request_follow(alice, bob)
+
+      Relationships.unfollow(alice, bob)
+
+      assert Notifications.list(bob) == []
+    end
+  end
+
+  describe "following an account that approves its followers" do
+    setup do
+      %{locked: account_fixture(%{locked: true})}
+    end
+
+    test "asks instead of following", %{alice: alice, locked: locked} do
+      assert {:ok, %FollowRequest{}} = Relationships.follow_or_request(alice, locked)
+
+      refute Relationships.following?(alice, locked)
+      assert Relationships.get_follow_request(alice, locked)
+    end
+
+    test "follows anybody else outright", %{alice: alice, bob: bob} do
+      assert {:ok, %Follow{}} = Relationships.follow_or_request(alice, bob)
+
+      assert Relationships.following?(alice, bob)
+    end
+
+    test "carries the options into the request", %{alice: alice, locked: locked} do
+      {:ok, request} =
+        Relationships.follow_or_request(alice, locked, %{show_reblogs: false, languages: ["de"]})
+
+      assert request.show_reblogs == false
+      assert request.languages == ["de"]
+    end
+
+    # Somebody who locks their account after granting a follow has already said
+    # yes to the people following them, and a repeat follow is how the options
+    # on that follow are changed. Asking again would hand them a question about
+    # somebody they already answered for.
+    test "changes an existing follow rather than asking again", %{alice: alice, bob: bob} do
+      {:ok, _} = Relationships.follow(alice, bob)
+      {:ok, locked} = Accounts.update_account(bob, %{locked: true})
+
+      assert {:ok, %Follow{}} =
+               Relationships.follow_or_request(alice, locked, %{show_reblogs: false})
+
+      assert Relationships.get_follow_request(alice, locked) == nil
+      refute Relationships.get_follow(alice, locked).show_reblogs
+    end
+
+    test "asking twice is one request, not an error", %{alice: alice, locked: locked} do
+      {:ok, _} = Relationships.follow_or_request(alice, locked)
+
+      assert {:ok, request} =
+               Relationships.follow_or_request(alice, locked, %{show_reblogs: false})
+
+      assert request.show_reblogs == false
+    end
+
+    test "is refused where either has blocked the other", %{alice: alice, locked: locked} do
+      {:ok, _} = Relationships.block(locked, alice)
+
+      assert {:error, :blocked} = Relationships.follow_or_request(alice, locked)
     end
   end
 

--- a/test/abuuba_web/api/account_controller_test.exs
+++ b/test/abuuba_web/api/account_controller_test.exs
@@ -400,6 +400,47 @@ defmodule AbuubaWeb.API.AccountControllerTest do
       assert body["requested"]
     end
 
+    test "asking a locked account twice is one request", %{conn: conn} do
+      locked = account_fixture(%{username: "dora", locked: true})
+
+      post(conn, "/api/v1/accounts/#{locked.id}/follow")
+      body = json_response(post(conn, "/api/v1/accounts/#{locked.id}/follow"), 200)
+
+      assert body["requested"]
+    end
+
+    # A follow already granted is changed by a repeat follow, on a locked
+    # account like on any other. Asking again would leave a request pending
+    # beside a follow that is already in place.
+    test "setting the options on a follow a locked account granted", %{
+      conn: conn,
+      account: account
+    } do
+      locked = account_fixture(%{username: "elke", locked: true})
+      {:ok, request} = Relationships.request_follow(account, locked)
+      {:ok, _follow} = Relationships.accept_follow_request(request)
+
+      body =
+        json_response(
+          post(conn, "/api/v1/accounts/#{locked.id}/follow", %{"reblogs" => false}),
+          200
+        )
+
+      assert body["following"]
+      refute body["requested"]
+      refute body["showing_reblogs"]
+    end
+
+    test "unfollowing withdraws a request nobody has answered", %{conn: conn, account: account} do
+      locked = account_fixture(%{username: "frida", locked: true})
+      post(conn, "/api/v1/accounts/#{locked.id}/follow")
+
+      body = json_response(post(conn, "/api/v1/accounts/#{locked.id}/unfollow"), 200)
+
+      refute body["requested"]
+      assert Relationships.get_follow_request(account, locked) == nil
+    end
+
     test "carrying the per-follow options", %{conn: conn, other: other} do
       body =
         json_response(

--- a/test/abuuba_web/explore_live_test.exs
+++ b/test/abuuba_web/explore_live_test.exs
@@ -151,6 +151,27 @@ defmodule AbuubaWeb.ExploreLiveTest do
       assert Abuuba.Relationships.following?(reader, author)
     end
 
+    test "somebody who approves their followers is asked, not followed", %{
+      signed_in: conn,
+      author: author,
+      reader: reader
+    } do
+      {:ok, locked} = Accounts.update_account(author, %{locked: true})
+
+      {:ok, live, _html} = live(conn, ~p"/explore/people")
+
+      html =
+        live
+        |> element("button[phx-value-account='#{locked.id}'][phx-click='follow']")
+        |> render_click()
+
+      refute Abuuba.Relationships.following?(reader, locked),
+             "the card followed a locked account outright instead of asking it"
+
+      assert Abuuba.Relationships.get_follow_request(reader, locked)
+      assert html =~ "Requested"
+    end
+
     test "a passer-by is offered nothing to press", %{conn: conn} do
       html = conn |> get(~p"/explore/people") |> html_response(200)
 

--- a/test/abuuba_web/profile_live_test.exs
+++ b/test/abuuba_web/profile_live_test.exs
@@ -450,6 +450,44 @@ defmodule AbuubaWeb.ProfileLiveTest do
     end
   end
 
+  describe "following somebody who approves their followers" do
+    setup %{subject: subject} do
+      {:ok, locked} = Accounts.update_account(subject, %{locked: true})
+
+      %{subject: locked}
+    end
+
+    test "asks rather than follows", %{signed_in: conn, subject: subject, reader: reader} do
+      {:ok, live, _html} = live(conn, "/@bob")
+
+      html = live |> element("button[phx-click='follow']") |> render_click()
+
+      refute Relationships.following?(reader, subject),
+             "the button followed a locked account outright instead of asking it"
+
+      assert Relationships.get_follow_request(reader, subject)
+      assert html =~ "approves"
+    end
+
+    test "says the request is waiting, and offers a way out of waiting", %{
+      signed_in: conn,
+      subject: subject,
+      reader: reader
+    } do
+      {:ok, _request} = Relationships.request_follow(reader, subject)
+
+      {:ok, live, html} = live(conn, "/@bob")
+
+      refute html =~ ~s(phx-click="follow")
+      assert html =~ "Cancel follow request"
+
+      live |> element("button[phx-click='unfollow']") |> render_click()
+
+      assert Relationships.get_follow_request(reader, subject) == nil
+      assert render(live) =~ ~s(phx-click="follow")
+    end
+  end
+
   describe "acting on somebody" do
     test "following and unfollowing", %{signed_in: conn, subject: subject, reader: reader} do
       {:ok, live, _html} = live(conn, "/@bob")
@@ -459,6 +497,23 @@ defmodule AbuubaWeb.ProfileLiveTest do
 
       live |> element("button[phx-click='unfollow']") |> render_click()
       refute Relationships.following?(reader, subject)
+    end
+
+    # The page holds the profile it was built from, and that copy is as old as
+    # the tab. What decides whether to ask is the account as it stands at the
+    # moment of the press, not as it stood when somebody opened the page.
+    test "somebody who locks their account while the page is open is asked", %{
+      signed_in: conn,
+      subject: subject,
+      reader: reader
+    } do
+      {:ok, live, _html} = live(conn, "/@bob")
+      {:ok, subject} = Accounts.update_account(subject, %{locked: true})
+
+      live |> element("button[phx-click='follow']") |> render_click()
+
+      refute Relationships.following?(reader, subject)
+      assert Relationships.get_follow_request(reader, subject)
     end
 
     test "blocking", %{signed_in: conn, subject: subject, reader: reader} do


### PR DESCRIPTION
**TL;DR** The profile and explore Follow buttons followed a locked account outright, walking past the approval its owner asked for.

**Where:** `profile_live.ex`, `explore_live.ex` both called `Relationships.follow/3`, which never reads `locked`. Only the API and inbound federation branched on it.

**Now:** one door, `Relationships.follow_or_request/3`, used by the profile, the explore list, the API and the CSV follow-list import. It reads `locked` from the row, not from the struct a page was built with, which can be as old as the tab. The paths that mean an outright follow (a local move, an inbound `Move`, invite autofollow) stay on `follow/3` and say why.

Unfollowing now withdraws an unanswered request and sends the `Undo`, so the profile offers **Cancel follow request** instead of leaving somebody waiting for good. Explore shows a **Requested** badge.

Docs and German strings updated. 4375 tests, credo strict, `mix precommit` green; smoke-tested in Chrome.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01RGuvfrhkTi7DxzUp5tdwsk
