### PR TITLE
Sweep the tree for duplication and wasted work

### DIFF
--- a/docs/de/user/benachrichtigungen.md
+++ b/docs/de/user/benachrichtigungen.md
@@ -7,7 +7,10 @@ favorisiert, teilt oder zitiert einen deiner Beiträge, folgt dir oder fragt
 danach, bearbeitet einen Beitrag, den du geteilt hast, oder eine Umfrage, an
 der du teilgenommen hast, ist zu Ende. Zusammengehörendes steht in einer
 Zeile: Zwölf Leute, die denselben Beitrag teilen, sind eine Sache, die passiert
-ist, und nicht zwölf, und der Beitrag selbst steht einmal darunter.
+ist, und nicht zwölf, und der Beitrag selbst steht einmal darunter. Dieser
+Beitrag hat dieselben Schaltflächen wie überall sonst: Du kannst ihn
+favorisieren, teilen, als Lesezeichen speichern, beantworten oder übersetzen,
+ohne die Spalte zu verlassen.
 
 Das Ende einer Umfrage erreicht auch die Person, die sie gestellt hat, denn die
 Antwort ist der Teil, der erst nach dem Beitrag kommt.

--- a/docs/user/notifications.md
+++ b/docs/user/notifications.md
@@ -7,6 +7,8 @@ you, favouriting or boosting or quoting one of your posts, following you or
 asking to, editing a post you boosted, and a poll you voted in closing. Events
 that belong together are one line: twelve people boosting the same post is one
 thing that happened, not twelve, and the post itself is shown once underneath.
+That post carries the same buttons it has anywhere else, so you can favourite,
+boost, bookmark, reply to or translate it without leaving the column.
 
 A poll closing reaches its author as well as everybody who voted, since the
 answer is the part that arrives after the post does.

--- a/lib/abuuba/accounts/account.ex
+++ b/lib/abuuba/accounts/account.ex
@@ -541,6 +541,17 @@ defmodule Abuuba.Accounts.Account do
   def acct(%Account{username: username, domain: domain}), do: "#{username}@#{domain}"
 
   @doc """
+  The name to show for an account, falling back to the username.
+
+  `display_name` is optional and blank far more often than it looks, so every
+  screen that renders an account needs this fallback. It lives here because it
+  was written out privately in eleven modules, in two spellings, and the most
+  rendered string in the product should have one definition.
+  """
+  def display_name(%Account{display_name: name}) when is_binary(name) and name != "", do: name
+  def display_name(%Account{username: username}), do: username
+
+  @doc """
   The pattern a username must match.
 
   Exposed so that the signup form checks the same rule the schema does; two

--- a/lib/abuuba/admin.ex
+++ b/lib/abuuba/admin.ex
@@ -41,6 +41,7 @@ defmodule Abuuba.Admin do
   alias Abuuba.Roles
   alias Abuuba.Roles.Role
   alias Abuuba.Settings
+  alias Abuuba.Snowflake
   alias Abuuba.Statuses.Status
   alias Abuuba.Statuses.Tag
   alias AbuubaWeb.Endpoint
@@ -192,7 +193,7 @@ defmodule Abuuba.Admin do
   """
   @spec get_user(integer() | String.t()) :: User.t() | nil
   def get_user(id) do
-    case numeric(id) do
+    case Snowflake.cast(id) do
       {:ok, id} -> Repo.get(User, id)
       _ -> nil
     end
@@ -313,7 +314,7 @@ defmodule Abuuba.Admin do
   """
   @spec get_tag(term()) :: Tag.t() | nil
   def get_tag(id) do
-    case numeric(id) do
+    case Snowflake.cast(id) do
       {:ok, id} -> Repo.get(Tag, id)
       :error -> nil
     end
@@ -560,14 +561,14 @@ defmodule Abuuba.Admin do
   end
 
   defp write_setting("remote_post_retention_days", value) do
-    case numeric(value) do
+    case day_count(value) do
       {:ok, days} when days >= 0 -> Settings.put("remote_post_retention_days", days)
       _ -> :error
     end
   end
 
   defp write_setting("content_retention_days", value) do
-    case numeric(value) do
+    case day_count(value) do
       {:ok, days} when days >= 0 -> Settings.put("content_retention_days", days)
       _ -> :error
     end
@@ -762,14 +763,16 @@ defmodule Abuuba.Admin do
 
   defp escape_like(text), do: String.replace(text, ~r/([%_\\])/, "\\\\\\1")
 
-  defp numeric(value) when is_integer(value), do: {:ok, value}
+  # A day count from the settings form, and deliberately not an id: the whole
+  # string has to be the number, so "30 days" is a refusal rather than thirty.
+  defp day_count(value) when is_integer(value), do: {:ok, value}
 
-  defp numeric(value) when is_binary(value) do
+  defp day_count(value) when is_binary(value) do
     case Integer.parse(value) do
       {number, ""} -> {:ok, number}
       _ -> :error
     end
   end
 
-  defp numeric(_value), do: :error
+  defp day_count(_value), do: :error
 end

--- a/lib/abuuba/annual_reports.ex
+++ b/lib/abuuba/annual_reports.ex
@@ -34,6 +34,7 @@ defmodule Abuuba.AnnualReports do
   alias Abuuba.Notifications
   alias Abuuba.Relationships.Follow
   alias Abuuba.Repo
+  alias Abuuba.Snowflake
   alias Abuuba.Statuses.Status
   alias Abuuba.Statuses.Tag
 
@@ -80,7 +81,7 @@ defmodule Abuuba.AnnualReports do
   def get(%Account{id: id}, report_id), do: get(id, report_id)
 
   def get(account_id, report_id) do
-    case numeric(report_id) do
+    case Snowflake.cast(report_id) do
       {:ok, id} -> Repo.get_by(Report, id: id, account_id: account_id)
       :error -> nil
     end
@@ -310,20 +311,9 @@ defmodule Abuuba.AnnualReports do
   @int4 -2_147_483_648..2_147_483_647
 
   defp year(value) do
-    case numeric(value) do
+    case Snowflake.cast(value) do
       {:ok, year} when year in @int4 -> {:ok, year}
       _outside -> :error
     end
   end
-
-  defp numeric(value) when is_integer(value), do: {:ok, value}
-
-  defp numeric(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, ""} -> {:ok, number}
-      _ -> :error
-    end
-  end
-
-  defp numeric(_value), do: :error
 end

--- a/lib/abuuba/collections.ex
+++ b/lib/abuuba/collections.ex
@@ -29,6 +29,7 @@ defmodule Abuuba.Collections do
   alias Abuuba.Collections.Item
   alias Abuuba.Notifications
   alias Abuuba.Repo
+  alias Abuuba.Snowflake
   alias Abuuba.Statuses.Tag
 
   @doc """
@@ -74,7 +75,7 @@ defmodule Abuuba.Collections do
   """
   @spec get(term()) :: Collection.t() | nil
   def get(id) do
-    case numeric(id) do
+    case Snowflake.cast(id) do
       {:ok, id} -> Collection |> where([c], c.id == ^id) |> preload(:tag) |> Repo.one()
       :error -> nil
     end
@@ -100,7 +101,7 @@ defmodule Abuuba.Collections do
   def get_item(%Collection{id: id}, item_id), do: get_item(id, item_id)
 
   def get_item(collection_id, item_id) do
-    case numeric(item_id) do
+    case Snowflake.cast(item_id) do
       {:ok, id} -> Repo.get_by(Item, id: id, collection_id: collection_id)
       :error -> nil
     end
@@ -292,15 +293,4 @@ defmodule Abuuba.Collections do
 
   defp reload({:ok, %Collection{id: id}}), do: {:ok, get(id)}
   defp reload(other), do: other
-
-  defp numeric(value) when is_integer(value), do: {:ok, value}
-
-  defp numeric(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, ""} -> {:ok, number}
-      _ -> :error
-    end
-  end
-
-  defp numeric(_value), do: :error
 end

--- a/lib/abuuba/conversations.ex
+++ b/lib/abuuba/conversations.ex
@@ -31,6 +31,7 @@ defmodule Abuuba.Conversations do
   alias Abuuba.Accounts.Account
   alias Abuuba.Pagination
   alias Abuuba.Repo
+  alias Abuuba.Snowflake
   alias Abuuba.Statuses.Mention
   alias Abuuba.Statuses.Status
   alias Abuuba.Streaming
@@ -141,7 +142,7 @@ defmodule Abuuba.Conversations do
   def get(%Account{id: id}, row_id), do: get(id, row_id)
 
   def get(account_id, row_id) do
-    with {:ok, row_id} <- numeric(row_id) do
+    with {:ok, row_id} <- Snowflake.cast(row_id) do
       # The same shape `list/2` returns. A narrower one here would mean every
       # caller having to know which of the two it was holding.
       from(c in "account_conversations",
@@ -199,7 +200,7 @@ defmodule Abuuba.Conversations do
   def remove(%Account{id: id}, row_id), do: remove(id, row_id)
 
   def remove(account_id, row_id) do
-    with {:ok, row_id} <- numeric(row_id) do
+    with {:ok, row_id} <- Snowflake.cast(row_id) do
       from(c in "account_conversations",
         where: c.account_id == ^account_id and c.id == ^row_id
       )
@@ -312,7 +313,7 @@ defmodule Abuuba.Conversations do
   defp set(%Account{id: id}, row_id, changes), do: set(id, row_id, changes)
 
   defp set(account_id, row_id, changes) do
-    with {:ok, row_id} <- numeric(row_id),
+    with {:ok, row_id} <- Snowflake.cast(row_id),
          {1, _} <-
            from(c in "account_conversations",
              where: c.account_id == ^account_id and c.id == ^row_id
@@ -329,15 +330,4 @@ defmodule Abuuba.Conversations do
 
   defp after_cursor(query, nil), do: query
   defp after_cursor(query, id), do: where(query, [c], c.last_status_id > ^id)
-
-  defp numeric(value) when is_integer(value), do: {:ok, value}
-
-  defp numeric(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, ""} -> {:ok, number}
-      _ -> nil
-    end
-  end
-
-  defp numeric(_value), do: nil
 end

--- a/lib/abuuba/moderation/actions.ex
+++ b/lib/abuuba/moderation/actions.ex
@@ -36,6 +36,7 @@ defmodule Abuuba.Moderation.Actions do
   alias Abuuba.Notifications
   alias Abuuba.OAuth
   alias Abuuba.Repo
+  alias Abuuba.Snowflake
   alias Abuuba.Statuses
   alias Abuuba.Statuses.Status
 
@@ -124,7 +125,7 @@ defmodule Abuuba.Moderation.Actions do
   def own_strike(%Account{id: id}, strike_id), do: own_strike(id, strike_id)
 
   def own_strike(target_id, strike_id) do
-    with {:ok, id} <- numeric(strike_id) do
+    with {:ok, id} <- Snowflake.cast(strike_id) do
       Repo.get_by(Strike, id: id, target_account_id: target_id)
     end
   end
@@ -476,15 +477,4 @@ defmodule Abuuba.Moderation.Actions do
 
   defp report_id(nil), do: nil
   defp report_id(%{id: id}), do: id
-
-  defp numeric(value) when is_integer(value), do: {:ok, value}
-
-  defp numeric(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, ""} -> {:ok, number}
-      _ -> nil
-    end
-  end
-
-  defp numeric(_value), do: nil
 end

--- a/lib/abuuba/moderation/domains.ex
+++ b/lib/abuuba/moderation/domains.ex
@@ -148,6 +148,22 @@ defmodule Abuuba.Moderation.Domains do
   end
 
   @doc """
+  How many domains are blocked and how many are allowed.
+
+  Counted in the database rather than by measuring the lists. The screen that
+  asks wants two integers for a sentence, and reading the rows to length them
+  meant loading every column of up to ten thousand blocks and sorting them,
+  once per view of the page.
+  """
+  @spec counts() :: %{blocks: non_neg_integer(), allows: non_neg_integer()}
+  def counts do
+    %{
+      blocks: Repo.aggregate(DomainBlock, :count),
+      allows: Repo.aggregate(DomainAllow, :count)
+    }
+  end
+
+  @doc """
   One block by id, or `nil`.
   """
   @spec get_block(integer() | String.t()) :: DomainBlock.t() | nil

--- a/lib/abuuba/moderation/domains.ex
+++ b/lib/abuuba/moderation/domains.ex
@@ -63,6 +63,7 @@ defmodule Abuuba.Moderation.Domains do
   alias Abuuba.Relationships.FollowRequest
   alias Abuuba.Repo
   alias Abuuba.Settings
+  alias Abuuba.Snowflake
 
   @csv_header "#domain,#severity,#reject_media,#reject_reports,#public_comment,#obfuscate"
 
@@ -168,7 +169,7 @@ defmodule Abuuba.Moderation.Domains do
   """
   @spec get_block(integer() | String.t()) :: DomainBlock.t() | nil
   def get_block(id) do
-    case numeric(id) do
+    case Snowflake.cast(id) do
       {:ok, id} -> Repo.get(DomainBlock, id)
       _ -> nil
     end
@@ -435,7 +436,7 @@ defmodule Abuuba.Moderation.Domains do
   """
   @spec get_allow(term()) :: DomainAllow.t() | nil
   def get_allow(id) do
-    case numeric(id) do
+    case Snowflake.cast(id) do
       {:ok, id} -> Repo.get(DomainAllow, id)
       :error -> nil
     end
@@ -826,15 +827,4 @@ defmodule Abuuba.Moderation.Domains do
   end
 
   defp truthy(value), do: String.downcase(to_string(value)) in ["true", "1", "yes"]
-
-  defp numeric(value) when is_integer(value), do: {:ok, value}
-
-  defp numeric(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, ""} -> {:ok, number}
-      _ -> :error
-    end
-  end
-
-  defp numeric(_value), do: :error
 end

--- a/lib/abuuba/moderation/reports.ex
+++ b/lib/abuuba/moderation/reports.ex
@@ -35,6 +35,7 @@ defmodule Abuuba.Moderation.Reports do
   alias Abuuba.Pagination
   alias Abuuba.Repo
   alias Abuuba.Roles
+  alias Abuuba.Snowflake
   alias Abuuba.Statuses.Status
   alias Abuuba.Webhooks
 
@@ -88,7 +89,7 @@ defmodule Abuuba.Moderation.Reports do
   """
   @spec get(integer() | String.t()) :: Report.t() | nil
   def get(id) do
-    case numeric(id) do
+    case Snowflake.cast(id) do
       {:ok, id} -> Repo.get(Report, id)
       _ -> nil
     end
@@ -320,20 +321,9 @@ defmodule Abuuba.Moderation.Reports do
   defp id_of(id) when is_integer(id), do: id
 
   defp numeric_list(value) do
-    case numeric(value) do
+    case Snowflake.cast(value) do
       {:ok, id} -> [id]
       _ -> []
     end
   end
-
-  defp numeric(value) when is_integer(value), do: {:ok, value}
-
-  defp numeric(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, ""} -> {:ok, number}
-      _ -> nil
-    end
-  end
-
-  defp numeric(_value), do: nil
 end

--- a/lib/abuuba/roles.ex
+++ b/lib/abuuba/roles.ex
@@ -109,9 +109,23 @@ defmodule Abuuba.Roles do
   @spec can?(User.t() | nil, String.t() | atom()) :: boolean()
   def can?(nil, _permission), do: false
 
-  def can?(%User{} = user, permission) do
+  def can?(%User{} = user, permission), do: allows?(permissions_of(user), permission)
+
+  @doc """
+  Whether a mask of held permissions covers one thing.
+
+  The same question as `can?/2` with the reading already done, for a screen
+  that asks it many times over one render: the admin area's own navigation
+  asks it once per section and its permission form twice per permission, and
+  each of those went to the database for the same role row.
+
+  Use `can?/2` to decide anything. This answers from a mask somebody read
+  earlier, which is right for drawing a page and wrong for allowing an action:
+  a permission taken away should stop the next click, not the next page load.
+  """
+  @spec allows?(integer(), String.t() | atom()) :: boolean()
+  def allows?(held, permission) do
     wanted = bit(permission)
-    held = permissions_of(user)
 
     # An unknown permission is zero, and zero must never be "yes". Checked
     # before the administrator short circuit for exactly that reason.

--- a/lib/abuuba/roles.ex
+++ b/lib/abuuba/roles.ex
@@ -30,6 +30,7 @@ defmodule Abuuba.Roles do
   alias Abuuba.Repo
   alias Abuuba.Roles.Role
   alias Abuuba.Settings
+  alias Abuuba.Snowflake
 
   # The reference implementation's flags and its bit positions. Its admin API
   # hands these numbers to clients, so they are part of the protocol rather
@@ -200,7 +201,7 @@ defmodule Abuuba.Roles do
   """
   @spec get(integer() | String.t()) :: Role.t() | nil
   def get(id) do
-    case numeric(id) do
+    case Snowflake.cast(id) do
       {:ok, id} -> Repo.get(Role, id)
       _ -> nil
     end
@@ -327,15 +328,4 @@ defmodule Abuuba.Roles do
     administrator?(user) or
       Bitwise.band(role.permissions, Bitwise.bnot(permissions_of(user))) == 0
   end
-
-  defp numeric(value) when is_integer(value), do: {:ok, value}
-
-  defp numeric(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, ""} -> {:ok, number}
-      _ -> nil
-    end
-  end
-
-  defp numeric(_value), do: nil
 end

--- a/lib/abuuba/statuses/formatter.ex
+++ b/lib/abuuba/statuses/formatter.ex
@@ -158,6 +158,22 @@ defmodule Abuuba.Statuses.Formatter do
   end
 
   @doc """
+  An account's bio, as markup that is safe to render.
+
+  Ours is plain text and is escaped on the way out; theirs is markup that was
+  cleaned on the way in. Both go through this, so neither is ever rendered as
+  the other — and it is one function rather than two copies, because it was
+  two, and only one of them carried the sentence above.
+
+  Matches on the shape rather than on `%Account{}` so that this module does not
+  have to know the schema: it is already what resolves mentions through
+  `Abuuba.Accounts`, and depending on the struct as well would close the loop.
+  """
+  @spec note_html(%{optional(:domain) => String.t() | nil, note: String.t() | nil}) :: String.t()
+  def note_html(%{domain: nil, note: note}), do: to_html(note)
+  def note_html(%{note: note}), do: sanitize(note)
+
+  @doc """
   What a post says, with the markup taken off.
 
   The other direction from `to_html/2`, and here beside it for that reason: a

--- a/lib/abuuba/statuses/formatter.ex
+++ b/lib/abuuba/statuses/formatter.ex
@@ -157,6 +157,33 @@ defmodule Abuuba.Statuses.Formatter do
     |> mark_links()
   end
 
+  @doc """
+  What a post says, with the markup taken off.
+
+  The other direction from `to_html/2`, and here beside it for that reason: a
+  summary line, a meta description, an RSS blurb and an admin listing all want
+  the words and none of them want the tags. It was written out separately in
+  eight places under four names, each with its own length baked in, which is
+  how a tag-stripping regex comes to be fixed in one of them.
+
+  `:limit` cuts the result to that many characters; without it the whole text
+  comes back.
+  """
+  @spec plain_text(String.t() | nil, keyword()) :: String.t()
+  def plain_text(html, opts \\ []) do
+    text =
+      html
+      |> to_string()
+      |> String.replace(~r/<[^>]*>/, " ")
+      |> String.replace(~r/\s+/u, " ")
+      |> String.trim()
+
+    case Keyword.get(opts, :limit) do
+      nil -> text
+      limit -> String.slice(text, 0, limit)
+    end
+  end
+
   # The sanitiser takes `rel` and `target` off along with everything else it
   # does not recognise, and puts nothing back. Upstream's adds both to every
   # anchor it keeps, and since local posts got them a link in the same timeline

--- a/lib/abuuba/web_push.ex
+++ b/lib/abuuba/web_push.ex
@@ -25,6 +25,7 @@ defmodule Abuuba.WebPush do
   alias Abuuba.OAuth.AccessToken
   alias Abuuba.Relationships
   alias Abuuba.Repo
+  alias Abuuba.Statuses.Formatter
   alias Abuuba.WebPush.Subscription
 
   @body_limit 140
@@ -216,17 +217,17 @@ defmodule Abuuba.WebPush do
 
   defp body(%Notification{status_id: status_id}) do
     case Repo.get(Abuuba.Statuses.Status, status_id) do
-      nil -> ""
-      status -> status.text |> to_string() |> String.slice(0, @body_limit)
+      nil ->
+        ""
+
+      status ->
+        # The words rather than the markup. A post that arrived from another
+        # server keeps its HTML in `text`, so slicing the column put "<p>" and
+        # a half-closed tag on somebody's lock screen.
+        Formatter.plain_text(status.text, limit: @body_limit)
     end
   end
 
   defp display_name(nil), do: "Somebody"
-
-  defp display_name(%Account{} = account) do
-    case account.display_name do
-      name when is_binary(name) and name != "" -> name
-      _ -> account.username
-    end
-  end
+  defp display_name(%Account{} = account), do: Account.display_name(account)
 end

--- a/lib/abuuba_web/components/status_component.ex
+++ b/lib/abuuba_web/components/status_component.ex
@@ -518,6 +518,18 @@ defmodule AbuubaWeb.StatusComponent do
 
   defp posted_at(value), do: value
 
+  @doc """
+  The `viewer_id` this component wants, from the reader or from nobody.
+
+  Here rather than in each screen because the attribute is this component's
+  idea: it compares against string ids inside already-rendered entities, so
+  every screen drawing a post had the same two-line conversion privately, five
+  times over, purely to satisfy it.
+  """
+  @spec viewer_id(map() | nil) :: String.t() | nil
+  def viewer_id(nil), do: nil
+  def viewer_id(viewer), do: to_string(viewer.id)
+
   defp display_name(account) do
     case account["display_name"] do
       name when is_binary(name) and name != "" -> name

--- a/lib/abuuba_web/controllers/feed_controller.ex
+++ b/lib/abuuba_web/controllers/feed_controller.ex
@@ -32,6 +32,7 @@ defmodule AbuubaWeb.FeedController do
   alias Abuuba.Federation.Serializer
   alias Abuuba.Settings
   alias Abuuba.Statuses
+  alias Abuuba.Statuses.Formatter
   alias Abuuba.Timelines
 
   @limit 20
@@ -46,7 +47,7 @@ defmodule AbuubaWeb.FeedController do
 
         conn
         |> render_feed(
-          title: display_name(subject) <> " (@" <> subject.username <> ")",
+          title: Account.display_name(subject) <> " (@" <> subject.username <> ")",
           description: summary(subject.note),
           link: url(~p"/@#{subject.username}"),
           self: url(~p"/@#{subject.username}/feed.rss"),
@@ -138,16 +139,7 @@ defmodule AbuubaWeb.FeedController do
   defp public?(%{visibility: :public}), do: true
   defp public?(_status), do: false
 
-  defp display_name(%Account{display_name: name}) when is_binary(name) and name != "", do: name
-  defp display_name(%Account{username: username}), do: username
-
-  defp summary(html) do
-    html
-    |> to_string()
-    |> String.replace(~r/<[^>]*>/, " ")
-    |> String.replace(~r/\s+/u, " ")
-    |> String.trim()
-  end
+  defp summary(html), do: Formatter.plain_text(html)
 
   # `]]>` inside a CDATA section closes it early, and what follows is then read
   # as markup. Nothing in a post may end this block.

--- a/lib/abuuba_web/controllers/oembed_controller.ex
+++ b/lib/abuuba_web/controllers/oembed_controller.ex
@@ -61,7 +61,7 @@ defmodule AbuubaWeb.OEmbedController do
       "version" => "1.0",
       "provider_name" => Abuuba.Instance.software_name(),
       "provider_url" => URIs.base_url(),
-      "author_name" => display_name(author),
+      "author_name" => Account.display_name(author),
       "author_url" => URIs.profile_url(author),
       "width" => width,
       "height" => height,
@@ -86,8 +86,4 @@ defmodule AbuubaWeb.OEmbedController do
       _ -> fallback
     end
   end
-
-  defp display_name(%Account{display_name: name}) when is_binary(name) and name != "", do: name
-  defp display_name(%Account{username: username}), do: username
-  defp display_name(_account), do: ""
 end

--- a/lib/abuuba_web/live/about_live.ex
+++ b/lib/abuuba_web/live/about_live.ex
@@ -15,6 +15,7 @@ defmodule AbuubaWeb.AboutLive do
   alias Abuuba.Instance
   alias Abuuba.Settings
   alias AbuubaWeb.Formats
+  alias AbuubaWeb.RegistrationWords
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
@@ -60,7 +61,7 @@ defmodule AbuubaWeb.AboutLive do
 
         <section>
           <h2 class="text-xl font-semibold">{gettext("Signing up")}</h2>
-          <p class="mt-2">{registration_note(@registration_mode)}</p>
+          <p class="mt-2">{RegistrationWords.note(@registration_mode)}</p>
         </section>
 
         <section :if={@rules != []}>
@@ -106,14 +107,4 @@ defmodule AbuubaWeb.AboutLive do
       {gettext("people active this half-year"), usage.active_halfyear}
     ]
   end
-
-  defp registration_note(:open), do: gettext("Registration is open: anybody may sign up.")
-
-  defp registration_note(:approved),
-    do: gettext("Registration needs approval: you sign up and an admin reads your request.")
-
-  defp registration_note(:closed),
-    do: gettext("Registration is closed here, but any other server on the network will do.")
-
-  defp registration_note(_mode), do: ""
 end

--- a/lib/abuuba_web/live/admin_live.ex
+++ b/lib/abuuba_web/live/admin_live.ex
@@ -192,10 +192,17 @@ defmodule AbuubaWeb.AdminLive do
   def handle_params(params, _uri, socket) do
     section = socket.assigns.live_action
 
-    if Roles.can?(socket.assigns.user, permission_for(section)) do
+    # Read once here and then drawn from for the rest of the render. The
+    # navigation asks about every section and the permission form twice about
+    # every permission, and each of those was another read of the same role
+    # row. Still a fresh read at the moment the answer below is a decision.
+    permissions = Roles.permissions_of(socket.assigns.user)
+
+    if Roles.allows?(permissions, permission_for(section)) do
       {:noreply,
        socket
        |> assign(
+         permissions: permissions,
          new_secret: nil,
          editing_role: nil,
          subject_statuses: [],
@@ -220,7 +227,7 @@ defmodule AbuubaWeb.AdminLive do
     <Layouts.app flash={@flash} current_scope={@current_scope} page_title={@page_title}>
       <nav class="border-b border-base-300 p-2" aria-label={gettext("Administration")}>
         <ul class="flex flex-wrap gap-1">
-          <li :for={{action, label} <- allowed_sections(@user)}>
+          <li :for={{action, label} <- allowed_sections(@permissions)}>
             <.link
               navigate={section_path(action)}
               aria-current={@section == action && "page"}
@@ -242,7 +249,7 @@ defmodule AbuubaWeb.AdminLive do
         <.dashboard
           :if={@section == :dashboard}
           counts={@counts}
-          may_appeals?={Roles.can?(@user, "manage_appeals")}
+          may_appeals?={Roles.allows?(@permissions, "manage_appeals")}
           checks={@checks}
           measures={@measures}
           dimensions={@dimensions}
@@ -290,7 +297,13 @@ defmodule AbuubaWeb.AdminLive do
         <.domain_lists :if={@section == :domain_lists} counts={@domain_counts} />
         <.suggestions :if={@section == :suggestions} suggestions={@suggestions} />
         <.subscriptions :if={@section == :subscriptions} subscriptions={@subscriptions} />
-        <.roles :if={@section == :roles} roles={@roles} user={@user} editing={@editing_role} />
+        <.roles
+          :if={@section == :roles}
+          roles={@roles}
+          user={@user}
+          permissions={@permissions}
+          editing={@editing_role}
+        />
         <.webhooks
           :if={@section == :webhooks}
           webhooks={@webhooks}
@@ -1666,6 +1679,7 @@ defmodule AbuubaWeb.AdminLive do
 
   attr :roles, :list, required: true
   attr :user, :map, required: true
+  attr :permissions, :integer, required: true
   attr :editing, :any, required: true
 
   defp roles(assigns) do
@@ -1721,13 +1735,13 @@ defmodule AbuubaWeb.AdminLive do
             name={"permissions[#{permission}]"}
             value="true"
             checked={held?(@editing, permission)}
-            disabled={not Roles.can?(@user, permission)}
+            disabled={not Roles.allows?(@permissions, permission)}
             class="checkbox checkbox-sm mt-1"
           />
           <span>
             <span class="font-medium">{permission_label(permission)}</span>
             <span class="block text-sm text-base-content/60">{permission_hint(permission)}</span>
-            <span :if={not Roles.can?(@user, permission)} class="block text-sm text-warning">
+            <span :if={not Roles.allows?(@permissions, permission)} class="block text-sm text-warning">
               {gettext("You do not hold this yourself, so you cannot grant it.")}
             </span>
           </span>
@@ -2345,7 +2359,7 @@ defmodule AbuubaWeb.AdminLive do
       Instance.set_custom_emoji_offered(emoji, not emoji.visible_in_picker)
     end
 
-    {:noreply, socket |> assign(saved?: true) |> load(:emoji, %{})}
+    {:noreply, socket |> assign(saved?: true, error: nil) |> load(:emoji, %{})}
   end
 
   def handle_event("toggle_emoji", %{"id" => id}, socket) do
@@ -2353,7 +2367,7 @@ defmodule AbuubaWeb.AdminLive do
       Instance.set_custom_emoji_disabled(emoji, not emoji.disabled)
     end
 
-    {:noreply, socket |> assign(saved?: true) |> load(:emoji, %{})}
+    {:noreply, socket |> assign(saved?: true, error: nil) |> load(:emoji, %{})}
   end
 
   def handle_event("delete_emoji", %{"id" => id}, socket) do
@@ -2361,7 +2375,7 @@ defmodule AbuubaWeb.AdminLive do
       Instance.delete_custom_emoji(emoji)
     end
 
-    {:noreply, socket |> assign(saved?: true) |> load(:emoji, %{})}
+    {:noreply, socket |> assign(saved?: true, error: nil) |> load(:emoji, %{})}
   end
 
   def handle_event("filter_reports", %{"state" => state}, socket) do
@@ -2401,7 +2415,7 @@ defmodule AbuubaWeb.AdminLive do
 
       {:noreply,
        socket
-       |> assign(saved?: true)
+       |> assign(saved?: true, error: nil)
        |> assign(report_notes: Admin.notes_with_authors(:report, report.id))}
     end
   end
@@ -2419,7 +2433,7 @@ defmodule AbuubaWeb.AdminLive do
 
   def handle_event("save_preset", %{"preset" => %{"title" => title, "text" => text}}, socket) do
     case WarningPresets.put(socket.assigns.account, title, text) do
-      :ok -> {:noreply, socket |> assign(saved?: true) |> load(:settings, %{})}
+      :ok -> {:noreply, socket |> assign(saved?: true, error: nil) |> load(:settings, %{})}
       {:error, :blank} -> {:noreply, assign(socket, error: gettext("A preset needs both."))}
     end
   end
@@ -2427,7 +2441,7 @@ defmodule AbuubaWeb.AdminLive do
   def handle_event("delete_preset", %{"title" => title}, socket) do
     WarningPresets.delete(socket.assigns.account, title)
 
-    {:noreply, socket |> assign(saved?: true) |> load(:settings, %{})}
+    {:noreply, socket |> assign(saved?: true, error: nil) |> load(:settings, %{})}
   end
 
   # Filled in rather than replaced silently: the moderator sees the text and
@@ -2444,7 +2458,7 @@ defmodule AbuubaWeb.AdminLive do
       Actions.undo(socket.assigns.account, strike)
     end
 
-    {:noreply, socket |> assign(saved?: true) |> reload_subject()}
+    {:noreply, socket |> assign(saved?: true, error: nil) |> reload_subject()}
   end
 
   def handle_event("save_role", %{"role" => id}, socket) do
@@ -2462,14 +2476,14 @@ defmodule AbuubaWeb.AdminLive do
       true ->
         Admin.assign_role(socket.assigns.account, socket.assigns.subject_user, role)
 
-        {:noreply, socket |> assign(saved?: true) |> reload_subject()}
+        {:noreply, socket |> assign(saved?: true, error: nil) |> reload_subject()}
     end
   end
 
   def handle_event("save_email", %{"email" => email}, socket) do
     case Admin.change_email(socket.assigns.account, socket.assigns.subject_user, email) do
       {:ok, _user} ->
-        {:noreply, socket |> assign(saved?: true) |> reload_subject()}
+        {:noreply, socket |> assign(saved?: true, error: nil) |> reload_subject()}
 
       {:error, _changeset} ->
         {:noreply, assign(socket, error: gettext("That is not an address."))}
@@ -2485,13 +2499,13 @@ defmodule AbuubaWeb.AdminLive do
   def handle_event("approve_trend", %{"kind" => kind, "subject" => subject}, socket) do
     :ok = Trends.approve(socket.assigns.account, kind, subject)
 
-    {:noreply, socket |> assign(saved?: true) |> load(:trends, %{})}
+    {:noreply, socket |> assign(saved?: true, error: nil) |> load(:trends, %{})}
   end
 
   def handle_event("reject_trend", %{"kind" => kind, "subject" => subject}, socket) do
     :ok = Trends.reject(socket.assigns.account, kind, subject)
 
-    {:noreply, socket |> assign(saved?: true) |> load(:trends, %{})}
+    {:noreply, socket |> assign(saved?: true, error: nil) |> load(:trends, %{})}
   end
 
   def handle_event("create_announcement", %{"text" => text} = params, socket) do
@@ -2509,7 +2523,7 @@ defmodule AbuubaWeb.AdminLive do
       {:ok, announcement} ->
         if announcement.published, do: Streaming.publish_announcement(announcement)
 
-        {:noreply, socket |> assign(saved?: true) |> load(:announcements, %{})}
+        {:noreply, socket |> assign(saved?: true, error: nil) |> load(:announcements, %{})}
 
       {:error, _changeset} ->
         {:noreply, assign(socket, error: gettext("An announcement needs some text."))}
@@ -2525,7 +2539,7 @@ defmodule AbuubaWeb.AdminLive do
         {:ok, _} = Instance.delete_announcement(announcement)
         Streaming.publish_announcement_delete(announcement)
 
-        {:noreply, socket |> assign(saved?: true) |> load(:announcements, %{})}
+        {:noreply, socket |> assign(saved?: true, error: nil) |> load(:announcements, %{})}
     end
   end
 
@@ -2534,7 +2548,7 @@ defmodule AbuubaWeb.AdminLive do
 
     case Instance.publish_terms(socket.assigns.account, attrs) do
       {:ok, _terms} ->
-        {:noreply, socket |> assign(saved?: true) |> load(:settings, %{})}
+        {:noreply, socket |> assign(saved?: true, error: nil) |> load(:settings, %{})}
 
       {:error, _changeset} ->
         {:noreply,
@@ -2582,7 +2596,7 @@ defmodule AbuubaWeb.AdminLive do
   def handle_event("unblock", %{"kind" => kind, "id" => id}, socket) do
     lift(socket.assigns.account, kind, socket.assigns.lists, id)
 
-    {:noreply, socket |> assign(saved?: true) |> load(:signups, %{})}
+    {:noreply, socket |> assign(saved?: true, error: nil) |> load(:signups, %{})}
   end
 
   def handle_event("add_webhook", params, socket) do
@@ -2827,7 +2841,7 @@ defmodule AbuubaWeb.AdminLive do
   def handle_event("add_rule", %{"text" => text}, socket) do
     case Settings.create_rule(%{text: text, position: length(socket.assigns.rules)}) do
       {:ok, _rule} ->
-        {:noreply, socket |> assign(saved?: true) |> load(:settings, %{})}
+        {:noreply, socket |> assign(saved?: true, error: nil) |> load(:settings, %{})}
 
       {:error, _changeset} ->
         {:noreply, assign(socket, error: gettext("A rule needs some text."))}
@@ -2844,7 +2858,7 @@ defmodule AbuubaWeb.AdminLive do
       rule ->
         {:ok, _retired} = Settings.delete_rule(rule)
 
-        {:noreply, socket |> assign(saved?: true) |> load(:settings, %{})}
+        {:noreply, socket |> assign(saved?: true, error: nil) |> load(:settings, %{})}
     end
   end
 
@@ -2859,7 +2873,7 @@ defmodule AbuubaWeb.AdminLive do
   defp take_action(socket, action, text) do
     case Actions.take(socket.assigns.account, socket.assigns.subject, action, text: text) do
       {:ok, _strike} ->
-        {:noreply, socket |> assign(saved?: true) |> reload_subject()}
+        {:noreply, socket |> assign(saved?: true, error: nil) |> reload_subject()}
 
       {:error, :no_statuses} ->
         {:noreply,
@@ -2884,7 +2898,8 @@ defmodule AbuubaWeb.AdminLive do
   end
 
   defp after_user_change(socket, _result) do
-    {:noreply, socket |> assign(saved?: true) |> load(:accounts, socket.assigns.filters)}
+    {:noreply,
+     socket |> assign(saved?: true, error: nil) |> load(:accounts, socket.assigns.filters)}
   end
 
   defp reload_subject(socket) do
@@ -3340,9 +3355,9 @@ defmodule AbuubaWeb.AdminLive do
     end
   end
 
-  defp allowed_sections(user) do
+  defp allowed_sections(permissions) do
     for {action, permission} <- @sections,
-        Roles.can?(user, permission),
+        Roles.allows?(permissions, permission),
         do: {action, section_label(action)}
   end
 
@@ -3728,7 +3743,7 @@ defmodule AbuubaWeb.AdminLive do
   defp check_advice(_key), do: ""
 
   defp blocked(socket, {:ok, _block}) do
-    {:noreply, socket |> assign(saved?: true) |> load(:signups, %{})}
+    {:noreply, socket |> assign(saved?: true, error: nil) |> load(:signups, %{})}
   end
 
   defp blocked(socket, {:error, _changeset}) do
@@ -3774,7 +3789,7 @@ defmodule AbuubaWeb.AdminLive do
   end
 
   defp announce(socket, {:ok, _terms}) do
-    {:noreply, socket |> assign(saved?: true) |> load(:settings, %{})}
+    {:noreply, socket |> assign(saved?: true, error: nil) |> load(:settings, %{})}
   end
 
   defp announce(socket, {:error, :already_announced}) do

--- a/lib/abuuba_web/live/admin_live.ex
+++ b/lib/abuuba_web/live/admin_live.ex
@@ -276,7 +276,7 @@ defmodule AbuubaWeb.AdminLive do
           filters={@filters}
           pending={@pending}
           batch={@batch}
-          batch_count={@batch_count}
+          batch_count={MapSet.size(@batch)}
         />
         <.account
           :if={@section == :account}
@@ -2424,7 +2424,7 @@ defmodule AbuubaWeb.AdminLive do
   def handle_event("pick_batch", params, socket) do
     batch = ticked(params)
 
-    {:noreply, assign(socket, batch: batch, batch_count: MapSet.size(batch))}
+    {:noreply, assign(socket, batch: batch)}
   end
 
   def handle_event("batch", params, socket) do
@@ -2944,8 +2944,7 @@ defmodule AbuubaWeb.AdminLive do
       filters: filters,
       accounts: accounts,
       pending: Admin.pending_user_ids(accounts),
-      batch: batch,
-      batch_count: MapSet.size(batch)
+      batch: batch
     )
   end
 
@@ -3257,7 +3256,7 @@ defmodule AbuubaWeb.AdminLive do
       |> Enum.frequencies()
 
     socket
-    |> assign(saved?: true, batch: MapSet.new(), batch_count: 0)
+    |> assign(saved?: true, batch: MapSet.new())
     |> assign(error: batch_message(outcomes))
     |> load(:accounts, socket.assigns.filters)
   end
@@ -3519,10 +3518,7 @@ defmodule AbuubaWeb.AdminLive do
             "label" => saved.name
           })
 
-          {:noreply,
-           socket
-           |> assign(saved?: true, error: nil, editing_role: nil)
-           |> load(:roles, %{})}
+          {:noreply, socket |> assign(saved?: true, error: nil) |> load(:roles, %{})}
 
         {:error, _changeset} ->
           {:noreply, assign(socket, error: gettext("That role could not be saved."))}

--- a/lib/abuuba_web/live/admin_live.ex
+++ b/lib/abuuba_web/live/admin_live.ex
@@ -42,6 +42,7 @@ defmodule AbuubaWeb.AdminLive do
   alias Abuuba.Roles.Role
   alias Abuuba.Settings
   alias Abuuba.Statuses
+  alias Abuuba.Statuses.Formatter
   alias Abuuba.Streaming
   alias Abuuba.Trends
   alias Abuuba.Webhooks
@@ -189,7 +190,7 @@ defmodule AbuubaWeb.AdminLive do
 
   @impl Phoenix.LiveView
   def handle_params(params, _uri, socket) do
-    section = section_of(socket.assigns.live_action)
+    section = socket.assigns.live_action
 
     if Roles.can?(socket.assigns.user, permission_for(section)) do
       {:noreply,
@@ -235,6 +236,7 @@ defmodule AbuubaWeb.AdminLive do
         <h2 class="text-xl font-semibold">{section_label(@section)}</h2>
 
         <p :if={@saved?} class="mt-2 text-sm text-success" role="status">{gettext("Saved.")}</p>
+        <p :if={@imported} class="mt-2 text-sm text-success" role="status">{@imported}</p>
         <p :if={@error} class="mt-2 text-sm text-error" role="alert">{@error}</p>
 
         <.dashboard
@@ -3012,12 +3014,7 @@ defmodule AbuubaWeb.AdminLive do
   end
 
   defp load(socket, :domain_lists, _params) do
-    assign(socket,
-      domain_counts: %{
-        blocks: length(Domains.blocks(%{limit: 10_000})),
-        allows: length(Domains.allows())
-      }
-    )
+    assign(socket, domain_counts: Domains.counts())
   end
 
   defp load(socket, :suggestions, _params) do
@@ -3332,9 +3329,6 @@ defmodule AbuubaWeb.AdminLive do
   defp outranks_message,
     do: gettext("That account outranks yours, so there is nothing here you can do to it.")
 
-  defp section_of(:account), do: :account
-  defp section_of(action), do: action
-
   # The account page belongs to the accounts section, and needs its permission.
   defp permission_for(:account), do: "manage_users"
   defp permission_for(:report), do: "manage_reports"
@@ -3434,14 +3428,7 @@ defmodule AbuubaWeb.AdminLive do
   # to anybody there, so it is recorded with the domain rather than only taken.
   defp subject_id(socket), do: to_string(socket.assigns.subject.id)
 
-  defp plain_text(html) do
-    html
-    |> to_string()
-    |> String.replace(~r/<[^>]*>/, " ")
-    |> String.replace(~r/\s+/u, " ")
-    |> String.trim()
-    |> String.slice(0, 200)
-  end
+  defp plain_text(html), do: Formatter.plain_text(html, limit: 200)
 
   defp with_instance(socket, domain, action, act) do
     act.(domain)

--- a/lib/abuuba_web/live/annual_report_live.ex
+++ b/lib/abuuba_web/live/annual_report_live.ex
@@ -116,11 +116,14 @@ defmodule AbuubaWeb.AnnualReportLive do
         year: report.year
       )
 
-    assign(socket, :page_meta, [
-      {"property", "og:type", "article"},
-      {"property", "og:title", page_title(account, report)},
-      {"property", "og:description", summary},
-      {"name", "description", summary}
-    ])
+    assign(
+      socket,
+      :page_meta,
+      Meta.open_graph(
+        title: page_title(account, report),
+        description: summary,
+        url: url(~p"/@#{account.username}/year/#{report.year}")
+      )
+    )
   end
 end

--- a/lib/abuuba_web/live/annual_report_live.ex
+++ b/lib/abuuba_web/live/annual_report_live.ex
@@ -43,7 +43,7 @@ defmodule AbuubaWeb.AnnualReportLive do
       <header class="border-b border-base-300 p-4">
         <p class="text-xs uppercase text-base-content/60">{@report.year}</p>
         <h1 class="text-2xl font-semibold">
-          {gettext("%{name}'s year", name: display_name(@account))}
+          {gettext("%{name}'s year", name: Account.display_name(@account))}
         </h1>
         <p class="text-base-content/60">
           <.link navigate={~p"/@#{@account.username}"} class="link link-hover">
@@ -85,10 +85,7 @@ defmodule AbuubaWeb.AnnualReportLive do
     """
   end
 
-  defp display_name(%Account{display_name: name}) when name not in [nil, ""], do: name
-  defp display_name(%Account{username: username}), do: username
-
-  defp page_title(account, report), do: "#{display_name(account)} · #{report.year}"
+  defp page_title(account, report), do: "#{Account.display_name(account)} · #{report.year}"
 
   defp posts_total(report) do
     report.data |> Map.get("time_series", []) |> Enum.map(&(&1["statuses"] || 0)) |> Enum.sum()

--- a/lib/abuuba_web/live/collection_live.ex
+++ b/lib/abuuba_web/live/collection_live.ex
@@ -28,7 +28,6 @@ defmodule AbuubaWeb.CollectionLive do
         raise AbuubaWeb.NotFound, "no such collection"
 
       collection ->
-        viewer = current_account(socket)
         owner = Accounts.get_account(collection.account_id)
 
         {:ok,
@@ -36,7 +35,7 @@ defmodule AbuubaWeb.CollectionLive do
          |> assign(
            collection: collection,
            owner: owner,
-           accounts: listed_accounts(collection, viewer),
+           accounts: listed_accounts(collection),
            page_title: collection.name,
            robots: Meta.noindex()
          )
@@ -72,13 +71,13 @@ defmodule AbuubaWeb.CollectionLive do
       </header>
 
       <ul class="divide-y divide-base-300">
-        <li :for={account <- @accounts} class="p-4">
-          <.link navigate={~p"/@#{account.username}"} class="font-medium link link-hover">
-            {Account.display_name(account)}
+        <li :for={listed <- @accounts} class="p-4">
+          <.link navigate={~p"/@#{listed.account.username}"} class="font-medium link link-hover">
+            {Account.display_name(listed.account)}
           </.link>
-          <p class="text-sm text-base-content/60">@{Account.acct(account)}</p>
-          <p :if={account.note not in [nil, ""]} class="mt-1 break-words text-sm">
-            {raw(note_html(account))}
+          <p class="text-sm text-base-content/60">@{Account.acct(listed.account)}</p>
+          <p :if={listed.account.note not in [nil, ""]} class="mt-1 break-words text-sm">
+            {raw(listed.note_html)}
           </p>
         </li>
       </ul>
@@ -93,14 +92,20 @@ defmodule AbuubaWeb.CollectionLive do
   # Suspended accounts are left out rather than shown as a name and nothing
   # else: a list recommending somebody this server has taken down is the one
   # thing it must stop doing on its owner's behalf.
-  defp listed_accounts(collection, _viewer) do
+  defp listed_accounts(collection) do
     items = Collections.items(collection)
     accounts = items |> Enum.map(& &1.account_id) |> Accounts.get_accounts()
 
     # In the order the owner put them, which is the order the list means.
+    #
+    # The bio is rendered here rather than in the template. It is a sanitiser
+    # pass for a remote account and a lookup per `@mention` for a local one,
+    # and in the template that was paid once per row on every render for text
+    # that cannot change while the page is open.
     items
     |> Enum.map(&Map.get(accounts, &1.account_id))
     |> Enum.reject(&(&1 == nil or &1.suspended_at != nil))
+    |> Enum.map(&%{account: &1, note_html: note_html(&1)})
   end
 
   defp note_html(%Account{domain: nil, note: note}), do: Formatter.to_html(note)
@@ -112,12 +117,14 @@ defmodule AbuubaWeb.CollectionLive do
         do: gettext("A collection by %{name}", name: Account.acct(owner)),
         else: collection.description
 
-    assign(socket, :page_meta, [
-      {"property", "og:type", "article"},
-      {"property", "og:title", collection.name},
-      {"property", "og:description", summary},
-      {"property", "og:url", Entities.collection(collection)["url"]},
-      {"name", "description", summary}
-    ])
+    assign(
+      socket,
+      :page_meta,
+      Meta.open_graph(
+        title: collection.name,
+        description: summary,
+        url: Entities.collection(collection)["url"]
+      )
+    )
   end
 end

--- a/lib/abuuba_web/live/collection_live.ex
+++ b/lib/abuuba_web/live/collection_live.ex
@@ -105,11 +105,8 @@ defmodule AbuubaWeb.CollectionLive do
     items
     |> Enum.map(&Map.get(accounts, &1.account_id))
     |> Enum.reject(&(&1 == nil or &1.suspended_at != nil))
-    |> Enum.map(&%{account: &1, note_html: note_html(&1)})
+    |> Enum.map(&%{account: &1, note_html: Formatter.note_html(&1)})
   end
-
-  defp note_html(%Account{domain: nil, note: note}), do: Formatter.to_html(note)
-  defp note_html(%Account{note: note}), do: Formatter.sanitize(note)
 
   defp put_meta(socket, collection, owner) do
     summary =

--- a/lib/abuuba_web/live/collection_live.ex
+++ b/lib/abuuba_web/live/collection_live.ex
@@ -74,7 +74,7 @@ defmodule AbuubaWeb.CollectionLive do
       <ul class="divide-y divide-base-300">
         <li :for={account <- @accounts} class="p-4">
           <.link navigate={~p"/@#{account.username}"} class="font-medium link link-hover">
-            {display_name(account)}
+            {Account.display_name(account)}
           </.link>
           <p class="text-sm text-base-content/60">@{Account.acct(account)}</p>
           <p :if={account.note not in [nil, ""]} class="mt-1 break-words text-sm">
@@ -102,9 +102,6 @@ defmodule AbuubaWeb.CollectionLive do
     |> Enum.map(&Map.get(accounts, &1.account_id))
     |> Enum.reject(&(&1 == nil or &1.suspended_at != nil))
   end
-
-  defp display_name(%Account{display_name: name}) when name not in [nil, ""], do: name
-  defp display_name(%Account{username: username}), do: username
 
   defp note_html(%Account{domain: nil, note: note}), do: Formatter.to_html(note)
   defp note_html(%Account{note: note}), do: Formatter.sanitize(note)

--- a/lib/abuuba_web/live/compose_component.ex
+++ b/lib/abuuba_web/live/compose_component.ex
@@ -61,6 +61,7 @@ defmodule AbuubaWeb.ComposeComponent do
   alias Abuuba.Statuses.ScheduledStatus
   alias Abuuba.Statuses.Status
   alias AbuubaWeb.Formats
+  alias AbuubaWeb.Params
 
   # Endonyms, so somebody looking for their own language reads it in their own
   # language. Not a full ISO-639 list: a picker of nine thousand entries is one
@@ -312,7 +313,7 @@ defmodule AbuubaWeb.ComposeComponent do
   # one, and an id in an event payload is written by whoever is at the other
   # end of the socket.
   defp own_attachment(socket, id) do
-    with {:ok, id} <- numeric(id) do
+    with {:ok, id} <- Params.id(id) do
       if id in socket.assigns.attachment_ids do
         Media.get_own_unattached(socket.assigns.account, id)
       end
@@ -320,7 +321,7 @@ defmodule AbuubaWeb.ComposeComponent do
   end
 
   defp without(socket, id) do
-    case numeric(id) do
+    case Params.id(id) do
       {:ok, id} -> socket.assigns.attachment_ids -- [id]
       _ -> socket.assigns.attachment_ids
     end
@@ -332,7 +333,7 @@ defmodule AbuubaWeb.ComposeComponent do
   defp move_earlier(socket, id) do
     ids = socket.assigns.attachment_ids
 
-    with {:ok, id} <- numeric(id),
+    with {:ok, id} <- Params.id(id),
          index when is_integer(index) and index > 0 <- Enum.find_index(ids, &(&1 == id)) do
       ids |> List.delete_at(index) |> List.insert_at(index - 1, id)
     else
@@ -357,23 +358,12 @@ defmodule AbuubaWeb.ComposeComponent do
   # socket, not by the button this server drew. A `Repo.get` on "../etc/passwd"
   # raises rather than returning nothing.
   defp find_draft(socket, id) do
-    with {:ok, id} <- numeric(id), do: Statuses.get_draft(socket.assigns.account, id)
+    with {:ok, id} <- Params.id(id), do: Statuses.get_draft(socket.assigns.account, id)
   end
 
   defp find_scheduled(socket, id) do
-    with {:ok, id} <- numeric(id), do: Statuses.get_scheduled(socket.assigns.account, id)
+    with {:ok, id} <- Params.id(id), do: Statuses.get_scheduled(socket.assigns.account, id)
   end
-
-  defp numeric(value) when is_integer(value), do: {:ok, value}
-
-  defp numeric(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, ""} when number >= 0 and number < 9_223_372_036_854_775_807 -> {:ok, number}
-      _ -> nil
-    end
-  end
-
-  defp numeric(_value), do: nil
 
   defp current_draft(%{assigns: %{draft_id: nil}}), do: nil
 
@@ -1053,7 +1043,7 @@ defmodule AbuubaWeb.ComposeComponent do
     options = socket.assigns.draft["poll_options"]
 
     if length(options) > 2 do
-      {:noreply, put(socket, "poll_options", List.delete_at(options, to_integer(index)))}
+      {:noreply, put(socket, "poll_options", List.delete_at(options, Params.to_integer(index)))}
     else
       {:noreply, socket}
     end
@@ -1247,7 +1237,8 @@ defmodule AbuubaWeb.ComposeComponent do
       options: options,
       tallies: List.duplicate(0, length(options)),
       multiple: draft["poll_multiple"] == true,
-      expires_at: DateTime.add(DateTime.utc_now(), to_integer(draft["poll_expires_in"]), :second)
+      expires_at:
+        DateTime.add(DateTime.utc_now(), Params.to_integer(draft["poll_expires_in"]), :second)
     }
 
     case Statuses.create_poll(status, attrs) do
@@ -1306,7 +1297,7 @@ defmodule AbuubaWeb.ComposeComponent do
     Map.put(params, "poll", %{
       "options" => usable_options(draft),
       "multiple" => draft["poll_multiple"] == true,
-      "expires_in" => to_integer(draft["poll_expires_in"])
+      "expires_in" => Params.to_integer(draft["poll_expires_in"])
     })
   end
 
@@ -1609,7 +1600,7 @@ defmodule AbuubaWeb.ComposeComponent do
   defp caret(draft) do
     length = String.length(draft["text"])
 
-    case to_integer(draft["caret"]) do
+    case Params.to_integer(draft["caret"]) do
       caret when caret >= 0 and caret <= length -> caret
       _ -> length
     end
@@ -1692,15 +1683,4 @@ defmodule AbuubaWeb.ComposeComponent do
       nil -> gettext("Public")
     end
   end
-
-  defp to_integer(value) when is_integer(value), do: value
-
-  defp to_integer(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, _rest} -> number
-      :error -> 0
-    end
-  end
-
-  defp to_integer(_value), do: 0
 end

--- a/lib/abuuba_web/live/compose_component.ex
+++ b/lib/abuuba_web/live/compose_component.ex
@@ -1564,7 +1564,7 @@ defmodule AbuubaWeb.ComposeComponent do
     |> Enum.map(fn account ->
       %{
         value: "@" <> Account.acct(account),
-        label: display_name(account),
+        label: Account.display_name(account),
         hint: "@" <> Account.acct(account),
         image: nil
       }
@@ -1650,12 +1650,9 @@ defmodule AbuubaWeb.ComposeComponent do
   defp reply_name(%Status{account_id: account_id}) do
     case Accounts.get_account(account_id) do
       nil -> gettext("somebody")
-      account -> display_name(account)
+      account -> Account.display_name(account)
     end
   end
-
-  defp display_name(%Account{display_name: name}) when is_binary(name) and name != "", do: name
-  defp display_name(%Account{username: username}), do: username
 
   # What the person chose in their settings, rather than what this module would
   # have guessed. A default audience is the setting people most regret not

--- a/lib/abuuba_web/live/compose_component.ex
+++ b/lib/abuuba_web/live/compose_component.ex
@@ -55,6 +55,7 @@ defmodule AbuubaWeb.ComposeComponent do
   alias Abuuba.Media.Blurhash
   alias Abuuba.Media.Upload
   alias Abuuba.Search
+  alias Abuuba.Snowflake
   alias Abuuba.Statuses
   alias Abuuba.Statuses.Formatter
   alias Abuuba.Statuses.Poll
@@ -313,7 +314,7 @@ defmodule AbuubaWeb.ComposeComponent do
   # one, and an id in an event payload is written by whoever is at the other
   # end of the socket.
   defp own_attachment(socket, id) do
-    with {:ok, id} <- Params.id(id) do
+    with {:ok, id} <- Snowflake.cast(id) do
       if id in socket.assigns.attachment_ids do
         Media.get_own_unattached(socket.assigns.account, id)
       end
@@ -321,7 +322,7 @@ defmodule AbuubaWeb.ComposeComponent do
   end
 
   defp without(socket, id) do
-    case Params.id(id) do
+    case Snowflake.cast(id) do
       {:ok, id} -> socket.assigns.attachment_ids -- [id]
       _ -> socket.assigns.attachment_ids
     end
@@ -333,7 +334,7 @@ defmodule AbuubaWeb.ComposeComponent do
   defp move_earlier(socket, id) do
     ids = socket.assigns.attachment_ids
 
-    with {:ok, id} <- Params.id(id),
+    with {:ok, id} <- Snowflake.cast(id),
          index when is_integer(index) and index > 0 <- Enum.find_index(ids, &(&1 == id)) do
       ids |> List.delete_at(index) |> List.insert_at(index - 1, id)
     else
@@ -358,11 +359,11 @@ defmodule AbuubaWeb.ComposeComponent do
   # socket, not by the button this server drew. A `Repo.get` on "../etc/passwd"
   # raises rather than returning nothing.
   defp find_draft(socket, id) do
-    with {:ok, id} <- Params.id(id), do: Statuses.get_draft(socket.assigns.account, id)
+    with {:ok, id} <- Snowflake.cast(id), do: Statuses.get_draft(socket.assigns.account, id)
   end
 
   defp find_scheduled(socket, id) do
-    with {:ok, id} <- Params.id(id), do: Statuses.get_scheduled(socket.assigns.account, id)
+    with {:ok, id} <- Snowflake.cast(id), do: Statuses.get_scheduled(socket.assigns.account, id)
   end
 
   defp current_draft(%{assigns: %{draft_id: nil}}), do: nil

--- a/lib/abuuba_web/live/compose_component.ex
+++ b/lib/abuuba_web/live/compose_component.ex
@@ -57,6 +57,7 @@ defmodule AbuubaWeb.ComposeComponent do
   alias Abuuba.Search
   alias Abuuba.Statuses
   alias Abuuba.Statuses.Formatter
+  alias Abuuba.Statuses.Poll
   alias Abuuba.Statuses.ScheduledStatus
   alias Abuuba.Statuses.Status
   alias AbuubaWeb.Formats
@@ -82,20 +83,6 @@ defmodule AbuubaWeb.ComposeComponent do
     {"한국어", "ko"},
     {"العربية", "ar"}
   ]
-
-  # Mastodon's ladder, which is what other servers and clients expect to see.
-  @poll_durations [
-    {300, "5 minutes"},
-    {1800, "30 minutes"},
-    {3600, "1 hour"},
-    {21_600, "6 hours"},
-    {86_400, "1 day"},
-    {259_200, "3 days"},
-    {604_800, "7 days"}
-  ]
-
-  @max_poll_options 4
-  @max_option_characters 50
 
   # Long enough that a sentence is one write rather than twenty, short enough
   # that a closed tab loses a few words rather than a paragraph.
@@ -623,7 +610,7 @@ defmodule AbuubaWeb.ComposeComponent do
               type="text"
               name="draft[poll_options][]"
               value={option}
-              maxlength={@max_option_characters}
+              maxlength={Poll.max_option_characters()}
               placeholder={gettext("Choice %{number}", number: index + 1)}
               class="input input-sm w-full"
             />
@@ -642,7 +629,7 @@ defmodule AbuubaWeb.ComposeComponent do
 
           <div class="flex flex-wrap items-center gap-3">
             <button
-              :if={length(@draft["poll_options"]) < @max_poll_options}
+              :if={length(@draft["poll_options"]) < Poll.max_options()}
               type="button"
               phx-click="poll_option_add"
               phx-target={@myself}
@@ -948,8 +935,6 @@ defmodule AbuubaWeb.ComposeComponent do
     end
   end
 
-  def handle_event("upload_validate", _params, socket), do: {:noreply, socket}
-
   def handle_event("upload_cancel", %{"ref" => ref}, socket) do
     {:noreply, cancel_upload(socket, :media, ref)}
   end
@@ -1057,7 +1042,7 @@ defmodule AbuubaWeb.ComposeComponent do
   def handle_event("poll_option_add", _params, socket) do
     options = socket.assigns.draft["poll_options"]
 
-    if length(options) < @max_poll_options do
+    if length(options) < Poll.max_options() do
       {:noreply, put(socket, "poll_options", options ++ [""])}
     else
       {:noreply, socket}
@@ -1158,7 +1143,7 @@ defmodule AbuubaWeb.ComposeComponent do
       Enum.any?(options, &too_long?/1) ->
         {:error,
          gettext("A poll choice is too long. Keep each under %{count} characters.",
-           count: @max_option_characters
+           count: Poll.max_option_characters()
          )}
 
       length(Enum.uniq(options)) != length(options) ->
@@ -1470,9 +1455,7 @@ defmodule AbuubaWeb.ComposeComponent do
       remaining: Instance.max_characters() - length_of(draft),
       mentions: reply_chips(socket.assigns),
       token: token,
-      suggestions: suggestions,
-      max_poll_options: @max_poll_options,
-      max_option_characters: @max_option_characters
+      suggestions: suggestions
     )
   end
 
@@ -1491,7 +1474,7 @@ defmodule AbuubaWeb.ComposeComponent do
   defp warning(%{"warn" => true} = draft), do: String.trim(draft["spoiler_text"])
   defp warning(_draft), do: ""
 
-  defp too_long?(option), do: String.length(option) > @max_option_characters
+  defp too_long?(option), do: String.length(option) > Poll.max_option_characters()
 
   defp usable_options(draft) do
     draft["poll_options"] |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == ""))
@@ -1670,16 +1653,20 @@ defmodule AbuubaWeb.ComposeComponent do
 
   defp languages, do: @languages
 
+  # Mastodon's ladder, which is what other servers and clients expect to see.
+  # Written once, translated where it is written: the list used to be an
+  # attribute of English labels that this threw away and replaced clause by
+  # clause, so an eighth rung added above raised inside `render/1`.
   defp poll_durations do
-    Enum.map(@poll_durations, fn
-      {300, _} -> {300, gettext("5 minutes")}
-      {1800, _} -> {1800, gettext("30 minutes")}
-      {3600, _} -> {3600, gettext("1 hour")}
-      {21_600, _} -> {21_600, gettext("6 hours")}
-      {86_400, _} -> {86_400, gettext("1 day")}
-      {259_200, _} -> {259_200, gettext("3 days")}
-      {604_800, _} -> {604_800, gettext("7 days")}
-    end)
+    [
+      {300, gettext("5 minutes")},
+      {1800, gettext("30 minutes")},
+      {3600, gettext("1 hour")},
+      {21_600, gettext("6 hours")},
+      {86_400, gettext("1 day")},
+      {259_200, gettext("3 days")},
+      {604_800, gettext("7 days")}
+    ]
   end
 
   defp visibilities do

--- a/lib/abuuba_web/live/conversations_live.ex
+++ b/lib/abuuba_web/live/conversations_live.ex
@@ -31,6 +31,7 @@ defmodule AbuubaWeb.ConversationsLive do
   alias Abuuba.Accounts.Account
   alias Abuuba.Conversations
   alias Abuuba.Statuses
+  alias Abuuba.Statuses.Formatter
   alias Abuuba.Streaming
   alias AbuubaWeb.API.Entities
 
@@ -175,18 +176,24 @@ defmodule AbuubaWeb.ConversationsLive do
       |> Enum.map(& &1.last_status_id)
       |> Enum.reject(&is_nil/1)
       |> Statuses.get_visible_statuses(account)
-      |> Map.new(&{&1.id, &1})
 
-    assign(socket, rows: Enum.map(rows, &decorate(&1, account, people, last)))
+    # Rendered in one batch like the names and the messages above. Rendering
+    # each row's post on its own asked the fourteen-odd questions behind an
+    # entity once per row, for a page that keeps one line of the answer.
+    excerpts =
+      last
+      |> Entities.statuses(account)
+      |> Map.new(&{&1["id"], &1["content"]})
+
+    assign(socket, rows: Enum.map(rows, &decorate(&1, account, people, excerpts)))
   end
 
-  defp decorate(row, account, people, last) do
+  defp decorate(row, account, people, excerpts) do
     %{
       id: row.id,
       unread: row.unread,
-      last_status_id: row.last_status_id,
       people: people(row, account, people),
-      excerpt: excerpt(row, account, last)
+      excerpt: excerpt(row, excerpts)
     }
   end
 
@@ -210,16 +217,10 @@ defmodule AbuubaWeb.ConversationsLive do
   # it.
   @excerpt_length 140
 
-  defp excerpt(row, account, last) do
+  defp excerpt(row, excerpts) do
     with id when not is_nil(id) <- row.last_status_id,
-         %{} = status <- Map.get(last, id) do
-      status
-      |> Entities.status(account)
-      |> Map.get("content", "")
-      |> String.replace(~r/<[^>]*>/, " ")
-      |> String.replace(~r/\s+/u, " ")
-      |> String.trim()
-      |> String.slice(0, @excerpt_length)
+         content when is_binary(content) <- Map.get(excerpts, to_string(id)) do
+      Formatter.plain_text(content, limit: @excerpt_length)
     else
       _ -> gettext("The last message has been deleted.")
     end

--- a/lib/abuuba_web/live/explore_live.ex
+++ b/lib/abuuba_web/live/explore_live.ex
@@ -33,6 +33,7 @@ defmodule AbuubaWeb.ExploreLive do
   alias Abuuba.Relationships
   alias Abuuba.Settings
   alias Abuuba.Statuses
+  alias Abuuba.Statuses.Formatter
   alias Abuuba.Trends
   alias AbuubaWeb.API.Entities
   alias AbuubaWeb.Meta
@@ -95,10 +96,10 @@ defmodule AbuubaWeb.ExploreLive do
       <ul :if={@tab == :people} class="divide-y divide-base-300">
         <li :for={person <- @people} class="flex items-center gap-3 p-4">
           <div class="min-w-0 flex-1">
-            <a href={"/@" <> person.username} class="font-semibold">{display_name(person)}</a>
+            <a href={"/@" <> person.username} class="font-semibold">{Account.display_name(person)}</a>
             <p class="text-sm text-base-content/60">@{Account.acct(person)}</p>
             <p :if={person.note not in [nil, ""]} class="mt-1 text-sm break-words">
-              {summary(person.note)}
+              {Formatter.plain_text(person.note, limit: 160)}
             </p>
           </div>
 
@@ -258,21 +259,6 @@ defmodule AbuubaWeb.ExploreLive do
   # The same address a hashtag inside a post links to, so the two cannot point
   # at different places.
   defp tag_path(tag), do: "/tags/#{tag.name}"
-
-  defp summary(note) do
-    note
-    |> to_string()
-    |> String.replace(~r/<[^>]*>/, " ")
-    |> String.replace(~r/\s+/u, " ")
-    |> String.trim()
-    |> String.slice(0, 160)
-  end
-
-  defp display_name(%Account{display_name: name}) when is_binary(name) and name != "", do: name
-  defp display_name(%Account{username: username}), do: username
-
-  defp viewer_id(nil), do: nil
-  defp viewer_id(viewer), do: to_string(viewer.id)
 
   defp numeric(value) when is_binary(value) do
     case Integer.parse(value) do

--- a/lib/abuuba_web/live/explore_live.ex
+++ b/lib/abuuba_web/live/explore_live.ex
@@ -38,19 +38,18 @@ defmodule AbuubaWeb.ExploreLive do
   alias AbuubaWeb.Meta
   alias AbuubaWeb.PostActions
 
-  # Answered here because the action bar is drawn here.
-  @post_actions PostActions.toggles()
-
   @page_size 20
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     {:ok,
-     assign(socket,
+     socket
+     |> assign(
        page_title: gettext("Explore"),
        viewer: current_account(socket),
        robots: Meta.noindex()
-     )}
+     )
+     |> PostActions.attach(lists: [:posts])}
   end
 
   @impl Phoenix.LiveView
@@ -152,61 +151,6 @@ defmodule AbuubaWeb.ExploreLive do
       end
 
     {:noreply, load(socket)}
-  end
-
-  # The action bar is drawn on this screen, so the events it raises are
-  # answered here. See `AbuubaWeb.PostActions` for why the work behind them is
-  # one module rather than a copy per screen.
-  def handle_event(event, %{"id" => id}, socket) when event in @post_actions do
-    case PostActions.toggle(socket.assigns.viewer, event, id) do
-      {:ok, status} -> {:noreply, replace_post(socket, status)}
-      :error -> {:noreply, socket}
-    end
-  end
-
-  # The poll form is drawn by the same component as the action bar, so it is
-  # answered in the same place. See `AbuubaWeb.PostActions`.
-  def handle_event("vote", %{"poll_id" => poll_id} = params, socket) do
-    choices = params |> Map.get("choices", []) |> List.wrap()
-
-    case PostActions.vote(socket.assigns.viewer, poll_id, choices) do
-      {:ok, status} -> {:noreply, replace_post(socket, status)}
-      :error -> {:noreply, socket}
-    end
-  end
-
-  # There is no composer on this screen, so replying goes to the post, which
-  # has one. A box that appears on some screens and not others is worse than
-  # the same answer everywhere.
-  def handle_event("reply", %{"id" => id}, socket) do
-    case PostActions.page_of(socket.assigns.viewer, id) do
-      nil -> {:noreply, socket}
-      path -> {:noreply, push_navigate(socket, to: path)}
-    end
-  end
-
-  # The pencil is drawn by the same component as the rest of the bar, and the
-  # box to edit in is on the post's own page. Same answer as "reply" for the
-  # same reason: a composer that appears on some screens and not others is
-  # worse than the same answer everywhere.
-  def handle_event("edit", %{"id" => id}, socket) do
-    case PostActions.page_of(socket.assigns.viewer, id) do
-      nil -> {:noreply, socket}
-      path -> {:noreply, push_navigate(socket, to: path)}
-    end
-  end
-
-  # Drawn by the same component as the rest of the bar. A translation is not a
-  # change to the post, so it is put straight back into the list rather than
-  # re-read. See `AbuubaWeb.PostActions`.
-  def handle_event("translate", %{"id" => id}, socket) do
-    case PostActions.translate(socket.assigns.viewer, id, locale(socket)) do
-      {:ok, rendered} ->
-        {:noreply, update(socket, :posts, &PostActions.swap(&1, rendered))}
-
-      :error ->
-        {:noreply, put_flash(socket, :error, gettext("That could not be translated just now."))}
-    end
   end
 
   def handle_event(_event, _params, socket), do: {:noreply, socket}
@@ -339,13 +283,4 @@ defmodule AbuubaWeb.ExploreLive do
 
   defp numeric(value) when is_integer(value), do: {:ok, value}
   defp numeric(_value), do: nil
-
-  # Rendered the way this screen renders the rest of them, then swapped in.
-  defp replace_post(socket, status) do
-    rendered = Entities.status(status, socket.assigns.viewer)
-
-    update(socket, :posts, &PostActions.swap(&1, rendered))
-  end
-
-  defp locale(socket), do: socket.assigns[:locale] || Gettext.get_locale(AbuubaWeb.Gettext)
 end

--- a/lib/abuuba_web/live/home_live.ex
+++ b/lib/abuuba_web/live/home_live.ex
@@ -330,7 +330,7 @@ defmodule AbuubaWeb.HomeLive do
   # Same shared path as everywhere else; a stream takes the rendered post
   # directly, so the translated words go straight back in place.
   def handle_event("translate", %{"id" => id}, socket) do
-    case PostActions.translate(socket.assigns.account, id, translation_locale(socket)) do
+    case PostActions.translate(socket.assigns.account, id, PostActions.locale(socket)) do
       {:ok, rendered} ->
         {:noreply, stream_insert(socket, :statuses, rendered)}
 
@@ -384,7 +384,4 @@ defmodule AbuubaWeb.HomeLive do
 
   defp newest_id([]), do: nil
   defp newest_id(statuses), do: statuses |> Enum.map(& &1.id) |> Enum.max()
-
-  defp translation_locale(socket),
-    do: socket.assigns[:locale] || Gettext.get_locale(AbuubaWeb.Gettext)
 end

--- a/lib/abuuba_web/live/home_live.ex
+++ b/lib/abuuba_web/live/home_live.ex
@@ -35,6 +35,7 @@ defmodule AbuubaWeb.HomeLive do
   alias Abuuba.Timelines.Broadcast
   alias AbuubaWeb.API.Entities
   alias AbuubaWeb.ComposeComponent
+  alias AbuubaWeb.Params
   alias AbuubaWeb.PostActions
 
   @post_actions PostActions.toggles()
@@ -269,7 +270,7 @@ defmodule AbuubaWeb.HomeLive do
   # having worked.
   def handle_event("mute_thread", %{"id" => id}, socket) do
     with account when not is_nil(account) <- socket.assigns.account,
-         status when not is_nil(status) <- Statuses.get_status(to_integer(id), account),
+         status when not is_nil(status) <- Statuses.get_status(Params.to_integer(id), account),
          {:ok, _mute} <- Statuses.mute_thread(account, status) do
       {:noreply, stream_delete(socket, :statuses, %{"id" => to_string(status.id)})}
     else
@@ -280,7 +281,7 @@ defmodule AbuubaWeb.HomeLive do
   def handle_event("unmute_thread", %{"id" => id}, socket) do
     account = socket.assigns.account
 
-    case Statuses.get_status(to_integer(id), account) do
+    case Statuses.get_status(Params.to_integer(id), account) do
       nil ->
         {:noreply, socket}
 
@@ -306,7 +307,7 @@ defmodule AbuubaWeb.HomeLive do
   end
 
   def handle_event("reply", %{"id" => id}, socket) do
-    case Statuses.get_status(to_integer(id), socket.assigns.account) do
+    case Statuses.get_status(Params.to_integer(id), socket.assigns.account) do
       nil -> {:noreply, socket}
       status -> {:noreply, open_compose(socket, reply_to: status)}
     end
@@ -317,7 +318,7 @@ defmodule AbuubaWeb.HomeLive do
   def handle_event("edit", %{"id" => id}, socket) do
     account = socket.assigns.account
 
-    case Statuses.get_status(to_integer(id), account) do
+    case Statuses.get_status(Params.to_integer(id), account) do
       %{account_id: author_id} = status when author_id == account.id ->
         {:noreply, open_compose(socket, editing: status)}
 
@@ -341,7 +342,7 @@ defmodule AbuubaWeb.HomeLive do
   def handle_event("mark_read", %{"id" => id}, socket) do
     # Where the reader had got to, so the next device starts there rather than
     # at the top with no idea what this one already saw.
-    Timelines.put_marker(socket.assigns.account, "home", to_integer(id))
+    Timelines.put_marker(socket.assigns.account, "home", Params.to_integer(id))
 
     {:noreply, socket}
   end
@@ -383,17 +384,6 @@ defmodule AbuubaWeb.HomeLive do
 
   defp newest_id([]), do: nil
   defp newest_id(statuses), do: statuses |> Enum.map(& &1.id) |> Enum.max()
-
-  defp to_integer(value) when is_integer(value), do: value
-
-  defp to_integer(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, _rest} -> number
-      :error -> 0
-    end
-  end
-
-  defp to_integer(_value), do: 0
 
   defp translation_locale(socket),
     do: socket.assigns[:locale] || Gettext.get_locale(AbuubaWeb.Gettext)

--- a/lib/abuuba_web/live/home_live.ex
+++ b/lib/abuuba_web/live/home_live.ex
@@ -29,13 +29,13 @@ defmodule AbuubaWeb.HomeLive do
   import AbuubaWeb.StatusComponent
 
   alias Abuuba.Filters
+  alias Abuuba.Snowflake
   alias Abuuba.Statuses
   alias Abuuba.Streaming
   alias Abuuba.Timelines
   alias Abuuba.Timelines.Broadcast
   alias AbuubaWeb.API.Entities
   alias AbuubaWeb.ComposeComponent
-  alias AbuubaWeb.Params
   alias AbuubaWeb.PostActions
 
   @post_actions PostActions.toggles()
@@ -270,7 +270,7 @@ defmodule AbuubaWeb.HomeLive do
   # having worked.
   def handle_event("mute_thread", %{"id" => id}, socket) do
     with account when not is_nil(account) <- socket.assigns.account,
-         status when not is_nil(status) <- Statuses.get_status(Params.to_integer(id), account),
+         status when not is_nil(status) <- status_by_id(id, account),
          {:ok, _mute} <- Statuses.mute_thread(account, status) do
       {:noreply, stream_delete(socket, :statuses, %{"id" => to_string(status.id)})}
     else
@@ -281,7 +281,7 @@ defmodule AbuubaWeb.HomeLive do
   def handle_event("unmute_thread", %{"id" => id}, socket) do
     account = socket.assigns.account
 
-    case Statuses.get_status(Params.to_integer(id), account) do
+    case status_by_id(id, account) do
       nil ->
         {:noreply, socket}
 
@@ -307,7 +307,7 @@ defmodule AbuubaWeb.HomeLive do
   end
 
   def handle_event("reply", %{"id" => id}, socket) do
-    case Statuses.get_status(Params.to_integer(id), socket.assigns.account) do
+    case status_by_id(id, socket.assigns.account) do
       nil -> {:noreply, socket}
       status -> {:noreply, open_compose(socket, reply_to: status)}
     end
@@ -318,7 +318,7 @@ defmodule AbuubaWeb.HomeLive do
   def handle_event("edit", %{"id" => id}, socket) do
     account = socket.assigns.account
 
-    case Statuses.get_status(Params.to_integer(id), account) do
+    case status_by_id(id, account) do
       %{account_id: author_id} = status when author_id == account.id ->
         {:noreply, open_compose(socket, editing: status)}
 
@@ -342,7 +342,10 @@ defmodule AbuubaWeb.HomeLive do
   def handle_event("mark_read", %{"id" => id}, socket) do
     # Where the reader had got to, so the next device starts there rather than
     # at the top with no idea what this one already saw.
-    Timelines.put_marker(socket.assigns.account, "home", Params.to_integer(id))
+    case Snowflake.cast(id) do
+      {:ok, id} -> Timelines.put_marker(socket.assigns.account, "home", id)
+      :error -> :ignored
+    end
 
     {:noreply, socket}
   end
@@ -384,4 +387,14 @@ defmodule AbuubaWeb.HomeLive do
 
   defp newest_id([]), do: nil
   defp newest_id(statuses), do: statuses |> Enum.map(& &1.id) |> Enum.max()
+
+  # Through the id type rather than a lenient parse. `to_integer/1` happily
+  # answers with a number too large for a bigint column, which reaches Postgres
+  # as an encode error rather than as a post that is not there.
+  defp status_by_id(id, viewer) do
+    case Snowflake.cast(id) do
+      {:ok, id} -> Statuses.get_status(id, viewer)
+      :error -> nil
+    end
+  end
 end

--- a/lib/abuuba_web/live/landing_live.ex
+++ b/lib/abuuba_web/live/landing_live.ex
@@ -23,6 +23,7 @@ defmodule AbuubaWeb.LandingLive do
   alias Abuuba.Settings
   alias Abuuba.Statuses
   alias AbuubaWeb.API.Entities
+  alias AbuubaWeb.RegistrationWords
 
   @page_size 10
 
@@ -72,7 +73,7 @@ defmodule AbuubaWeb.LandingLive do
         </p>
 
         <p class="mt-3 text-sm text-base-content/70">
-          {registration_note(@registration_mode)}
+          {RegistrationWords.note(@registration_mode)}
         </p>
 
         <div class="mt-4 flex flex-wrap gap-2">
@@ -101,15 +102,4 @@ defmodule AbuubaWeb.LandingLive do
     </Layouts.app>
     """
   end
-
-  # Said plainly on the way in rather than discovered at the end of a form.
-  defp registration_note(:open), do: gettext("Registration is open: anybody may sign up.")
-
-  defp registration_note(:approved),
-    do: gettext("Registration needs approval: you sign up and an admin reads your request.")
-
-  defp registration_note(:closed),
-    do: gettext("Registration is closed here, but any other server on the network will do.")
-
-  defp registration_note(_mode), do: ""
 end

--- a/lib/abuuba_web/live/notifications_live.ex
+++ b/lib/abuuba_web/live/notifications_live.ex
@@ -36,6 +36,7 @@ defmodule AbuubaWeb.NotificationsLive do
   alias Abuuba.Timelines
   alias AbuubaWeb.API.Entities
   alias AbuubaWeb.API.NestedParams
+  alias AbuubaWeb.Params
 
   @page_size 40
 
@@ -234,7 +235,7 @@ defmodule AbuubaWeb.NotificationsLive do
   end
 
   def handle_event("accept_request", %{"account" => id}, socket) do
-    with {:ok, id} <- numeric(id) do
+    with {:ok, id} <- Params.id(id) do
       Notifications.accept_request(socket.assigns.account, id)
     end
 
@@ -242,7 +243,7 @@ defmodule AbuubaWeb.NotificationsLive do
   end
 
   def handle_event("dismiss_request", %{"account" => id}, socket) do
-    with {:ok, id} <- numeric(id) do
+    with {:ok, id} <- Params.id(id) do
       Notifications.dismiss_request(socket.assigns.account, id)
     end
 
@@ -453,15 +454,4 @@ defmodule AbuubaWeb.NotificationsLive do
   # A group key carries characters a DOM id may not, so it is hashed rather
   # than interpolated.
   defp dom_id(key), do: :erlang.phash2(key)
-
-  defp numeric(value) when is_integer(value), do: {:ok, value}
-
-  defp numeric(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, ""} -> {:ok, number}
-      _ -> nil
-    end
-  end
-
-  defp numeric(_value), do: nil
 end

--- a/lib/abuuba_web/live/notifications_live.ex
+++ b/lib/abuuba_web/live/notifications_live.ex
@@ -32,11 +32,11 @@ defmodule AbuubaWeb.NotificationsLive do
   alias Abuuba.Accounts
   alias Abuuba.Accounts.Account
   alias Abuuba.Notifications
+  alias Abuuba.Snowflake
   alias Abuuba.Streaming
   alias Abuuba.Timelines
   alias AbuubaWeb.API.Entities
   alias AbuubaWeb.API.NestedParams
-  alias AbuubaWeb.Params
   alias AbuubaWeb.PostActions
 
   @page_size 40
@@ -253,7 +253,7 @@ defmodule AbuubaWeb.NotificationsLive do
   end
 
   def handle_event("accept_request", %{"account" => id}, socket) do
-    with {:ok, id} <- Params.id(id) do
+    with {:ok, id} <- Snowflake.cast(id) do
       Notifications.accept_request(socket.assigns.viewer, id)
     end
 
@@ -261,7 +261,7 @@ defmodule AbuubaWeb.NotificationsLive do
   end
 
   def handle_event("dismiss_request", %{"account" => id}, socket) do
-    with {:ok, id} <- Params.id(id) do
+    with {:ok, id} <- Snowflake.cast(id) do
       Notifications.dismiss_request(socket.assigns.viewer, id)
     end
 

--- a/lib/abuuba_web/live/notifications_live.ex
+++ b/lib/abuuba_web/live/notifications_live.ex
@@ -332,11 +332,11 @@ defmodule AbuubaWeb.NotificationsLive do
   # wrongly in half the languages this is translated into, and the plural of
   # "one other person" is not a suffix.
   defp headline(%{count: 1, senders: [sender | _]} = group) do
-    verb(group.type, display_name(sender))
+    verb(group.type, Account.display_name(sender))
   end
 
   defp headline(%{senders: [sender | _]} = group) do
-    others(group.type, display_name(sender), group.count)
+    others(group.type, Account.display_name(sender), group.count)
   end
 
   defp headline(group), do: verb(group.type, gettext("Somebody"))
@@ -405,12 +405,9 @@ defmodule AbuubaWeb.NotificationsLive do
   defp sender_name(request, senders) do
     case senders[request.from_account_id] do
       nil -> gettext("Somebody")
-      account -> display_name(account)
+      account -> Account.display_name(account)
     end
   end
-
-  defp display_name(%Account{display_name: name}) when is_binary(name) and name != "", do: name
-  defp display_name(%Account{username: username}), do: username
 
   defp stored_types(%{settings: settings}) when is_map(settings) do
     settings |> Map.get("notification_types", []) |> Enum.filter(&(&1 in @offered_types))

--- a/lib/abuuba_web/live/notifications_live.ex
+++ b/lib/abuuba_web/live/notifications_live.ex
@@ -37,6 +37,7 @@ defmodule AbuubaWeb.NotificationsLive do
   alias AbuubaWeb.API.Entities
   alias AbuubaWeb.API.NestedParams
   alias AbuubaWeb.Params
+  alias AbuubaWeb.PostActions
 
   @page_size 40
 
@@ -53,12 +54,29 @@ defmodule AbuubaWeb.NotificationsLive do
     # No `load/1` here: `handle_params/3` always runs right after mount and
     # loads the page, so loading here too would ask everything twice.
     {:ok,
-     assign(socket,
+     socket
+     |> assign(
        page_title: gettext("Notifications"),
-       account: account,
+       viewer: account,
        types: stored_types(socket.assigns.current_scope.user)
-     )}
+     )
+     |> PostActions.attach(put_back: &put_status_back/2)}
   end
+
+  # This screen draws the action bar like the other five, but its posts are not
+  # in a list: each one sits inside the group of notifications about it, so
+  # twelve boosts of a post are one row. So it hands `PostActions` its own way
+  # of putting a post back rather than naming an assign.
+  defp put_status_back(socket, rendered) do
+    update(socket, :groups, &Enum.map(&1, fn group -> swap_group(group, rendered) end))
+  end
+
+  # The same id in both patterns, so only the group showing this post is
+  # rewritten. A group with no post at all falls to the second clause.
+  defp swap_group(%{status: %{"id" => id}} = group, %{"id" => id} = rendered),
+    do: %{group | status: rendered}
+
+  defp swap_group(group, _rendered), do: group
 
   @impl Phoenix.LiveView
   def handle_params(_params, _uri, socket) do
@@ -184,7 +202,7 @@ defmodule AbuubaWeb.NotificationsLive do
             :if={group.status}
             id={"group-#{dom_id(group.key)}-status"}
             status={group.status}
-            viewer_id={to_string(@account.id)}
+            viewer_id={to_string(@viewer.id)}
           />
         </article>
       </div>
@@ -212,8 +230,8 @@ defmodule AbuubaWeb.NotificationsLive do
   end
 
   def handle_event("mark_read", _params, socket) do
-    case Notifications.list(socket.assigns.account, %{limit: 1}) do
-      [newest | _] -> Timelines.put_marker(socket.assigns.account, "notifications", newest.id)
+    case Notifications.list(socket.assigns.viewer, %{limit: 1}) do
+      [newest | _] -> Timelines.put_marker(socket.assigns.viewer, "notifications", newest.id)
       [] -> :ok
     end
 
@@ -221,7 +239,7 @@ defmodule AbuubaWeb.NotificationsLive do
   end
 
   def handle_event("dismiss", %{"group" => key}, socket) do
-    account = socket.assigns.account
+    account = socket.assigns.viewer
 
     Notifications.dismiss_group(account, key)
 
@@ -229,14 +247,14 @@ defmodule AbuubaWeb.NotificationsLive do
   end
 
   def handle_event("clear_all", _params, socket) do
-    Notifications.clear(socket.assigns.account)
+    Notifications.clear(socket.assigns.viewer)
 
     {:noreply, load(socket)}
   end
 
   def handle_event("accept_request", %{"account" => id}, socket) do
     with {:ok, id} <- Params.id(id) do
-      Notifications.accept_request(socket.assigns.account, id)
+      Notifications.accept_request(socket.assigns.viewer, id)
     end
 
     {:noreply, load(socket)}
@@ -244,7 +262,7 @@ defmodule AbuubaWeb.NotificationsLive do
 
   def handle_event("dismiss_request", %{"account" => id}, socket) do
     with {:ok, id} <- Params.id(id) do
-      Notifications.dismiss_request(socket.assigns.account, id)
+      Notifications.dismiss_request(socket.assigns.viewer, id)
     end
 
     {:noreply, load(socket)}
@@ -262,7 +280,7 @@ defmodule AbuubaWeb.NotificationsLive do
   ## Plumbing
 
   defp load(socket) do
-    account = socket.assigns.account
+    account = socket.assigns.viewer
     page = %{limit: @page_size, types: wanted_types(socket)}
     groups = Notifications.grouped(account, page)
     requests = Notifications.requests(account)

--- a/lib/abuuba_web/live/post_actions.ex
+++ b/lib/abuuba_web/live/post_actions.ex
@@ -28,6 +28,8 @@ defmodule AbuubaWeb.PostActions do
   turns a correction into a silent no-op.
   """
 
+  use Gettext, backend: AbuubaWeb.Gettext
+
   alias Abuuba.Accounts.Account
   alias Abuuba.Statuses
   alias Abuuba.Statuses.Poll
@@ -203,5 +205,109 @@ defmodule AbuubaWeb.PostActions do
       {number, ""} -> Statuses.get_status(number, viewer)
       _not_a_number -> nil
     end
+  end
+
+  @doc """
+  Answers every event the action bar raises, for a screen that keeps its posts
+  in plain lists.
+
+  ## Why the wiring moved here too
+
+  The work behind these events came here first and the wiring did not, so the
+  same fifty-four lines sat in four screens: identical in three of them, and
+  identical apart from one list name in the fourth. That is the shape the
+  moduledoc above describes, one level up — the copies were what disagreed.
+  Search's translate put the fresh post into an assign that screen never had,
+  so the button raised on every result, and nothing said so until somebody
+  pressed it.
+
+  `:lists` names the assigns holding the posts, so a screen that keeps two of
+  them (a profile, with its pinned posts above the rest) says so rather than
+  writing the loop again.
+
+  ## What a screen keeps for itself
+
+  Replying and editing here go to the post's own page, because these screens
+  have no composer. A screen that has one — the home timeline, a post's own
+  page — answers those two itself and does not attach this.
+  """
+  @spec attach(Phoenix.LiveView.Socket.t(), keyword()) :: Phoenix.LiveView.Socket.t()
+  def attach(socket, opts) do
+    put_back = put_back_fun(opts)
+
+    Phoenix.LiveView.attach_hook(socket, :post_actions, :handle_event, fn event, params, socket ->
+      handle(event, params, socket, put_back)
+    end)
+  end
+
+  # `:lists` covers every screen that keeps posts in plain lists, which is most
+  # of them. `:put_back` is for the one that does not — the notifications page
+  # holds each post inside the group of notifications about it — and is the
+  # same division of labour the moduledoc describes: this decides what an
+  # action does, the screen decides where the answer goes.
+  defp put_back_fun(opts) do
+    case Keyword.fetch(opts, :put_back) do
+      {:ok, fun} when is_function(fun, 2) -> fun
+      :error -> lists_put_back(opts |> Keyword.fetch!(:lists) |> List.wrap())
+    end
+  end
+
+  defp lists_put_back(lists), do: &swap_lists(&1, lists, &2)
+
+  defp swap_lists(socket, lists, rendered) do
+    Enum.reduce(lists, socket, fn list, acc ->
+      Phoenix.Component.update(acc, list, &swap(&1, rendered))
+    end)
+  end
+
+  defp handle(event, %{"id" => id}, socket, put_back) when event in @toggles do
+    case toggle(socket.assigns.viewer, event, id) do
+      {:ok, status} -> {:halt, rendered_back(socket, status, put_back)}
+      :error -> {:halt, socket}
+    end
+  end
+
+  defp handle("vote", %{"poll_id" => poll_id} = params, socket, put_back) do
+    choices = params |> Map.get("choices", []) |> List.wrap()
+
+    case vote(socket.assigns.viewer, poll_id, choices) do
+      {:ok, status} -> {:halt, rendered_back(socket, status, put_back)}
+      :error -> {:halt, socket}
+    end
+  end
+
+  defp handle(event, %{"id" => id}, socket, _put_back) when event in ~w(reply edit) do
+    case page_of(socket.assigns.viewer, id) do
+      nil -> {:halt, socket}
+      path -> {:halt, Phoenix.LiveView.push_navigate(socket, to: path)}
+    end
+  end
+
+  defp handle("translate", %{"id" => id}, socket, put_back) do
+    case translate(socket.assigns.viewer, id, locale(socket)) do
+      {:ok, rendered} ->
+        {:halt, put_back.(socket, rendered)}
+
+      :error ->
+        {:halt,
+         Phoenix.LiveView.put_flash(
+           socket,
+           :error,
+           gettext("That could not be translated just now.")
+         )}
+    end
+  end
+
+  defp handle(_event, _params, socket, _put_back), do: {:cont, socket}
+
+  # Rendered the way the screen rendered the rest of them, then handed back.
+  defp rendered_back(socket, %Status{} = status, put_back) do
+    put_back.(socket, Entities.status(status, socket.assigns.viewer))
+  end
+
+  # The reader's own language where the hook has one, and the request's
+  # otherwise. Was a private one-liner in five screens.
+  defp locale(socket) do
+    socket.assigns[:locale] || Gettext.get_locale(AbuubaWeb.Gettext)
   end
 end

--- a/lib/abuuba_web/live/post_actions.ex
+++ b/lib/abuuba_web/live/post_actions.ex
@@ -305,9 +305,16 @@ defmodule AbuubaWeb.PostActions do
     put_back.(socket, Entities.status(status, socket.assigns.viewer))
   end
 
-  # The reader's own language where the hook has one, and the request's
-  # otherwise. Was a private one-liner in five screens.
-  defp locale(socket) do
+  @doc """
+  The language to translate into for this reader.
+
+  Their own where the locale hook has set one, and the request's otherwise.
+  Public because the two screens with a composer answer `translate` themselves
+  and still have to pick the same target; it was a private one-liner in six
+  screens, one of which had drifted to a different name.
+  """
+  @spec locale(Phoenix.LiveView.Socket.t()) :: String.t()
+  def locale(socket) do
     socket.assigns[:locale] || Gettext.get_locale(AbuubaWeb.Gettext)
   end
 end

--- a/lib/abuuba_web/live/post_actions.ex
+++ b/lib/abuuba_web/live/post_actions.ex
@@ -46,6 +46,18 @@ defmodule AbuubaWeb.PostActions do
   def toggles, do: @toggles
 
   @doc """
+  Every event `attach/2` answers.
+
+  Stated rather than implied so the sweep in
+  `AbuubaWeb.StatusComponentEventsTest` can hold this list against the one the
+  component raises. Without it, attaching the hook counts as answering
+  everything, and a clause dropped from `handle/4` later would leave every
+  attached screen passing a check that is no longer true.
+  """
+  @spec answers() :: [String.t()]
+  def answers, do: Enum.sort(@toggles ++ ~w(edit reply translate vote))
+
+  @doc """
   Performs one, answering with the post as it now stands.
 
   `:error` where there is nobody signed in, the id names nothing, or the event

--- a/lib/abuuba_web/live/profile_live.ex
+++ b/lib/abuuba_web/live/profile_live.ex
@@ -109,7 +109,7 @@ defmodule AbuubaWeb.ProfileLive do
           alt=""
           class="mb-3 size-20 rounded bg-base-300 object-cover"
         />
-        <h1 class="text-2xl font-semibold">{display_name(@subject)}</h1>
+        <h1 class="text-2xl font-semibold">{Account.display_name(@subject)}</h1>
         <p class="text-base-content/60">@{Account.acct(@subject)}</p>
 
         <div :if={@subject.note not in [nil, ""]} class="mt-3 break-words">
@@ -271,7 +271,7 @@ defmodule AbuubaWeb.ProfileLive do
         >
           <label class="block">
             <span class="font-medium">
-              {gettext("Get updates from %{name} by email", name: display_name(@subject))}
+              {gettext("Get updates from %{name} by email", name: Account.display_name(@subject))}
             </span>
             <span class="mt-1 block text-sm text-base-content/60">
               {gettext(
@@ -335,7 +335,7 @@ defmodule AbuubaWeb.ProfileLive do
                 alt=""
                 class="size-6 rounded"
               />
-              <span class="font-medium">{display_name(person)}</span>
+              <span class="font-medium">{Account.display_name(person)}</span>
               <span class="text-sm text-base-content/60">@{Account.acct(person)}</span>
             </.link>
           </li>
@@ -383,7 +383,7 @@ defmodule AbuubaWeb.ProfileLive do
           <img :if={avatar_url(person) != ""} src={avatar_url(person)} alt="" class="size-10 rounded" />
           <span class="min-w-0 flex-1">
             <.link navigate={~p"/@#{Account.acct(person)}"} class="font-medium">
-              {display_name(person)}
+              {Account.display_name(person)}
             </.link>
             <span class="block truncate text-sm text-base-content/60">@{Account.acct(person)}</span>
           </span>
@@ -582,8 +582,8 @@ defmodule AbuubaWeb.ProfileLive do
 
     socket
     |> assign(
-      page_title: display_name(subject),
-      note_html: note_html(subject),
+      page_title: Account.display_name(subject),
+      note_html: Formatter.note_html(subject),
       fields: rendered["fields"] || [],
       featured_tags: Statuses.featured_tag_names(subject),
       moved_to: moved_to(subject),
@@ -706,13 +706,7 @@ defmodule AbuubaWeb.ProfileLive do
   defp put_meta(socket) do
     subject = socket.assigns.subject
 
-    summary =
-      subject.note
-      |> to_string()
-      |> String.replace(~r/<[^>]*>/, " ")
-      |> String.replace(~r/\s+/u, " ")
-      |> String.trim()
-      |> String.slice(0, 200)
+    summary = Formatter.plain_text(subject.note, limit: 200)
 
     socket
     |> assign(:robots, robots(subject, socket.assigns[:live_action]))
@@ -725,7 +719,7 @@ defmodule AbuubaWeb.ProfileLive do
     ])
     |> assign(:page_meta, [
       {"property", "og:type", "profile"},
-      {"property", "og:title", "#{display_name(subject)} (@#{Account.acct(subject)})"},
+      {"property", "og:title", "#{Account.display_name(subject)} (@#{Account.acct(subject)})"},
       {"property", "og:description", summary},
       {"property", "og:url", URIs.profile_url(subject)},
       {"name", "description", summary}
@@ -741,12 +735,6 @@ defmodule AbuubaWeb.ProfileLive do
   defp robots(_subject, action) when action in [:followers, :following], do: Meta.noindex()
   defp robots(%Account{indexable: true}, _action), do: nil
   defp robots(_subject, _action), do: Meta.noindex()
-
-  # Ours is plain text and is escaped on the way out; theirs is markup that was
-  # cleaned on the way in. Both go through a function that says which is which,
-  # so neither is ever rendered as the other.
-  defp note_html(%Account{domain: nil, note: note}), do: Formatter.to_html(note)
-  defp note_html(%Account{note: note}), do: Formatter.sanitize(note)
 
   defp relationship(nil, _subject),
     do: %{
@@ -825,12 +813,6 @@ defmodule AbuubaWeb.ProfileLive do
   # would be.
   defp avatar_url(account), do: ProfileImages.url(account, :avatar)
   defp header_url(account), do: ProfileImages.url(account, :header)
-
-  defp display_name(%Account{display_name: name}) when is_binary(name) and name != "", do: name
-  defp display_name(%Account{username: username}), do: username
-
-  defp viewer_id(nil), do: nil
-  defp viewer_id(viewer), do: to_string(viewer.id)
 
   # Rendered the way this screen renders the rest of them, then swapped in.
   # Both lists, because a pinned post is drawn twice on a profile and updating

--- a/lib/abuuba_web/live/profile_live.ex
+++ b/lib/abuuba_web/live/profile_live.ex
@@ -38,9 +38,6 @@ defmodule AbuubaWeb.ProfileLive do
   alias AbuubaWeb.Meta
   alias AbuubaWeb.PostActions
 
-  # Answered here because the action bar is drawn here.
-  @post_actions PostActions.toggles()
-
   @page_size 20
 
   # Enough to be a recommendation and not a directory. The API pages through
@@ -68,6 +65,7 @@ defmodule AbuubaWeb.ProfileLive do
            client_ip: AbuubaWeb.ClientIP.of_socket(socket),
            email_subscription_said: nil
          )
+         |> PostActions.attach(lists: [:posts, :pinned])
          |> load_profile()}
 
       _ ->
@@ -470,66 +468,6 @@ defmodule AbuubaWeb.ProfileLive do
     act(socket, fn viewer, subject -> Relationships.put_note(viewer, subject, note) end)
   end
 
-  # The action bar is drawn on this screen, so the events it raises are
-  # answered here. See `AbuubaWeb.PostActions` for why the work behind them is
-  # one module rather than a copy per screen.
-  def handle_event(event, %{"id" => id}, socket) when event in @post_actions do
-    case PostActions.toggle(socket.assigns.viewer, event, id) do
-      {:ok, status} -> {:noreply, replace_post(socket, status)}
-      :error -> {:noreply, socket}
-    end
-  end
-
-  # The poll form is drawn by the same component as the action bar, so it is
-  # answered in the same place. See `AbuubaWeb.PostActions`.
-  def handle_event("vote", %{"poll_id" => poll_id} = params, socket) do
-    choices = params |> Map.get("choices", []) |> List.wrap()
-
-    case PostActions.vote(socket.assigns.viewer, poll_id, choices) do
-      {:ok, status} -> {:noreply, replace_post(socket, status)}
-      :error -> {:noreply, socket}
-    end
-  end
-
-  # There is no composer on this screen, so replying goes to the post, which
-  # has one. A box that appears on some screens and not others is worse than
-  # the same answer everywhere.
-  def handle_event("reply", %{"id" => id}, socket) do
-    case PostActions.page_of(socket.assigns.viewer, id) do
-      nil -> {:noreply, socket}
-      path -> {:noreply, push_navigate(socket, to: path)}
-    end
-  end
-
-  # The pencil is drawn by the same component as the rest of the bar, and the
-  # box to edit in is on the post's own page. Same answer as "reply" for the
-  # same reason: a composer that appears on some screens and not others is
-  # worse than the same answer everywhere.
-  def handle_event("edit", %{"id" => id}, socket) do
-    case PostActions.page_of(socket.assigns.viewer, id) do
-      nil -> {:noreply, socket}
-      path -> {:noreply, push_navigate(socket, to: path)}
-    end
-  end
-
-  # Drawn by the same component as the rest of the bar. A translation is not a
-  # change to the post, so it is put straight back into the list rather than
-  # re-read. See `AbuubaWeb.PostActions`.
-  def handle_event("translate", %{"id" => id}, socket) do
-    case PostActions.translate(socket.assigns.viewer, id, locale(socket)) do
-      {:ok, rendered} ->
-        {:noreply,
-         Enum.reduce(
-           [:posts, :pinned],
-           socket,
-           &update(&2, &1, fn posts -> PostActions.swap(posts, rendered) end)
-         )}
-
-      :error ->
-        {:noreply, put_flash(socket, :error, gettext("That could not be translated just now."))}
-    end
-  end
-
   def handle_event(_event, _params, socket), do: {:noreply, socket}
 
   ## Plumbing
@@ -897,15 +835,4 @@ defmodule AbuubaWeb.ProfileLive do
   # Rendered the way this screen renders the rest of them, then swapped in.
   # Both lists, because a pinned post is drawn twice on a profile and updating
   # one copy would leave the other showing the old count.
-  defp replace_post(socket, status) do
-    rendered = Entities.status(status, socket.assigns.viewer)
-
-    Enum.reduce(
-      [:posts, :pinned],
-      socket,
-      &update(&2, &1, fn posts -> PostActions.swap(posts, rendered) end)
-    )
-  end
-
-  defp locale(socket), do: socket.assigns[:locale] || Gettext.get_locale(AbuubaWeb.Gettext)
 end

--- a/lib/abuuba_web/live/search_live.ex
+++ b/lib/abuuba_web/live/search_live.ex
@@ -217,7 +217,4 @@ defmodule AbuubaWeb.SearchLive do
   defp operator_hint("before:"), do: gettext("posts older than a date")
   defp operator_hint("after:"), do: gettext("posts newer than a date")
   defp operator_hint(name), do: name
-
-  defp viewer_id(nil), do: nil
-  defp viewer_id(viewer), do: to_string(viewer.id)
 end

--- a/lib/abuuba_web/live/search_live.ex
+++ b/lib/abuuba_web/live/search_live.ex
@@ -103,7 +103,7 @@ defmodule AbuubaWeb.SearchLive do
         <h2 class="px-4 pt-3 text-xs uppercase text-base-content/60">{gettext("People")}</h2>
         <ul class="divide-y divide-base-300">
           <li :for={person <- @accounts} class="p-4">
-            <a href={"/@" <> Account.acct(person)} class="font-semibold">{display_name(person)}</a>
+            <a href={"/@" <> Account.acct(person)} class="font-semibold">{Account.display_name(person)}</a>
             <p class="text-sm text-base-content/60">@{Account.acct(person)}</p>
           </li>
         </ul>
@@ -189,7 +189,7 @@ defmodule AbuubaWeb.SearchLive do
   def handle_event("translate", %{"id" => id}, socket) do
     case PostActions.translate(socket.assigns.viewer, id, locale(socket)) do
       {:ok, rendered} ->
-        {:noreply, update(socket, :posts, &PostActions.swap(&1, rendered))}
+        {:noreply, update(socket, :statuses, &PostActions.swap(&1, rendered))}
 
       :error ->
         {:noreply, put_flash(socket, :error, gettext("That could not be translated just now."))}
@@ -273,9 +273,6 @@ defmodule AbuubaWeb.SearchLive do
   defp operator_hint("before:"), do: gettext("posts older than a date")
   defp operator_hint("after:"), do: gettext("posts newer than a date")
   defp operator_hint(name), do: name
-
-  defp display_name(%Account{display_name: name}) when is_binary(name) and name != "", do: name
-  defp display_name(%Account{username: username}), do: username
 
   defp viewer_id(nil), do: nil
   defp viewer_id(viewer), do: to_string(viewer.id)

--- a/lib/abuuba_web/live/search_live.ex
+++ b/lib/abuuba_web/live/search_live.ex
@@ -27,21 +27,20 @@ defmodule AbuubaWeb.SearchLive do
   alias AbuubaWeb.Meta
   alias AbuubaWeb.PostActions
 
-  # Answered here because the action bar is drawn here.
-  @post_actions PostActions.toggles()
-
   @page_size 20
   @types ~w(all accounts hashtags statuses)
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     {:ok,
-     assign(socket,
+     socket
+     |> assign(
        page_title: gettext("Search"),
        viewer: current_account(socket),
        operators: Search.operators(),
        robots: Meta.noindex()
-     )}
+     )
+     |> PostActions.attach(lists: [:statuses])}
   end
 
   @impl Phoenix.LiveView
@@ -141,61 +140,6 @@ defmodule AbuubaWeb.SearchLive do
     {:noreply, push_patch(socket, to: search_path(query, socket.assigns.type))}
   end
 
-  # The action bar is drawn on this screen, so the events it raises are
-  # answered here. See `AbuubaWeb.PostActions` for why the work behind them is
-  # one module rather than a copy per screen.
-  def handle_event(event, %{"id" => id}, socket) when event in @post_actions do
-    case PostActions.toggle(socket.assigns.viewer, event, id) do
-      {:ok, status} -> {:noreply, replace_post(socket, status)}
-      :error -> {:noreply, socket}
-    end
-  end
-
-  # The poll form is drawn by the same component as the action bar, so it is
-  # answered in the same place. See `AbuubaWeb.PostActions`.
-  def handle_event("vote", %{"poll_id" => poll_id} = params, socket) do
-    choices = params |> Map.get("choices", []) |> List.wrap()
-
-    case PostActions.vote(socket.assigns.viewer, poll_id, choices) do
-      {:ok, status} -> {:noreply, replace_post(socket, status)}
-      :error -> {:noreply, socket}
-    end
-  end
-
-  # There is no composer on this screen, so replying goes to the post, which
-  # has one. A box that appears on some screens and not others is worse than
-  # the same answer everywhere.
-  def handle_event("reply", %{"id" => id}, socket) do
-    case PostActions.page_of(socket.assigns.viewer, id) do
-      nil -> {:noreply, socket}
-      path -> {:noreply, push_navigate(socket, to: path)}
-    end
-  end
-
-  # The pencil is drawn by the same component as the rest of the bar, and the
-  # box to edit in is on the post's own page. Same answer as "reply" for the
-  # same reason: a composer that appears on some screens and not others is
-  # worse than the same answer everywhere.
-  def handle_event("edit", %{"id" => id}, socket) do
-    case PostActions.page_of(socket.assigns.viewer, id) do
-      nil -> {:noreply, socket}
-      path -> {:noreply, push_navigate(socket, to: path)}
-    end
-  end
-
-  # Drawn by the same component as the rest of the bar. A translation is not a
-  # change to the post, so it is put straight back into the list rather than
-  # re-read. See `AbuubaWeb.PostActions`.
-  def handle_event("translate", %{"id" => id}, socket) do
-    case PostActions.translate(socket.assigns.viewer, id, locale(socket)) do
-      {:ok, rendered} ->
-        {:noreply, update(socket, :statuses, &PostActions.swap(&1, rendered))}
-
-      :error ->
-        {:noreply, put_flash(socket, :error, gettext("That could not be translated just now."))}
-    end
-  end
-
   def handle_event(_event, _params, socket), do: {:noreply, socket}
 
   ## Plumbing
@@ -276,13 +220,4 @@ defmodule AbuubaWeb.SearchLive do
 
   defp viewer_id(nil), do: nil
   defp viewer_id(viewer), do: to_string(viewer.id)
-
-  # Rendered the way this screen renders the rest of them, then swapped in.
-  defp replace_post(socket, status) do
-    rendered = Entities.status(status, socket.assigns.viewer)
-
-    update(socket, :statuses, &PostActions.swap(&1, rendered))
-  end
-
-  defp locale(socket), do: socket.assigns[:locale] || Gettext.get_locale(AbuubaWeb.Gettext)
 end

--- a/lib/abuuba_web/live/settings_live.ex
+++ b/lib/abuuba_web/live/settings_live.ex
@@ -52,6 +52,7 @@ defmodule AbuubaWeb.SettingsLive do
   alias Abuuba.Relationships
   alias Abuuba.Statuses
   alias Abuuba.Statuses.Cleanup
+  alias Abuuba.Statuses.Formatter
   alias AbuubaWeb.CoreComponents
   alias AbuubaWeb.Formats
   alias AbuubaWeb.ScopeWords
@@ -856,10 +857,10 @@ defmodule AbuubaWeb.SettingsLive do
             name="accounts[]"
             value={person.id}
             class="checkbox checkbox-sm"
-            aria-label={display_name(person)}
+            aria-label={Account.display_name(person)}
           />
           <span class="min-w-0 flex-1">
-            <a href={"/@" <> Account.acct(person)} class="font-medium">{display_name(person)}</a>
+            <a href={"/@" <> Account.acct(person)} class="font-medium">{Account.display_name(person)}</a>
             <span class="block text-sm text-base-content/60">@{Account.acct(person)}</span>
           </span>
         </li>
@@ -1646,8 +1647,14 @@ defmodule AbuubaWeb.SettingsLive do
 
   ## Plumbing
 
+  # The section that was saved, not always the profile: privacy and aliases save
+  # through here too, and reloading `:profile` for them redrew the page with
+  # another section's data. `save_user/2` below already asks the socket.
   defp save(socket, {:ok, account}) do
-    {:noreply, socket |> assign(account: account, saved?: true, error: nil) |> load(:profile)}
+    {:noreply,
+     socket
+     |> assign(account: account, saved?: true, error: nil)
+     |> load(socket.assigns.section)}
   end
 
   defp save(socket, {:error, _changeset}) do
@@ -2167,13 +2174,7 @@ defmodule AbuubaWeb.SettingsLive do
     end)
   end
 
-  defp plain_text(html) do
-    html
-    |> to_string()
-    |> String.replace(~r/<[^>]*>/, " ")
-    |> String.replace(~r/\s+/u, " ")
-    |> String.trim()
-  end
+  defp plain_text(html), do: Formatter.plain_text(html)
 
   # `consume_uploaded_entries` hands over a path that is deleted the moment the
   # function returns, which is exactly the shape `ProfileImages.store/3` wants:
@@ -2316,9 +2317,6 @@ defmodule AbuubaWeb.SettingsLive do
   defp filter_action_label("warn"), do: gettext("Fold it behind a warning")
   defp filter_action_label("hide"), do: gettext("Hide it completely")
   defp filter_action_label(action), do: action
-
-  defp display_name(%Account{display_name: name}) when is_binary(name) and name != "", do: name
-  defp display_name(%Account{username: username}), do: username
 
   defp to_integer(value) when is_integer(value), do: value
 

--- a/lib/abuuba_web/live/settings_live.ex
+++ b/lib/abuuba_web/live/settings_live.ex
@@ -55,6 +55,7 @@ defmodule AbuubaWeb.SettingsLive do
   alias Abuuba.Statuses.Formatter
   alias AbuubaWeb.CoreComponents
   alias AbuubaWeb.Formats
+  alias AbuubaWeb.Params
   alias AbuubaWeb.ScopeWords
 
   @impl Phoenix.LiveView
@@ -1331,11 +1332,11 @@ defmodule AbuubaWeb.SettingsLive do
   end
 
   def handle_event("remove_field", %{"index" => index}, socket) do
-    {:noreply, update(socket, :fields, &List.delete_at(&1, to_integer(index)))}
+    {:noreply, update(socket, :fields, &List.delete_at(&1, Params.to_integer(index)))}
   end
 
   def handle_event("move_field", %{"index" => index}, socket) do
-    index = to_integer(index)
+    index = Params.to_integer(index)
 
     {:noreply,
      update(socket, :fields, fn fields ->
@@ -1545,7 +1546,7 @@ defmodule AbuubaWeb.SettingsLive do
   end
 
   def handle_event("delete_filter", %{"filter" => id}, socket) do
-    with {:ok, id} <- numeric(id),
+    with {:ok, id} <- Params.id(id),
          filter when not is_nil(filter) <- Filters.get(socket.assigns.account, id) do
       Filters.delete(filter)
     end
@@ -1583,7 +1584,7 @@ defmodule AbuubaWeb.SettingsLive do
   end
 
   def handle_event("revoke_application", %{"application" => id}, socket) do
-    with {:ok, id} <- numeric(id) do
+    with {:ok, id} <- Params.id(id) do
       OAuth.revoke_application_for(socket.assigns.user, id)
     end
 
@@ -1809,7 +1810,7 @@ defmodule AbuubaWeb.SettingsLive do
       fields when is_map(fields) ->
         ordered =
           fields
-          |> Enum.sort_by(fn {index, _field} -> to_integer(index) end)
+          |> Enum.sort_by(fn {index, _field} -> Params.to_integer(index) end)
           |> Enum.map(fn {_index, field} -> field end)
           |> Enum.reject(&(String.trim(&1["name"] || "") == ""))
 
@@ -2330,32 +2331,10 @@ defmodule AbuubaWeb.SettingsLive do
   defp filter_action_label("hide"), do: gettext("Hide it completely")
   defp filter_action_label(action), do: action
 
-  defp to_integer(value) when is_integer(value), do: value
-
-  defp to_integer(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, _rest} -> number
-      :error -> 0
-    end
-  end
-
-  defp to_integer(_value), do: 0
-
   defp account_id(value) do
-    case numeric(value) do
+    case Params.id(value) do
       {:ok, id} -> id
       _ -> nil
     end
   end
-
-  defp numeric(value) when is_integer(value), do: {:ok, value}
-
-  defp numeric(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, ""} -> {:ok, number}
-      _ -> nil
-    end
-  end
-
-  defp numeric(_value), do: nil
 end

--- a/lib/abuuba_web/live/settings_live.ex
+++ b/lib/abuuba_web/live/settings_live.ex
@@ -50,6 +50,7 @@ defmodule AbuubaWeb.SettingsLive do
   alias Abuuba.Moderation.Domains
   alias Abuuba.OAuth
   alias Abuuba.Relationships
+  alias Abuuba.Snowflake
   alias Abuuba.Statuses
   alias Abuuba.Statuses.Cleanup
   alias Abuuba.Statuses.Formatter
@@ -1546,7 +1547,7 @@ defmodule AbuubaWeb.SettingsLive do
   end
 
   def handle_event("delete_filter", %{"filter" => id}, socket) do
-    with {:ok, id} <- Params.id(id),
+    with {:ok, id} <- Snowflake.cast(id),
          filter when not is_nil(filter) <- Filters.get(socket.assigns.account, id) do
       Filters.delete(filter)
     end
@@ -1584,7 +1585,7 @@ defmodule AbuubaWeb.SettingsLive do
   end
 
   def handle_event("revoke_application", %{"application" => id}, socket) do
-    with {:ok, id} <- Params.id(id) do
+    with {:ok, id} <- Snowflake.cast(id) do
       OAuth.revoke_application_for(socket.assigns.user, id)
     end
 
@@ -2332,7 +2333,7 @@ defmodule AbuubaWeb.SettingsLive do
   defp filter_action_label(action), do: action
 
   defp account_id(value) do
-    case Params.id(value) do
+    case Snowflake.cast(value) do
       {:ok, id} -> id
       _ -> nil
     end

--- a/lib/abuuba_web/live/settings_live.ex
+++ b/lib/abuuba_web/live/settings_live.ex
@@ -2224,7 +2224,19 @@ defmodule AbuubaWeb.SettingsLive do
 
   defp picture_url(account, kind), do: ProfileImages.url(account, kind)
 
-  defp human_bytes(bytes), do: "#{div(bytes, 1024 * 1024)} MB"
+  # Megabytes, through the formatter and with the unit translated. Integer
+  # division would render a 4.7 MB limit as "4 MB", which is a smaller number
+  # than the one the upload actually refuses at, and a bare interpolation
+  # would show a German reader "4.7" where they read "4,7".
+  defp human_bytes(bytes) do
+    case Float.round(bytes / (1024 * 1024), 1) do
+      whole when whole == trunc(whole) ->
+        gettext("%{size} MB", size: Formats.number(trunc(whole)))
+
+      fraction ->
+        gettext("%{size} MB", size: Formats.number(fraction))
+    end
+  end
 
   defp export_label("follows"), do: gettext("Follows")
   defp export_label("blocks"), do: gettext("Blocks")

--- a/lib/abuuba_web/live/status_live.ex
+++ b/lib/abuuba_web/live/status_live.ex
@@ -29,6 +29,7 @@ defmodule AbuubaWeb.StatusLive do
   import AbuubaWeb.StatusComponent
 
   alias Abuuba.Accounts
+  alias Abuuba.Accounts.Account
   alias Abuuba.Federation.ResolveStatus
   alias Abuuba.Federation.Serializer
   alias Abuuba.Federation.URIs
@@ -276,7 +277,7 @@ defmodule AbuubaWeb.StatusLive do
 
   defp title(author, status) do
     gettext("%{name} on %{server}",
-      name: display_name(author),
+      name: Account.display_name(author),
       server: Abuuba.Instance.software_name()
     ) <> ": " <> String.slice(summary(status), 0, 60)
   end
@@ -292,9 +293,6 @@ defmodule AbuubaWeb.StatusLive do
   defp one_line(text) do
     text |> to_string() |> String.replace(~r/\s+/u, " ") |> String.trim()
   end
-
-  defp display_name(%{display_name: name}) when is_binary(name) and name != "", do: name
-  defp display_name(%{username: username}), do: username
 
   # Under this author, and visible to whoever is asking. Both checks are the
   # query's rather than an afterthought: one that cannot return the wrong row

--- a/lib/abuuba_web/live/status_live.ex
+++ b/lib/abuuba_web/live/status_live.ex
@@ -241,13 +241,11 @@ defmodule AbuubaWeb.StatusLive do
     |> assign(:robots, robots(author))
     |> assign(
       :page_meta,
-      [
-        {"property", "og:type", "article"},
-        {"property", "og:title", title(author, status)},
-        {"property", "og:description", summary},
-        {"property", "og:url", URIs.status_url(author, status.id)},
-        {"name", "description", summary}
-      ]
+      Meta.open_graph(
+        title: title(author, status),
+        description: summary,
+        url: URIs.status_url(author, status.id)
+      )
     )
     # What an editor fetches before it turns a pasted link into an embed.
     # Without the tag, nothing discovers the endpoint.

--- a/lib/abuuba_web/live/status_live.ex
+++ b/lib/abuuba_web/live/status_live.ex
@@ -177,7 +177,7 @@ defmodule AbuubaWeb.StatusLive do
   # inside the rendered post now rather than in an assign of this page's own,
   # which is what lets a list screen put a translated post back where it was.
   def handle_event("translate", %{"id" => id}, socket) do
-    case PostActions.translate(socket.assigns.viewer, id, locale(socket)) do
+    case PostActions.translate(socket.assigns.viewer, id, PostActions.locale(socket)) do
       {:ok, rendered} ->
         {:noreply, assign(socket, rendered: rendered)}
 
@@ -187,8 +187,6 @@ defmodule AbuubaWeb.StatusLive do
   end
 
   def handle_event(_event, _params, socket), do: {:noreply, socket}
-
-  defp locale(socket), do: socket.assigns[:locale] || Gettext.get_locale(AbuubaWeb.Gettext)
 
   @impl Phoenix.LiveView
   # The fetcher is injected rather than called directly, so a test can exercise
@@ -346,7 +344,4 @@ defmodule AbuubaWeb.StatusLive do
   # the one place where a direct link would otherwise walk around that.
   defp blocked?(_author, nil), do: false
   defp blocked?(author, viewer), do: Abuuba.Relationships.blocking?(author, viewer)
-
-  defp viewer_id(nil), do: nil
-  defp viewer_id(viewer), do: to_string(viewer.id)
 end

--- a/lib/abuuba_web/live/tag_live.ex
+++ b/lib/abuuba_web/live/tag_live.ex
@@ -88,7 +88,7 @@ defmodule AbuubaWeb.TagLive do
       Statuses.follow_tag(viewer, tag)
     end
 
-    {:noreply, load(socket)}
+    {:noreply, assign_following(socket)}
   end
 
   def handle_event("unfollow_tag", _params, socket) do
@@ -96,7 +96,7 @@ defmodule AbuubaWeb.TagLive do
       Statuses.unfollow_tag(viewer, tag)
     end
 
-    {:noreply, load(socket)}
+    {:noreply, assign_following(socket)}
   end
 
   # The action bar is drawn on this screen, so the events it raises are
@@ -163,6 +163,13 @@ defmodule AbuubaWeb.TagLive do
       posts: posts(socket.assigns.tag, viewer),
       following?: following?(viewer, socket.assigns.tag)
     )
+  end
+
+  # Following a tag changes the button and nothing else on the page, so the
+  # timeline is left where it is. Re-read rather than assumed because the
+  # follow above is inside a `with` that can decline to do anything.
+  defp assign_following(socket) do
+    assign(socket, following?: following?(socket.assigns.viewer, socket.assigns.tag))
   end
 
   defp posts(nil, _viewer), do: []

--- a/lib/abuuba_web/live/tag_live.ex
+++ b/lib/abuuba_web/live/tag_live.ex
@@ -27,9 +27,6 @@ defmodule AbuubaWeb.TagLive do
   alias AbuubaWeb.Meta
   alias AbuubaWeb.PostActions
 
-  # Answered here because the action bar is drawn here.
-  @post_actions PostActions.toggles()
-
   @page_size 20
 
   @impl Phoenix.LiveView
@@ -45,6 +42,7 @@ defmodule AbuubaWeb.TagLive do
        viewer: current_account(socket),
        tag: Statuses.get_tag(normalised)
      )
+     |> PostActions.attach(lists: [:posts])
      |> load()}
   end
 
@@ -99,61 +97,6 @@ defmodule AbuubaWeb.TagLive do
     {:noreply, assign_following(socket)}
   end
 
-  # The action bar is drawn on this screen, so the events it raises are
-  # answered here. See `AbuubaWeb.PostActions` for why the work behind them is
-  # one module rather than a copy per screen.
-  def handle_event(event, %{"id" => id}, socket) when event in @post_actions do
-    case PostActions.toggle(socket.assigns.viewer, event, id) do
-      {:ok, status} -> {:noreply, replace_post(socket, status)}
-      :error -> {:noreply, socket}
-    end
-  end
-
-  # The poll form is drawn by the same component as the action bar, so it is
-  # answered in the same place. See `AbuubaWeb.PostActions`.
-  def handle_event("vote", %{"poll_id" => poll_id} = params, socket) do
-    choices = params |> Map.get("choices", []) |> List.wrap()
-
-    case PostActions.vote(socket.assigns.viewer, poll_id, choices) do
-      {:ok, status} -> {:noreply, replace_post(socket, status)}
-      :error -> {:noreply, socket}
-    end
-  end
-
-  # There is no composer on this screen, so replying goes to the post, which
-  # has one. A box that appears on some screens and not others is worse than
-  # the same answer everywhere.
-  def handle_event("reply", %{"id" => id}, socket) do
-    case PostActions.page_of(socket.assigns.viewer, id) do
-      nil -> {:noreply, socket}
-      path -> {:noreply, push_navigate(socket, to: path)}
-    end
-  end
-
-  # The pencil is drawn by the same component as the rest of the bar, and the
-  # box to edit in is on the post's own page. Same answer as "reply" for the
-  # same reason: a composer that appears on some screens and not others is
-  # worse than the same answer everywhere.
-  def handle_event("edit", %{"id" => id}, socket) do
-    case PostActions.page_of(socket.assigns.viewer, id) do
-      nil -> {:noreply, socket}
-      path -> {:noreply, push_navigate(socket, to: path)}
-    end
-  end
-
-  # Drawn by the same component as the rest of the bar. A translation is not a
-  # change to the post, so it is put straight back into the list rather than
-  # re-read. See `AbuubaWeb.PostActions`.
-  def handle_event("translate", %{"id" => id}, socket) do
-    case PostActions.translate(socket.assigns.viewer, id, locale(socket)) do
-      {:ok, rendered} ->
-        {:noreply, update(socket, :posts, &PostActions.swap(&1, rendered))}
-
-      :error ->
-        {:noreply, put_flash(socket, :error, gettext("That could not be translated just now."))}
-    end
-  end
-
   def handle_event(_event, _params, socket), do: {:noreply, socket}
 
   defp load(socket) do
@@ -191,13 +134,4 @@ defmodule AbuubaWeb.TagLive do
 
   defp viewer_id(nil), do: nil
   defp viewer_id(viewer), do: to_string(viewer.id)
-
-  # Rendered the way this screen renders the rest of them, then swapped in.
-  defp replace_post(socket, status) do
-    rendered = Entities.status(status, socket.assigns.viewer)
-
-    update(socket, :posts, &PostActions.swap(&1, rendered))
-  end
-
-  defp locale(socket), do: socket.assigns[:locale] || Gettext.get_locale(AbuubaWeb.Gettext)
 end

--- a/lib/abuuba_web/live/tag_live.ex
+++ b/lib/abuuba_web/live/tag_live.ex
@@ -131,7 +131,4 @@ defmodule AbuubaWeb.TagLive do
   defp following?(nil, _tag), do: false
   defp following?(_viewer, nil), do: false
   defp following?(viewer, tag), do: Statuses.following_tag?(viewer, tag)
-
-  defp viewer_id(nil), do: nil
-  defp viewer_id(viewer), do: to_string(viewer.id)
 end

--- a/lib/abuuba_web/live/two_factor_settings_live.ex
+++ b/lib/abuuba_web/live/two_factor_settings_live.ex
@@ -9,7 +9,6 @@ defmodule AbuubaWeb.TwoFactorSettingsLive do
 
   use AbuubaWeb, :live_view
 
-  alias Abuuba.Accounts.RecoveryCode
   alias Abuuba.Accounts.TwoFactor
 
   @impl Phoenix.LiveView
@@ -158,7 +157,4 @@ defmodule AbuubaWeb.TwoFactorSettingsLive do
     </Layouts.app>
     """
   end
-
-  @doc false
-  def recovery_code_count, do: RecoveryCode.code_count()
 end

--- a/lib/abuuba_web/meta.ex
+++ b/lib/abuuba_web/meta.ex
@@ -23,4 +23,29 @@ defmodule AbuubaWeb.Meta do
   """
   @spec noindex() :: String.t()
   def noindex, do: "noindex, noarchive"
+
+  @doc """
+  What a page tells a link preview: the Open Graph tags plus the plain
+  description that goes with them.
+
+  The vocabulary was open-coded on each page that wanted it, which is the same
+  shape as the bug above and went the same way: `og:description` and the plain
+  `description` are one sentence written twice, and the annual report shipped
+  without `og:url` because nothing said the list had one.
+
+  `:url` is required for that reason. A preview with no canonical address is
+  the one thing a crawler cannot work out for itself.
+  """
+  @spec open_graph(keyword()) :: [{String.t(), String.t(), String.t()}]
+  def open_graph(opts) do
+    description = Keyword.get(opts, :description, "")
+
+    [
+      {"property", "og:type", Keyword.get(opts, :type, "article")},
+      {"property", "og:title", Keyword.fetch!(opts, :title)},
+      {"property", "og:description", description},
+      {"property", "og:url", Keyword.fetch!(opts, :url)},
+      {"name", "description", description}
+    ]
+  end
 end

--- a/lib/abuuba_web/params.ex
+++ b/lib/abuuba_web/params.ex
@@ -1,0 +1,61 @@
+defmodule AbuubaWeb.Params do
+  @moduledoc """
+  Turning what a browser sent into something safe to look up.
+
+  Every screen that answers `phx-value-id` had its own copy of this, and the
+  copies did not agree: four modules defined a private `numeric/1` and three a
+  private `to_integer/1`, in two spellings with opposite strictness, so which
+  one a reader was looking at depended on which file they had open.
+
+  The two here are deliberately different from each other, and the names say
+  which is which rather than leaving it to be read out of the bodies.
+  """
+
+  # Postgres `bigint`. A larger number is not a row that is missing, it is a
+  # value the column cannot hold, and handing it to Ecto raises instead of
+  # answering nothing.
+  @max_id 9_223_372_036_854_775_807
+
+  @doc """
+  A database id, or `nil`.
+
+  Strict on purpose. The whole string has to be the number, so `"12abc"` is a
+  miss rather than row twelve, and it has to fit in a `bigint`, because an id
+  past that range reaches the database as an error rather than as a lookup
+  that finds nothing. Negative is refused for the same reason it is never
+  minted.
+
+  `nil` for anything else, which callers read as "no such row" — the same
+  answer they would get for an id that simply is not there.
+  """
+  @spec id(term()) :: {:ok, non_neg_integer()} | nil
+  def id(value) when is_integer(value) and value >= 0 and value <= @max_id, do: {:ok, value}
+
+  def id(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {number, ""} when number >= 0 and number <= @max_id -> {:ok, number}
+      _not_an_id -> nil
+    end
+  end
+
+  def id(_value), do: nil
+
+  @doc """
+  A whole number from a form field, falling back to zero.
+
+  Lenient on purpose, and not for ids: this reads the counters and offsets a
+  form sends, where a trailing unit or an empty box should mean zero rather
+  than an error on screen. Use `id/1` for anything that becomes a row.
+  """
+  @spec to_integer(term()) :: integer()
+  def to_integer(value) when is_integer(value), do: value
+
+  def to_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {number, _rest} -> number
+      :error -> 0
+    end
+  end
+
+  def to_integer(_value), do: 0
+end

--- a/lib/abuuba_web/params.ex
+++ b/lib/abuuba_web/params.ex
@@ -2,50 +2,26 @@ defmodule AbuubaWeb.Params do
   @moduledoc """
   Turning what a browser sent into something safe to look up.
 
-  Every screen that answers `phx-value-id` had its own copy of this, and the
-  copies did not agree: four modules defined a private `numeric/1` and three a
-  private `to_integer/1`, in two spellings with opposite strictness, so which
-  one a reader was looking at depended on which file they had open.
+  Three modules had their own private `to_integer/1` for reading a form field,
+  in one spelling, so this is where that lives now.
 
-  The two here are deliberately different from each other, and the names say
-  which is which rather than leaving it to be read out of the bodies.
+  There is deliberately no `id/1` here. Ids go through
+  `Abuuba.Snowflake.cast/1`, which is the id type itself and is stricter than
+  anything worth writing twice: it takes only the canonical spelling, so one
+  row cannot be addressed by `"7"`, `"+7"` and `"007"` alike when clients treat
+  those strings as cache keys; it bounds the value to what a `bigint` column
+  can hold, so a huge id in a URL is a miss rather than a Postgrex encode
+  error; and it keeps the reserved negative range reachable from our own code
+  for the actors abuuba creates for itself.
   """
-
-  # Postgres `bigint`. A larger number is not a row that is missing, it is a
-  # value the column cannot hold, and handing it to Ecto raises instead of
-  # answering nothing.
-  @max_id 9_223_372_036_854_775_807
-
-  @doc """
-  A database id, or `nil`.
-
-  Strict on purpose. The whole string has to be the number, so `"12abc"` is a
-  miss rather than row twelve, and it has to fit in a `bigint`, because an id
-  past that range reaches the database as an error rather than as a lookup
-  that finds nothing. Negative is refused for the same reason it is never
-  minted.
-
-  `nil` for anything else, which callers read as "no such row" — the same
-  answer they would get for an id that simply is not there.
-  """
-  @spec id(term()) :: {:ok, non_neg_integer()} | nil
-  def id(value) when is_integer(value) and value >= 0 and value <= @max_id, do: {:ok, value}
-
-  def id(value) when is_binary(value) do
-    case Integer.parse(value) do
-      {number, ""} when number >= 0 and number <= @max_id -> {:ok, number}
-      _not_an_id -> nil
-    end
-  end
-
-  def id(_value), do: nil
 
   @doc """
   A whole number from a form field, falling back to zero.
 
   Lenient on purpose, and not for ids: this reads the counters and offsets a
   form sends, where a trailing unit or an empty box should mean zero rather
-  than an error on screen. Use `id/1` for anything that becomes a row.
+  than an error on screen. Use `Abuuba.Snowflake.cast/1` for anything that
+  becomes a row.
   """
   @spec to_integer(term()) :: integer()
   def to_integer(value) when is_integer(value), do: value

--- a/lib/abuuba_web/registration_words.ex
+++ b/lib/abuuba_web/registration_words.ex
@@ -1,0 +1,32 @@
+defmodule AbuubaWeb.RegistrationWords do
+  @moduledoc """
+  Whether somebody may sign up here, in a sentence.
+
+  Shared by the two screens that say it: the front page a stranger arrives on,
+  and the about page they click through to for the detail. The same server
+  cannot describe its own door two ways, and it did — the wording lived twice,
+  so editing one left the other saying the old thing with nothing to notice it.
+
+  Follows `AbuubaWeb.ScopeWords` for the same reason it exists.
+  """
+
+  use Gettext, backend: AbuubaWeb.Gettext
+
+  @doc """
+  One registration mode, as a sentence.
+
+  Anything without a wording answers with an empty string: a mode added without
+  a line here should leave the paragraph out rather than draw an empty promise
+  about who may join.
+  """
+  @spec note(atom()) :: String.t()
+  def note(:open), do: gettext("Registration is open: anybody may sign up.")
+
+  def note(:approved),
+    do: gettext("Registration needs approval: you sign up and an admin reads your request.")
+
+  def note(:closed),
+    do: gettext("Registration is closed here, but any other server on the network will do.")
+
+  def note(_mode), do: ""
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.0",
+      version: "1.0.1",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -51,7 +51,7 @@ msgid "Change"
 msgstr "Ändern"
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:736
+#: lib/abuuba_web/live/compose_component.ex:723
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr "Sprache"
@@ -403,13 +403,13 @@ msgstr "Dieser Code stimmt nicht. Nimm den nächsten."
 msgid "This is the only time they are shown. Each one works once, and they are how you get back in if you lose your phone."
 msgstr "Sie werden nur dieses eine Mal angezeigt. Jeder funktioniert einmal, und damit kommst du wieder hinein, wenn du dein Telefon verlierst."
 
-#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/admin_live.ex:549
 #: lib/abuuba_web/live/two_factor_settings_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Turn it off"
 msgstr "Ausschalten"
 
-#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/admin_live.ex:549
 #: lib/abuuba_web/live/two_factor_settings_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Turn it on"
@@ -455,7 +455,7 @@ msgstr "Deine alten Wiederherstellungscodes funktionieren nicht mehr."
 msgid "Act as a moderator (%{scope})"
 msgstr "Als Moderator handeln (%{scope})"
 
-#: lib/abuuba_web/live/admin_live.ex:1051
+#: lib/abuuba_web/live/admin_live.ex:1064
 #: lib/abuuba_web/live/authorize_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Allow"
@@ -466,10 +466,10 @@ msgstr "Erlauben"
 msgid "Authorize %{app}"
 msgstr "%{app} autorisieren"
 
-#: lib/abuuba_web/live/admin_live.ex:1741
+#: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
+#: lib/abuuba_web/live/compose_component.ex:397
 #: lib/abuuba_web/live/compose_component.ex:410
-#: lib/abuuba_web/live/compose_component.ex:423
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -664,7 +664,7 @@ msgstr "Entdecken"
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
 #: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2310
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
@@ -691,7 +691,7 @@ msgstr "Hauptnavigation"
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr "Mitteilungen"
@@ -763,7 +763,7 @@ msgid "Follow some people and their posts will appear here."
 msgstr "Folge ein paar Menschen, dann erscheinen ihre Beiträge hier."
 
 #: lib/abuuba_web/components/status_component.ex:267
-#: lib/abuuba_web/live/compose_component.ex:616
+#: lib/abuuba_web/live/compose_component.ex:603
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Umfrage"
@@ -793,303 +793,303 @@ msgstr "Du bist am Ende angekommen."
 msgid "Your choice"
 msgstr "Deine Wahl"
 
-#: lib/abuuba_web/live/compose_component.ex:1679
+#: lib/abuuba_web/live/compose_component.ex:1666
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr "1 Tag"
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1664
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr "1 Stunde"
 
-#: lib/abuuba_web/live/compose_component.ex:1680
+#: lib/abuuba_web/live/compose_component.ex:1667
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr "3 Tage"
 
-#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/compose_component.ex:1663
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr "30 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/compose_component.ex:1662
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr "5 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1678
+#: lib/abuuba_web/live/compose_component.ex:1665
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr "6 Stunden"
 
-#: lib/abuuba_web/live/compose_component.ex:1681
+#: lib/abuuba_web/live/compose_component.ex:1668
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr "7 Tage"
 
-#: lib/abuuba_web/live/compose_component.ex:1156
+#: lib/abuuba_web/live/compose_component.ex:1141
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr "Eine Umfrage braucht mindestens zwei Antworten."
 
-#: lib/abuuba_web/live/compose_component.ex:651
+#: lib/abuuba_web/live/compose_component.ex:638
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr "Antwort hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:722
+#: lib/abuuba_web/live/compose_component.ex:709
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr "Umfrage hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:663
+#: lib/abuuba_web/live/compose_component.ex:650
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr "Mehrfachauswahl erlauben"
 
-#: lib/abuuba_web/live/compose_component.ex:1696
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/settings_live.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr "Alle"
 
-#: lib/abuuba_web/live/compose_component.ex:1687
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/compose_component.ex:1674
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr "Alle, und überall gelistet"
 
-#: lib/abuuba_web/live/compose_component.ex:1688
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr "Alle, aber nicht in öffentlichen Timelines"
 
-#: lib/abuuba_web/live/compose_component.ex:627
+#: lib/abuuba_web/live/compose_component.ex:614
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr "Antwort %{number}"
 
-#: lib/abuuba_web/live/compose_component.ex:451
-#: lib/abuuba_web/live/compose_component.ex:712
+#: lib/abuuba_web/live/compose_component.ex:438
+#: lib/abuuba_web/live/compose_component.ex:699
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/abuuba_web/live/compose_component.ex:813
+#: lib/abuuba_web/live/compose_component.ex:800
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr "Strg + Enter veröffentlicht"
 
-#: lib/abuuba_web/live/compose_component.ex:446
+#: lib/abuuba_web/live/compose_component.ex:433
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr "Diese Person nicht mit anschreiben"
 
 #: lib/abuuba_web/components/status_component.ex:432
-#: lib/abuuba_web/live/admin_live.ex:1761
+#: lib/abuuba_web/live/admin_live.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/abuuba_web/live/compose_component.ex:416
+#: lib/abuuba_web/live/compose_component.ex:403
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/abuuba_web/live/compose_component.ex:667
+#: lib/abuuba_web/live/compose_component.ex:654
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr "Endet nach"
 
-#: lib/abuuba_web/live/compose_component.ex:1689
+#: lib/abuuba_web/live/compose_component.ex:1676
 #: lib/abuuba_web/live/profile_live.ex:837
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1677
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr "Erwähnte Personen"
 
-#: lib/abuuba_web/live/admin_live.ex:3413
-#: lib/abuuba_web/live/compose_component.ex:1698
-#: lib/abuuba_web/live/settings_live.ex:2295
+#: lib/abuuba_web/live/admin_live.ex:3428
+#: lib/abuuba_web/live/compose_component.ex:1685
+#: lib/abuuba_web/live/settings_live.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr "Niemand"
 
-#: lib/abuuba_web/live/compose_component.ex:1689
-#: lib/abuuba_web/live/settings_live.ex:2290
+#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr "Nur die Leute, die dir folgen"
 
-#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1677
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr "Nur die Leute, die du nennst"
 
-#: lib/abuuba_web/live/compose_component.ex:1697
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/compose_component.ex:1684
+#: lib/abuuba_web/live/settings_live.ex:2306
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr "Leute, die dir folgen"
 
-#: lib/abuuba_web/live/compose_component.ex:1456
+#: lib/abuuba_web/live/compose_component.ex:1441
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/compose_component.ex:696
+#: lib/abuuba_web/live/compose_component.ex:683
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/abuuba_web/live/compose_component.ex:1687
-#: lib/abuuba_web/live/compose_component.ex:1705
+#: lib/abuuba_web/live/compose_component.ex:1674
+#: lib/abuuba_web/live/compose_component.ex:1692
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/abuuba_web/live/compose_component.ex:1688
+#: lib/abuuba_web/live/compose_component.ex:1675
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr "Still öffentlich"
 
-#: lib/abuuba_web/live/compose_component.ex:732
+#: lib/abuuba_web/live/compose_component.ex:719
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr "Umfrage entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:639
+#: lib/abuuba_web/live/compose_component.ex:626
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr "Diese Antwort entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:403
+#: lib/abuuba_web/live/compose_component.ex:390
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr "Antwort an %{name}"
 
-#: lib/abuuba_web/live/compose_component.ex:1454
+#: lib/abuuba_web/live/compose_component.ex:1439
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/abuuba_web/live/admin_live.ex:3374
-#: lib/abuuba_web/live/compose_component.ex:478
+#: lib/abuuba_web/live/admin_live.ex:3389
+#: lib/abuuba_web/live/compose_component.ex:465
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr "Vorschläge"
 
-#: lib/abuuba_web/live/compose_component.ex:1118
+#: lib/abuuba_web/live/compose_component.ex:1103
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr "Das ist %{count} Zeichen zu lang."
 
-#: lib/abuuba_web/live/compose_component.ex:1180
-#: lib/abuuba_web/live/compose_component.ex:1215
-#: lib/abuuba_web/live/compose_component.ex:1410
+#: lib/abuuba_web/live/compose_component.ex:1165
+#: lib/abuuba_web/live/compose_component.ex:1200
+#: lib/abuuba_web/live/compose_component.ex:1395
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr "Der Beitrag konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/compose_component.ex:462
-#: lib/abuuba_web/live/compose_component.ex:468
+#: lib/abuuba_web/live/compose_component.ex:449
+#: lib/abuuba_web/live/compose_component.ex:455
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr "Was beschäftigt dich?"
 
-#: lib/abuuba_web/live/compose_component.ex:456
+#: lib/abuuba_web/live/compose_component.ex:443
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr "Wovor sollen die Leute gewarnt werden?"
 
-#: lib/abuuba_web/live/compose_component.ex:772
+#: lib/abuuba_web/live/compose_component.ex:759
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr "Wer das zitieren darf"
 
-#: lib/abuuba_web/live/compose_component.ex:752
+#: lib/abuuba_web/live/compose_component.ex:739
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr "Wer das sehen darf"
 
-#: lib/abuuba_web/live/compose_component.ex:1114
+#: lib/abuuba_web/live/compose_component.ex:1099
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr "Schreib erst mal etwas."
 
-#: lib/abuuba_web/live/compose_component.ex:1212
+#: lib/abuuba_web/live/compose_component.ex:1197
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr "Du hast gerade viel veröffentlicht. Versuch es später noch einmal."
 
-#: lib/abuuba_web/live/compose_component.ex:1652
+#: lib/abuuba_web/live/compose_component.ex:1635
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr "jemanden"
 
-#: lib/abuuba_web/live/compose_component.ex:819
+#: lib/abuuba_web/live/compose_component.ex:806
 #, elixir-autogen, elixir-format
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] "%{count} Entwurf"
 msgstr[1] "%{count} Entwürfe"
 
-#: lib/abuuba_web/live/compose_component.ex:851
+#: lib/abuuba_web/live/compose_component.ex:838
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] "%{count} Beitrag wartet auf den Versand"
 msgstr[1] "%{count} Beiträge warten auf den Versand"
 
-#: lib/abuuba_web/live/compose_component.ex:1160
+#: lib/abuuba_web/live/compose_component.ex:1145
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr "Eine Antwort ist zu lang. Halte jede unter %{count} Zeichen."
 
-#: lib/abuuba_web/live/compose_component.ex:882
+#: lib/abuuba_web/live/compose_component.ex:869
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr "Absagen"
 
-#: lib/abuuba_web/live/compose_component.ex:843
+#: lib/abuuba_web/live/compose_component.ex:830
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: lib/abuuba_web/live/compose_component.ex:682
+#: lib/abuuba_web/live/compose_component.ex:669
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr "Geht raus am"
 
-#: lib/abuuba_web/live/compose_component.ex:833
-#: lib/abuuba_web/live/compose_component.ex:872
+#: lib/abuuba_web/live/compose_component.ex:820
+#: lib/abuuba_web/live/compose_component.ex:859
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr "Öffnen"
 
-#: lib/abuuba_web/live/compose_component.ex:1131
-#: lib/abuuba_web/live/compose_component.ex:1401
+#: lib/abuuba_web/live/compose_component.ex:1116
+#: lib/abuuba_web/live/compose_component.ex:1386
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr "Sag, wann der Beitrag rausgehen soll."
 
-#: lib/abuuba_web/live/compose_component.ex:804
+#: lib/abuuba_web/live/compose_component.ex:791
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr "Planen"
 
-#: lib/abuuba_web/live/compose_component.ex:1455
+#: lib/abuuba_web/live/compose_component.ex:1440
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr "Einplanen"
 
-#: lib/abuuba_web/live/compose_component.ex:317
+#: lib/abuuba_web/live/compose_component.ex:304
 #, elixir-autogen, elixir-format
 msgid "That draft could not be saved."
 msgstr "Der Entwurf konnte nicht gespeichert werden."
@@ -1099,104 +1099,104 @@ msgstr "Der Entwurf konnte nicht gespeichert werden."
 msgid "That post is scheduled."
 msgstr "Der Beitrag ist eingeplant."
 
-#: lib/abuuba_web/live/compose_component.ex:1165
+#: lib/abuuba_web/live/compose_component.ex:1150
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr "Zwei Antworten sind gleich. Mach sie unterschiedlich."
 
-#: lib/abuuba_web/live/compose_component.ex:313
+#: lib/abuuba_web/live/compose_component.ex:300
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr "Du hast zu viele Entwürfe für einen weiteren. Verwirf erst einen."
 
-#: lib/abuuba_web/live/compose_component.ex:1449
+#: lib/abuuba_web/live/compose_component.ex:1434
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr "ein leerer Beitrag"
 
-#: lib/abuuba_web/live/compose_component.ex:689
+#: lib/abuuba_web/live/compose_component.ex:676
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr "deine eigene Zeit, mindestens %{count} Minuten ab jetzt"
 
-#: lib/abuuba_web/live/compose_component.ex:1128
+#: lib/abuuba_web/live/compose_component.ex:1113
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr "Ein Bild geht ohne Beschreibung raus. Schick noch einmal ab, um es trotzdem zu veröffentlichen."
 
-#: lib/abuuba_web/live/compose_component.ex:497
+#: lib/abuuba_web/live/compose_component.ex:484
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr "Bild, Video oder Ton hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:592
+#: lib/abuuba_web/live/compose_component.ex:579
 #, elixir-autogen, elixir-format
 msgid "Add a still"
 msgstr "Standbild hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:542
+#: lib/abuuba_web/live/compose_component.ex:529
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr "Klick auf den wichtigsten Teil"
 
-#: lib/abuuba_web/live/compose_component.ex:559
-#: lib/abuuba_web/live/compose_component.ex:567
+#: lib/abuuba_web/live/compose_component.ex:546
+#: lib/abuuba_web/live/compose_component.ex:554
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr "Beschreibe das für Leute, die es nicht sehen können"
 
-#: lib/abuuba_web/live/compose_component.ex:581
+#: lib/abuuba_web/live/compose_component.ex:568
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr "Nach vorne"
 
-#: lib/abuuba_web/live/compose_component.ex:596
+#: lib/abuuba_web/live/compose_component.ex:583
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr "Standbild auswählen"
 
-#: lib/abuuba_web/live/compose_component.ex:554
+#: lib/abuuba_web/live/compose_component.ex:541
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr "Bildmittelpunkt festlegen"
 
-#: lib/abuuba_web/live/compose_component.ex:522
+#: lib/abuuba_web/live/compose_component.ex:509
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr "Abbrechen"
 
-#: lib/abuuba_web/live/compose_component.ex:607
+#: lib/abuuba_web/live/compose_component.ex:594
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:252
-#: lib/abuuba_web/live/compose_component.ex:1445
+#: lib/abuuba_web/live/compose_component.ex:239
+#: lib/abuuba_web/live/compose_component.ex:1430
 #, elixir-autogen, elixir-format
 msgid "That file could not be uploaded."
 msgstr "Die Datei konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/compose_component.ex:1442
+#: lib/abuuba_web/live/compose_component.ex:1427
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/compose_component.ex:239
+#: lib/abuuba_web/live/compose_component.ex:226
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr "Mehr als %{count} Bilder trägt ein Beitrag nicht."
 
-#: lib/abuuba_web/live/compose_component.ex:1443
+#: lib/abuuba_web/live/compose_component.ex:1428
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr "Das sind mehr Dateien, als ein Beitrag tragen kann."
 
-#: lib/abuuba_web/live/compose_component.ex:1444
+#: lib/abuuba_web/live/compose_component.ex:1429
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr "Dieser Server nimmt keine Dateien dieser Art."
 
-#: lib/abuuba_web/live/compose_component.ex:501
+#: lib/abuuba_web/live/compose_component.ex:488
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr "oder zieh eine ins Feld oder füg sie ein"
@@ -1268,7 +1268,7 @@ msgstr "Beiträge"
 msgid "Posts and replies"
 msgstr "Beiträge und Antworten"
 
-#: lib/abuuba_web/live/admin_live.ex:931
+#: lib/abuuba_web/live/admin_live.ex:944
 #: lib/abuuba_web/live/profile_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Save the note"
@@ -1506,7 +1506,7 @@ msgstr "Folgeanfragen"
 #: lib/abuuba_web/live/notifications_live.ex:440
 #: lib/abuuba_web/live/profile_live.ex:838
 #: lib/abuuba_web/live/settings_live.ex:2103
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folge ich"
@@ -1567,11 +1567,11 @@ msgstr "Umfragen"
 msgid "Private mentions out of nowhere"
 msgstr "Private Erwähnungen aus dem Nichts"
 
-#: lib/abuuba_web/live/admin_live.ex:1010
-#: lib/abuuba_web/live/admin_live.ex:1018
-#: lib/abuuba_web/live/admin_live.ex:1121
-#: lib/abuuba_web/live/admin_live.ex:1574
-#: lib/abuuba_web/live/admin_live.ex:2150
+#: lib/abuuba_web/live/admin_live.ex:1023
+#: lib/abuuba_web/live/admin_live.ex:1031
+#: lib/abuuba_web/live/admin_live.ex:1134
+#: lib/abuuba_web/live/admin_live.ex:1587
+#: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
 #: lib/abuuba_web/live/profile_live.ex:255
 #: lib/abuuba_web/live/settings_live.ex:294
@@ -1586,7 +1586,7 @@ msgstr "Private Erwähnungen aus dem Nichts"
 msgid "Save"
 msgstr "Speichern"
 
-#: lib/abuuba_web/live/admin_live.ex:238
+#: lib/abuuba_web/live/admin_live.ex:245
 #: lib/abuuba_web/live/notification_settings_live.ex:54
 #: lib/abuuba_web/live/settings_live.ex:136
 #, elixir-autogen, elixir-format
@@ -1640,8 +1640,8 @@ msgstr "ungelesen"
 msgid "A name, a #tag, or some words"
 msgstr "Ein Name, ein #Tag oder ein paar Wörter"
 
-#: lib/abuuba_web/live/admin_live.ex:2263
-#: lib/abuuba_web/live/admin_live.ex:3572
+#: lib/abuuba_web/live/admin_live.ex:2277
+#: lib/abuuba_web/live/admin_live.ex:3587
 #: lib/abuuba_web/live/search_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Everything"
@@ -1767,7 +1767,7 @@ msgstr "Ein neues Passwort"
 msgid "About you"
 msgstr "Über dich"
 
-#: lib/abuuba_web/live/admin_live.ex:3364
+#: lib/abuuba_web/live/admin_live.ex:3379
 #: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Account"
@@ -1788,7 +1788,7 @@ msgstr "Filter hinzufügen"
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr "Gilt nur für deine öffentlichen Beiträge."
@@ -1808,7 +1808,7 @@ msgstr "Apps, die in dein Konto gelassen wurden."
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr "Apps, bei denen du angemeldet bist. Eine wieder hinauszunehmen meldet sie sofort ab."
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr "Vor jedem Follow fragen"
@@ -1818,7 +1818,7 @@ msgstr "Vor jedem Follow fragen"
 msgid "Change the password"
 msgstr "Passwort ändern"
 
-#: lib/abuuba_web/live/admin_live.ex:985
+#: lib/abuuba_web/live/admin_live.ex:998
 #: lib/abuuba_web/live/settings_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Delete"
@@ -1829,7 +1829,7 @@ msgstr "Löschen"
 msgid "Display name"
 msgstr "Anzeigename"
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr "Medien nicht von selbst abspielen"
@@ -1839,7 +1839,7 @@ msgstr "Medien nicht von selbst abspielen"
 msgid "Each line has to be a web address, one per line."
 msgstr "Jede Zeile muss eine Webadresse sein, eine pro Zeile."
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr "Jeder Follow wird zu einer Anfrage, die du beantwortest."
@@ -1860,27 +1860,27 @@ msgid "Fields"
 msgstr "Felder"
 
 #: lib/abuuba_web/live/settings_live.ex:2102
-#: lib/abuuba_web/live/settings_live.ex:2235
+#: lib/abuuba_web/live/settings_live.ex:2247
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/abuuba_web/live/settings_live.ex:2317
+#: lib/abuuba_web/live/settings_live.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr "Hinter einer Warnung zusammenklappen"
 
-#: lib/abuuba_web/live/settings_live.ex:2318
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr "Ganz ausblenden"
 
-#: lib/abuuba_web/live/settings_live.ex:2266
+#: lib/abuuba_web/live/settings_live.ex:2278
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr "Verbergen, wem ich folge und wer mir folgt"
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr "Mehr Kontrast"
@@ -1895,17 +1895,17 @@ msgstr "Wie sich die Oberfläche verhält und liest."
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr "Suchmaschinen meine Beiträge indexieren lassen"
 
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr "Mich im Verzeichnis listen"
 
-#: lib/abuuba_web/live/settings_live.ex:2269
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr "Markiert das Konto als Bot, worauf manche Leute filtern."
@@ -1935,7 +1935,7 @@ msgstr "Nur die genannten Leute fehlt mit Absicht: als Voreinstellung wird jeder
 msgid "Other accounts of yours, and moving between them."
 msgstr "Deine anderen Konten und der Umzug zwischen ihnen."
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr "Überschreibt deine Systemeinstellung, wenn sie für dich falsch ist."
@@ -1960,26 +1960,26 @@ msgstr "Privatsphäre"
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/abuuba_web/live/settings_live.ex:2302
+#: lib/abuuba_web/live/settings_live.ex:2314
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr "Öffentliche Timelines"
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2285
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr "Bewegung reduzieren"
 
-#: lib/abuuba_web/live/admin_live.ex:546
-#: lib/abuuba_web/live/admin_live.ex:1656
-#: lib/abuuba_web/live/admin_live.ex:1772
-#: lib/abuuba_web/live/admin_live.ex:1864
-#: lib/abuuba_web/live/admin_live.ex:2188
+#: lib/abuuba_web/live/admin_live.ex:559
+#: lib/abuuba_web/live/admin_live.ex:1669
+#: lib/abuuba_web/live/admin_live.ex:1786
+#: lib/abuuba_web/live/admin_live.ex:1878
+#: lib/abuuba_web/live/admin_live.ex:2202
 #: lib/abuuba_web/live/conversations_live.ex:112
 #: lib/abuuba_web/live/settings_live.ex:280
 #: lib/abuuba_web/live/settings_live.ex:315
@@ -2002,7 +2002,7 @@ msgstr "Überall abmelden"
 msgid "Signing out everywhere ends every session, including this one."
 msgstr "Überall abmelden beendet jede Sitzung, auch diese."
 
-#: lib/abuuba_web/live/settings_live.ex:2284
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr "Hält das erste Absenden an, wenn ein Bild keine Beschreibung hat."
@@ -2012,7 +2012,7 @@ msgstr "Hält das erste Absenden an, wenn ein Bild keine Beschreibung hat."
 msgid "Take it back out"
 msgstr "Wieder hinausnehmen"
 
-#: lib/abuuba_web/live/admin_live.ex:3735
+#: lib/abuuba_web/live/admin_live.ex:3750
 #: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
@@ -2028,17 +2028,17 @@ msgstr "Das aktuelle Passwort stimmt nicht."
 msgid "The language you usually write in"
 msgstr "Die Sprache, in der du meistens schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:2267
+#: lib/abuuba_web/live/settings_live.ex:2279
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr "Die Listen sind nicht mehr öffentlich; die Follows selbst funktionieren weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:2268
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr "Dieses Konto veröffentlicht automatisch"
 
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr "Threads"
@@ -2058,7 +2058,7 @@ msgstr "Den angehakten entfolgen"
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr "Bis zu vier Zeilen auf deinem Profil. Die Reihenfolge hier ist die Reihenfolge dort."
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr "Die Schrift meines Systems verwenden"
@@ -2068,7 +2068,7 @@ msgstr "Die Schrift meines Systems verwenden"
 msgid "Value"
 msgstr "Wert"
 
-#: lib/abuuba_web/live/settings_live.ex:2277
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr "Mich auf fehlende Beschreibungen hinweisen"
@@ -2083,7 +2083,7 @@ msgstr "Was er tut"
 msgid "What the compose box starts with."
 msgstr "Womit das Schreibfeld beginnt."
 
-#: lib/abuuba_web/live/admin_live.ex:2164
+#: lib/abuuba_web/live/admin_live.ex:2178
 #: lib/abuuba_web/live/settings_live.ex:761
 #, elixir-autogen, elixir-format
 msgid "What to call it"
@@ -2119,7 +2119,7 @@ msgstr "Wörter und Wendungen, die du lieber nicht siehst."
 msgid "You are not following anybody yet."
 msgstr "Du folgst noch niemandem."
 
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr "Dein Konto erscheint auf der öffentlichen Verzeichnisseite dieses Servers."
@@ -2155,7 +2155,7 @@ msgid "A server on the fediverse, running %{software}."
 msgstr "Ein Server im Fediverse, betrieben mit %{software}."
 
 #: lib/abuuba_web/live/about_live.ex:24
-#: lib/abuuba_web/live/admin_live.ex:621
+#: lib/abuuba_web/live/admin_live.ex:634
 #: lib/abuuba_web/live/document_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "About"
@@ -2187,7 +2187,7 @@ msgid "No password is asked for and nothing is done on your behalf: you are simp
 msgstr "Es wird kein Passwort abgefragt und nichts in deinem Namen getan: du wirst nur zur Suche deines eigenen Servers geschickt, mit dieser Adresse eingetragen."
 
 #: lib/abuuba_web/live/about_live.ex:93
-#: lib/abuuba_web/live/admin_live.ex:1946
+#: lib/abuuba_web/live/admin_live.ex:1960
 #: lib/abuuba_web/live/document_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
@@ -2224,7 +2224,7 @@ msgid "Take me to my server"
 msgstr "Bring mich zu meinem Server"
 
 #: lib/abuuba_web/live/about_live.ex:92
-#: lib/abuuba_web/live/admin_live.ex:2193
+#: lib/abuuba_web/live/admin_live.ex:2207
 #: lib/abuuba_web/live/document_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
@@ -2403,427 +2403,427 @@ msgstr "Verbindungen, die dich die Entscheidungen dieses Servers gekostet haben"
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr "Wenn dieser Server die Verbindung zu einem anderen abbricht, gehen die Folgebeziehungen zwischen dir und den Leuten dort verloren. Von hier aus lassen sie sich nicht wiederherstellen, weil die andere Seite nicht mehr erreichbar ist."
 
-#: lib/abuuba_web/live/admin_live.ex:2248
+#: lib/abuuba_web/live/admin_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "A new rule"
 msgstr "Eine neue Regel"
 
-#: lib/abuuba_web/live/admin_live.ex:2833
+#: lib/abuuba_web/live/admin_live.ex:2847
 #, elixir-autogen, elixir-format
 msgid "A rule needs some text."
 msgstr "Eine Regel braucht einen Text."
 
-#: lib/abuuba_web/live/admin_live.ex:3363
+#: lib/abuuba_web/live/admin_live.ex:3378
 #, elixir-autogen, elixir-format
 msgid "Accounts"
 msgstr "Konten"
 
-#: lib/abuuba_web/live/admin_live.ex:1603
-#: lib/abuuba_web/live/admin_live.ex:1821
-#: lib/abuuba_web/live/admin_live.ex:2251
+#: lib/abuuba_web/live/admin_live.ex:1616
+#: lib/abuuba_web/live/admin_live.ex:1835
+#: lib/abuuba_web/live/admin_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/abuuba_web/live/admin_live.ex:1991
+#: lib/abuuba_web/live/admin_live.ex:2005
 #, elixir-autogen, elixir-format
 msgid "Address people can write to"
 msgstr "Adresse, an die man schreiben kann"
 
-#: lib/abuuba_web/live/admin_live.ex:221
-#: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/admin_live.ex:228
+#: lib/abuuba_web/live/admin_live.ex:3396
 #, elixir-autogen, elixir-format
 msgid "Administration"
 msgstr "Verwaltung"
 
-#: lib/abuuba_web/live/admin_live.ex:3718
+#: lib/abuuba_web/live/admin_live.ex:3733
 #, elixir-autogen, elixir-format
 msgid "An open server left unattended fills with spam registrations within days. Put sign-ups behind approval unless somebody is watching."
 msgstr "Ein offener Server ohne Aufsicht füllt sich innerhalb von Tagen mit Spam-Anmeldungen. Stell Anmeldungen auf Freigabe um, solange niemand mitliest."
 
-#: lib/abuuba_web/live/admin_live.ex:739
+#: lib/abuuba_web/live/admin_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "Any state"
 msgstr "Beliebiger Zustand"
 
-#: lib/abuuba_web/live/admin_live.ex:3703
+#: lib/abuuba_web/live/admin_live.ex:3718
 #, elixir-autogen, elixir-format
 msgid "Anybody may sign up without being checked"
 msgstr "Jede und jeder kann sich ungeprüft anmelden"
 
-#: lib/abuuba_web/live/admin_live.ex:3412
+#: lib/abuuba_web/live/admin_live.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Anybody, after somebody here says yes"
 msgstr "Alle, nachdem jemand hier zustimmt"
 
-#: lib/abuuba_web/live/admin_live.ex:3411
+#: lib/abuuba_web/live/admin_live.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Anybody, straight away"
 msgstr "Alle, sofort"
 
-#: lib/abuuba_web/live/admin_live.ex:732
+#: lib/abuuba_web/live/admin_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "Anywhere"
 msgstr "Überall"
 
-#: lib/abuuba_web/live/admin_live.ex:377
-#: lib/abuuba_web/live/admin_live.ex:381
+#: lib/abuuba_web/live/admin_live.ex:390
+#: lib/abuuba_web/live/admin_live.ex:394
 #, elixir-autogen, elixir-format
 msgid "Appeals waiting"
 msgstr "Offene Einsprüche"
 
-#: lib/abuuba_web/live/admin_live.ex:3380
+#: lib/abuuba_web/live/admin_live.ex:3395
 #, elixir-autogen, elixir-format
 msgid "Audit log"
 msgstr "Protokoll"
 
-#: lib/abuuba_web/live/admin_live.ex:1021
+#: lib/abuuba_web/live/admin_live.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Change an address only when somebody cannot reach their own."
 msgstr "Ändere eine Adresse nur, wenn jemand die eigene nicht mehr erreicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3362
+#: lib/abuuba_web/live/admin_live.ex:3377
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr "Übersicht"
 
-#: lib/abuuba_web/live/admin_live.ex:2867
+#: lib/abuuba_web/live/admin_live.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Deleting posts needs the posts named, which this page cannot do yet."
 msgstr "Beiträge zu löschen setzt voraus, dass die Beiträge benannt sind. Das kann diese Seite noch nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3422
+#: lib/abuuba_web/live/admin_live.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Disable: they cannot sign in"
 msgstr "Deaktivieren: Anmeldung nicht mehr möglich"
 
-#: lib/abuuba_web/live/admin_live.ex:874
+#: lib/abuuba_web/live/admin_live.ex:887
 #, elixir-autogen, elixir-format
 msgid "Do it"
 msgstr "Ausführen"
 
-#: lib/abuuba_web/live/admin_live.ex:735
+#: lib/abuuba_web/live/admin_live.ex:748
 #, elixir-autogen, elixir-format
 msgid "Elsewhere"
 msgstr "Anderswo"
 
-#: lib/abuuba_web/live/admin_live.ex:1015
+#: lib/abuuba_web/live/admin_live.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
-#: lib/abuuba_web/live/admin_live.ex:3708
+#: lib/abuuba_web/live/admin_live.ex:3723
 #, elixir-autogen, elixir-format
 msgid "Everything else on this page is guesswork until that is fixed."
 msgstr "Alles andere auf dieser Seite ist geraten, solange das nicht behoben ist."
 
-#: lib/abuuba_web/live/admin_live.ex:748
-#: lib/abuuba_web/live/admin_live.ex:1472
+#: lib/abuuba_web/live/admin_live.ex:761
+#: lib/abuuba_web/live/admin_live.ex:1485
 #, elixir-autogen, elixir-format
 msgid "Find"
 msgstr "Suchen"
 
-#: lib/abuuba_web/live/admin_live.ex:733
+#: lib/abuuba_web/live/admin_live.ex:746
 #, elixir-autogen, elixir-format
 msgid "Here"
 msgstr "Hier"
 
-#: lib/abuuba_web/live/admin_live.ex:811
+#: lib/abuuba_web/live/admin_live.ex:824
 #, elixir-autogen, elixir-format
 msgid "Let in"
 msgstr "Aufnehmen"
 
-#: lib/abuuba_web/live/admin_live.ex:895
-#: lib/abuuba_web/live/admin_live.ex:1193
-#: lib/abuuba_web/live/admin_live.ex:1220
-#: lib/abuuba_web/live/admin_live.ex:1248
-#: lib/abuuba_web/live/admin_live.ex:1272
+#: lib/abuuba_web/live/admin_live.ex:908
+#: lib/abuuba_web/live/admin_live.ex:1206
+#: lib/abuuba_web/live/admin_live.ex:1233
+#: lib/abuuba_web/live/admin_live.ex:1261
+#: lib/abuuba_web/live/admin_live.ex:1285
 #, elixir-autogen, elixir-format
 msgid "Lift it"
 msgstr "Aufheben"
 
-#: lib/abuuba_web/live/admin_live.ex:3404
+#: lib/abuuba_web/live/admin_live.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Limited"
 msgstr "Eingeschränkt"
 
-#: lib/abuuba_web/live/admin_live.ex:3423
+#: lib/abuuba_web/live/admin_live.ex:3438
 #, elixir-autogen, elixir-format
 msgid "Mark everything they post sensitive"
 msgstr "Alle Beiträge als sensibel markieren"
 
-#: lib/abuuba_web/live/admin_live.ex:728
+#: lib/abuuba_web/live/admin_live.ex:741
 #, elixir-autogen, elixir-format
 msgid "Name or name@server"
 msgstr "Name oder name@server"
 
-#: lib/abuuba_web/live/admin_live.ex:3724
+#: lib/abuuba_web/live/admin_live.ex:3739
 #, elixir-autogen, elixir-format
 msgid "Nobody can grant roles or change settings that need it. Give somebody a role holding the administrator permission."
 msgstr "Niemand kann Rollen vergeben oder Einstellungen ändern, die das voraussetzen. Gib jemandem eine Rolle mit der Administrator-Berechtigung."
 
-#: lib/abuuba_web/live/admin_live.ex:3704
+#: lib/abuuba_web/live/admin_live.ex:3719
 #, elixir-autogen, elixir-format
 msgid "Nobody here is an administrator"
 msgstr "Niemand hier ist Administrator"
 
-#: lib/abuuba_web/live/admin_live.ex:829
+#: lib/abuuba_web/live/admin_live.ex:842
 #, elixir-autogen, elixir-format
 msgid "Nobody here matches that."
 msgstr "Dazu passt hier niemand."
 
-#: lib/abuuba_web/live/admin_live.ex:1000
+#: lib/abuuba_web/live/admin_live.ex:1013
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr "Keine"
 
-#: lib/abuuba_web/live/admin_live.ex:2283
+#: lib/abuuba_web/live/admin_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Nothing has been done yet."
 msgstr "Es ist noch nichts passiert."
 
-#: lib/abuuba_web/live/admin_live.ex:418
-#: lib/abuuba_web/live/admin_live.ex:443
-#: lib/abuuba_web/live/admin_live.ex:701
-#: lib/abuuba_web/live/admin_live.ex:900
+#: lib/abuuba_web/live/admin_live.ex:431
+#: lib/abuuba_web/live/admin_live.ex:456
+#: lib/abuuba_web/live/admin_live.ex:714
+#: lib/abuuba_web/live/admin_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Nothing yet."
 msgstr "Hier ist noch nichts."
 
-#: lib/abuuba_web/live/admin_live.ex:457
+#: lib/abuuba_web/live/admin_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Nothing. Every check this server knows how to make came back fine."
 msgstr "Nichts. Jede Prüfung, die dieser Server kennt, war in Ordnung."
 
-#: lib/abuuba_web/live/admin_live.ex:385
+#: lib/abuuba_web/live/admin_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "People waiting to be let in"
 msgstr "Personen, die auf Aufnahme warten"
 
-#: lib/abuuba_web/live/admin_live.ex:369
+#: lib/abuuba_web/live/admin_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Reports waiting"
 msgstr "Offene Meldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:2241
+#: lib/abuuba_web/live/admin_live.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Retire it"
 msgstr "Zurückziehen"
 
-#: lib/abuuba_web/live/admin_live.ex:998
+#: lib/abuuba_web/live/admin_live.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/abuuba_web/live/admin_live.ex:2227
+#: lib/abuuba_web/live/admin_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Rules people agree to"
 msgstr "Regeln, denen man zustimmt"
 
-#: lib/abuuba_web/live/admin_live.ex:3419
+#: lib/abuuba_web/live/admin_live.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Send a warning and nothing else"
 msgstr "Nur verwarnen, sonst nichts"
 
-#: lib/abuuba_web/live/admin_live.ex:1469
-#: lib/abuuba_web/live/admin_live.ex:1909
+#: lib/abuuba_web/live/admin_live.ex:1482
+#: lib/abuuba_web/live/admin_live.ex:1923
 #, elixir-autogen, elixir-format
 msgid "Server name"
 msgstr "Name des Servers"
 
-#: lib/abuuba_web/live/admin_live.ex:3379
+#: lib/abuuba_web/live/admin_live.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Server settings"
 msgstr "Servereinstellungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3712
+#: lib/abuuba_web/live/admin_live.ex:3727
 #, elixir-autogen, elixir-format
 msgid "Servers running authorized fetch will refuse this one. It is created on first use, so this usually means something went wrong writing it."
 msgstr "Server mit Authorized Fetch weisen diesen hier ab. Er wird beim ersten Bedarf angelegt, das heißt hier ist beim Schreiben etwas schiefgegangen."
 
-#: lib/abuuba_web/live/admin_live.ex:2266
+#: lib/abuuba_web/live/admin_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr "Anzeigen"
 
-#: lib/abuuba_web/live/admin_live.ex:2229
+#: lib/abuuba_web/live/admin_live.ex:2243
 #, elixir-autogen, elixir-format
 msgid "Shown when somebody signs up and when they file a report."
 msgstr "Wird bei der Anmeldung und beim Melden angezeigt."
 
-#: lib/abuuba_web/live/admin_live.ex:3420
+#: lib/abuuba_web/live/admin_live.ex:3435
 #, elixir-autogen, elixir-format
 msgid "Silence: out of everywhere nobody asked for them"
 msgstr "Einschränken: nicht mehr dort, wo niemand danach gefragt hat"
 
-#: lib/abuuba_web/live/admin_live.ex:3421
+#: lib/abuuba_web/live/admin_live.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Suspend: hidden, and deleted after the grace window"
 msgstr "Sperren: verborgen, nach Ablauf der Frist gelöscht"
 
-#: lib/abuuba_web/live/admin_live.ex:3405
+#: lib/abuuba_web/live/admin_live.ex:3420
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr "Gesperrt"
 
-#: lib/abuuba_web/live/admin_live.ex:2059
+#: lib/abuuba_web/live/admin_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Talk only to servers on the allowlist"
 msgstr "Nur mit Servern auf der Positivliste sprechen"
 
-#: lib/abuuba_web/live/admin_live.ex:3330
+#: lib/abuuba_web/live/admin_live.ex:3345
 #, elixir-autogen, elixir-format
 msgid "That account outranks yours, so there is nothing here you can do to it."
 msgstr "Dieses Konto steht über deinem, hier kannst du nichts damit machen."
 
-#: lib/abuuba_web/live/admin_live.ex:2871
-#: lib/abuuba_web/live/admin_live.ex:2883
+#: lib/abuuba_web/live/admin_live.ex:2885
+#: lib/abuuba_web/live/admin_live.ex:2897
 #, elixir-autogen, elixir-format
 msgid "That could not be done."
 msgstr "Das ließ sich nicht ausführen."
 
-#: lib/abuuba_web/live/admin_live.ex:2460
+#: lib/abuuba_web/live/admin_live.ex:2474
 #, elixir-autogen, elixir-format
 msgid "That is not a role you can hand out."
 msgstr "Diese Rolle kannst du nicht vergeben."
 
-#: lib/abuuba_web/live/admin_live.ex:2475
+#: lib/abuuba_web/live/admin_live.ex:2489
 #, elixir-autogen, elixir-format
 msgid "That is not an address."
 msgstr "Das ist keine Adresse."
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
-#: lib/abuuba_web/live/admin_live.ex:3325
+#: lib/abuuba_web/live/admin_live.ex:3340
 #: lib/abuuba_web/live/settings_live.ex:1628
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr "Das kann dein Konto nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3701
+#: lib/abuuba_web/live/admin_live.ex:3716
 #, elixir-autogen, elixir-format
 msgid "The database is not answering"
 msgstr "Die Datenbank antwortet nicht"
 
-#: lib/abuuba_web/live/admin_live.ex:848
+#: lib/abuuba_web/live/admin_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "This account outranks yours, so there is nothing here you can do to it."
 msgstr "Dieses Konto steht über deinem, hier kannst du nichts damit machen."
 
-#: lib/abuuba_web/live/admin_live.ex:819
+#: lib/abuuba_web/live/admin_live.ex:832
 #, elixir-autogen, elixir-format
 msgid "This deletes the account as well. Go ahead?"
 msgstr "Damit wird auch das Konto gelöscht. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:3702
+#: lib/abuuba_web/live/admin_live.ex:3717
 #, elixir-autogen, elixir-format
 msgid "This server has no actor of its own"
 msgstr "Dieser Server hat keinen eigenen Actor"
 
-#: lib/abuuba_web/live/admin_live.ex:821
+#: lib/abuuba_web/live/admin_live.ex:834
 #, elixir-autogen, elixir-format
 msgid "Turn away"
 msgstr "Ablehnen"
 
-#: lib/abuuba_web/live/admin_live.ex:3403
+#: lib/abuuba_web/live/admin_live.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Waiting to be let in"
 msgstr "Wartet auf Aufnahme"
 
-#: lib/abuuba_web/live/admin_live.ex:877
+#: lib/abuuba_web/live/admin_live.ex:890
 #, elixir-autogen, elixir-format
 msgid "What has been decided about them"
 msgstr "Was über sie entschieden wurde"
 
-#: lib/abuuba_web/live/admin_live.ex:446
+#: lib/abuuba_web/live/admin_live.ex:459
 #, elixir-autogen, elixir-format
 msgid "What needs attention"
 msgstr "Was Aufmerksamkeit braucht"
 
-#: lib/abuuba_web/live/admin_live.ex:1914
+#: lib/abuuba_web/live/admin_live.ex:1928
 #, elixir-autogen, elixir-format
 msgid "What this server is for"
 msgstr "Wofür dieser Server da ist"
 
-#: lib/abuuba_web/live/admin_live.ex:863
+#: lib/abuuba_web/live/admin_live.ex:876
 #, elixir-autogen, elixir-format
 msgid "What to do"
 msgstr "Was passieren soll"
 
-#: lib/abuuba_web/live/admin_live.ex:2014
+#: lib/abuuba_web/live/admin_live.ex:2028
 #, elixir-autogen, elixir-format
 msgid "What to say when nobody may sign up"
 msgstr "Text, wenn niemand sich anmelden darf"
 
-#: lib/abuuba_web/live/admin_live.ex:870
+#: lib/abuuba_web/live/admin_live.ex:883
 #, elixir-autogen, elixir-format
 msgid "What to tell them"
 msgstr "Was ihnen gesagt wird"
 
-#: lib/abuuba_web/live/admin_live.ex:2001
+#: lib/abuuba_web/live/admin_live.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Who may sign up"
 msgstr "Wer sich anmelden darf"
 
-#: lib/abuuba_web/live/admin_live.ex:886
+#: lib/abuuba_web/live/admin_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "lifted"
 msgstr "aufgehoben"
 
-#: lib/abuuba_web/live/admin_live.ex:801
+#: lib/abuuba_web/live/admin_live.ex:814
 #, elixir-autogen, elixir-format
 msgid "limited"
 msgstr "eingeschränkt"
 
-#: lib/abuuba_web/live/admin_live.ex:800
+#: lib/abuuba_web/live/admin_live.ex:813
 #, elixir-autogen, elixir-format
 msgid "suspended"
 msgstr "gesperrt"
 
-#: lib/abuuba_web/live/admin_live.ex:2272
+#: lib/abuuba_web/live/admin_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "the server"
 msgstr "der Server"
 
 #: lib/abuuba_web/components/status_component.ex:307
-#: lib/abuuba_web/live/admin_live.ex:1077
+#: lib/abuuba_web/live/admin_live.ex:1090
 #, elixir-autogen, elixir-format
 msgid "%{count} person"
 msgid_plural "%{count} people"
 msgstr[0] "%{count} Person"
 msgstr[1] "%{count} Personen"
 
-#: lib/abuuba_web/live/admin_live.ex:1033
+#: lib/abuuba_web/live/admin_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Nothing appears in the trending lists until somebody here has looked at it. This is what is waiting."
 msgstr "In den Trendlisten erscheint nichts, bevor jemand hier es angesehen hat. Das hier wartet darauf."
 
-#: lib/abuuba_web/live/admin_live.ex:1092
+#: lib/abuuba_web/live/admin_live.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Nothing is trending. That is what a quiet day looks like."
 msgstr "Nichts im Trend. So sieht ein ruhiger Tag aus."
 
-#: lib/abuuba_web/live/admin_live.ex:1067
+#: lib/abuuba_web/live/admin_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting to be looked at."
 msgstr "Es wartet nichts darauf, angesehen zu werden."
 
-#: lib/abuuba_web/live/admin_live.ex:1060
+#: lib/abuuba_web/live/admin_live.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Refuse"
 msgstr "Ablehnen"
 
-#: lib/abuuba_web/live/admin_live.ex:1086
-#: lib/abuuba_web/live/admin_live.ex:1144
+#: lib/abuuba_web/live/admin_live.ex:1099
+#: lib/abuuba_web/live/admin_live.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Take it down"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/admin_live.ex:3369
+#: lib/abuuba_web/live/admin_live.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Trends"
 msgstr "Trends"
 
-#: lib/abuuba_web/live/admin_live.ex:1070
+#: lib/abuuba_web/live/admin_live.ex:1083
 #, elixir-autogen, elixir-format
 msgid "What is trending now"
 msgstr "Was gerade im Trend liegt"
@@ -2843,12 +2843,12 @@ msgstr "%{uses} von %{max} genutzt"
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr "Ein Code, mit dem sich jemand anmelden kann, auch wenn Anmeldungen geschlossen sind. Lass die Anzahl leer für beliebig viele."
 
-#: lib/abuuba_web/live/admin_live.ex:2515
+#: lib/abuuba_web/live/admin_live.ex:2529
 #, elixir-autogen, elixir-format
 msgid "An announcement needs some text."
 msgstr "Eine Ankündigung braucht einen Text."
 
-#: lib/abuuba_web/live/admin_live.ex:3370
+#: lib/abuuba_web/live/admin_live.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Announcements"
 msgstr "Ankündigungen"
@@ -2858,7 +2858,7 @@ msgstr "Ankündigungen"
 msgid "Codes that let somebody you know sign up."
 msgstr "Codes, mit denen sich Bekannte von dir anmelden können."
 
-#: lib/abuuba_web/live/admin_live.ex:2195
+#: lib/abuuba_web/live/admin_live.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Each version is kept with the day it takes effect, so somebody can still read what they agreed to."
 msgstr "Jede Fassung wird mit dem Tag aufbewahrt, an dem sie gilt, damit man nachlesen kann, wozu man zugestimmt hat."
@@ -2868,12 +2868,12 @@ msgstr "Jede Fassung wird mit dem Tag aufbewahrt, an dem sie gilt, damit man nac
 msgid "Earlier versions"
 msgstr "Frühere Fassungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3781
+#: lib/abuuba_web/live/admin_live.ex:3796
 #, elixir-autogen, elixir-format
 msgid "Everybody has already been told about that one."
 msgstr "Darüber wurden bereits alle informiert."
 
-#: lib/abuuba_web/live/admin_live.ex:1132
+#: lib/abuuba_web/live/admin_live.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Goes up"
 msgstr "Erscheint"
@@ -2883,7 +2883,7 @@ msgstr "Erscheint"
 msgid "How many people"
 msgstr "Wie viele Personen"
 
-#: lib/abuuba_web/live/admin_live.ex:2203
+#: lib/abuuba_web/live/admin_live.ex:2217
 #, elixir-autogen, elixir-format
 msgid "In effect from"
 msgstr "Gültig ab"
@@ -2903,7 +2903,7 @@ msgstr "Einladungen"
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
 
-#: lib/abuuba_web/live/admin_live.ex:1117
+#: lib/abuuba_web/live/admin_live.ex:1130
 #, elixir-autogen, elixir-format
 msgid "Leave this empty to publish it now."
 msgstr "Leer lassen, um sofort zu veröffentlichen."
@@ -2913,27 +2913,27 @@ msgstr "Leer lassen, um sofort zu veröffentlichen."
 msgid "Make one"
 msgstr "Erstellen"
 
-#: lib/abuuba_web/live/admin_live.ex:1135
+#: lib/abuuba_web/live/admin_live.ex:1148
 #, elixir-autogen, elixir-format
 msgid "Not published"
 msgstr "Nicht veröffentlicht"
 
-#: lib/abuuba_web/live/admin_live.ex:1150
+#: lib/abuuba_web/live/admin_live.ex:1163
 #, elixir-autogen, elixir-format
 msgid "Nothing has been announced."
 msgstr "Es wurde noch nichts angekündigt."
 
-#: lib/abuuba_web/live/admin_live.ex:2206
+#: lib/abuuba_web/live/admin_live.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr "Neue Fassung veröffentlichen"
 
-#: lib/abuuba_web/live/admin_live.ex:1129
+#: lib/abuuba_web/live/admin_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Published"
 msgstr "Veröffentlicht"
 
-#: lib/abuuba_web/live/admin_live.ex:1102
+#: lib/abuuba_web/live/admin_live.ex:1115
 #, elixir-autogen, elixir-format
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr "Etwas, das hier alle lesen sollten. Mit einer Uhrzeit veröffentlicht es sich selbst, sodass ein Hinweis auf Sonntag schon am Donnerstag geschrieben werden kann."
@@ -2943,12 +2943,12 @@ msgstr "Etwas, das hier alle lesen sollten. Mit einer Uhrzeit veröffentlicht es
 msgid "Take it back"
 msgstr "Zurücknehmen"
 
-#: lib/abuuba_web/live/admin_live.ex:2222
+#: lib/abuuba_web/live/admin_live.ex:2236
 #, elixir-autogen, elixir-format
 msgid "Tell everybody"
 msgstr "Alle informieren"
 
-#: lib/abuuba_web/live/admin_live.ex:2541
+#: lib/abuuba_web/live/admin_live.ex:2555
 #, elixir-autogen, elixir-format
 msgid "Terms need some text and a day they take effect."
 msgstr "Nutzungsbedingungen brauchen einen Text und einen Tag, ab dem sie gelten."
@@ -2963,13 +2963,13 @@ msgstr "Sie folgen dir"
 msgid "What it is for"
 msgstr "Wofür sie ist"
 
-#: lib/abuuba_web/live/admin_live.ex:1109
-#: lib/abuuba_web/live/admin_live.ex:2087
+#: lib/abuuba_web/live/admin_live.ex:1122
+#: lib/abuuba_web/live/admin_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "What to say"
 msgstr "Was gesagt werden soll"
 
-#: lib/abuuba_web/live/admin_live.ex:1114
+#: lib/abuuba_web/live/admin_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "When to publish it"
 msgstr "Wann es veröffentlicht wird"
@@ -2984,7 +2984,7 @@ msgstr "Du meldest dich auf eine Einladung hin an, eine Freigabe brauchst du des
 msgid "You have not made any."
 msgstr "Du hast noch keine erstellt."
 
-#: lib/abuuba_web/live/admin_live.ex:2213
+#: lib/abuuba_web/live/admin_live.ex:2227
 #, elixir-autogen, elixir-format
 msgid "everybody was told"
 msgstr "alle wurden informiert"
@@ -2996,59 +2996,59 @@ msgid_plural "used %{count} times"
 msgstr[0] "%{count}-mal genutzt"
 msgstr[1] "%{count}-mal genutzt"
 
-#: lib/abuuba_web/live/admin_live.ex:1200
+#: lib/abuuba_web/live/admin_live.ex:1213
 #, elixir-autogen, elixir-format
 msgid "Addresses"
 msgstr "Adressen"
 
-#: lib/abuuba_web/live/admin_live.ex:1232
+#: lib/abuuba_web/live/admin_live.ex:1245
 #, elixir-autogen, elixir-format
 msgid "Anywhere in a name"
 msgstr "Irgendwo im Namen"
 
-#: lib/abuuba_web/live/admin_live.ex:3763
+#: lib/abuuba_web/live/admin_live.ex:3778
 #, elixir-autogen, elixir-format
 msgid "Ask for approval"
 msgstr "Freigabe verlangen"
 
-#: lib/abuuba_web/live/admin_live.ex:1177
-#: lib/abuuba_web/live/admin_live.ex:1206
-#: lib/abuuba_web/live/admin_live.ex:1234
+#: lib/abuuba_web/live/admin_live.ex:1190
+#: lib/abuuba_web/live/admin_live.ex:1219
+#: lib/abuuba_web/live/admin_live.ex:1247
 #, elixir-autogen, elixir-format
 msgid "Block it"
 msgstr "Sperren"
 
-#: lib/abuuba_web/live/admin_live.ex:1255
+#: lib/abuuba_web/live/admin_live.ex:1268
 #, elixir-autogen, elixir-format
 msgid "Email addresses"
 msgstr "E-Mail-Adressen"
 
-#: lib/abuuba_web/live/admin_live.ex:1257
+#: lib/abuuba_web/live/admin_live.ex:1270
 #, elixir-autogen, elixir-format
 msgid "Kept as hashes rather than addresses. The list has to recognise somebody coming back, not be readable."
 msgstr "Als Hashes gespeichert, nicht als Adressen. Die Liste muss jemanden wiedererkennen, nicht lesbar sein."
 
-#: lib/abuuba_web/live/admin_live.ex:1166
+#: lib/abuuba_web/live/admin_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "Mail domains"
 msgstr "Mail-Domains"
 
-#: lib/abuuba_web/live/admin_live.ex:3765
+#: lib/abuuba_web/live/admin_live.ex:3780
 #, elixir-autogen, elixir-format
 msgid "No access at all"
 msgstr "Gar kein Zugriff"
 
-#: lib/abuuba_web/live/admin_live.ex:3764
+#: lib/abuuba_web/live/admin_live.ex:3779
 #, elixir-autogen, elixir-format
 msgid "No sign-ups"
 msgstr "Keine Anmeldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:1278
+#: lib/abuuba_web/live/admin_live.ex:1291
 #, elixir-autogen, elixir-format
 msgid "None. One is added when an account is suspended and you ask for it."
 msgstr "Keine. Ein Eintrag entsteht, wenn ein Konto gesperrt wird und du es verlangst."
 
-#: lib/abuuba_web/live/admin_live.ex:1175
+#: lib/abuuba_web/live/admin_live.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Only ask for approval"
 msgstr "Nur Freigabe verlangen"
@@ -3058,7 +3058,7 @@ msgstr "Nur Freigabe verlangen"
 msgid "Please complete the puzzle so we know you are a person."
 msgstr "Bitte löse das Rätsel, damit wir wissen, dass du ein Mensch bist."
 
-#: lib/abuuba_web/live/admin_live.ex:3371
+#: lib/abuuba_web/live/admin_live.ex:3386
 #, elixir-autogen, elixir-format
 msgid "Sign-up blocks"
 msgstr "Anmeldesperren"
@@ -3078,22 +3078,22 @@ msgstr "Das Rätsel ließ sich gerade nicht prüfen. Bitte versuch es gleich noc
 msgid "This server asks new accounts to solve a puzzle first."
 msgstr "Dieser Server lässt neue Konten zuerst ein Rätsel lösen."
 
-#: lib/abuuba_web/live/admin_live.ex:1227
+#: lib/abuuba_web/live/admin_live.ex:1240
 #, elixir-autogen, elixir-format
 msgid "Usernames"
 msgstr "Benutzernamen"
 
-#: lib/abuuba_web/live/admin_live.ex:1160
+#: lib/abuuba_web/live/admin_live.ex:1173
 #, elixir-autogen, elixir-format
 msgid "What this server refuses at the door. Most of these have a middle setting that asks somebody to look rather than shutting the door."
 msgstr "Was dieser Server an der Tür abweist. Das meiste davon hat eine mittlere Einstellung, die jemanden hinsehen lässt, statt die Tür zuzumachen."
 
-#: lib/abuuba_web/live/admin_live.ex:1240
+#: lib/abuuba_web/live/admin_live.ex:1253
 #, elixir-autogen, elixir-format
 msgid "anywhere"
 msgstr "irgendwo"
 
-#: lib/abuuba_web/live/admin_live.ex:1184
+#: lib/abuuba_web/live/admin_live.ex:1197
 #, elixir-autogen, elixir-format
 msgid "approval only"
 msgstr "nur mit Freigabe"
@@ -3306,7 +3306,7 @@ msgstr "Liste importieren"
 
 #: lib/abuuba_web/live/settings_live.ex:1064
 #: lib/abuuba_web/live/settings_live.ex:1913
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:2244
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr "Listen"
@@ -3401,7 +3401,7 @@ msgstr "Wonach gesucht wird"
 msgid "A filter needs at least one word to look for."
 msgstr "Ein Filter braucht mindestens ein Wort, nach dem er suchen soll."
 
-#: lib/abuuba_web/live/admin_live.ex:798
+#: lib/abuuba_web/live/admin_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "Why they want to join:"
 msgstr "Warum die Person mitmachen möchte:"
@@ -3458,27 +3458,27 @@ msgstr "Sagen, aus welcher App du schreibst"
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr "Steht für alle anderen unter deinen Beiträgen. An deinen eigenen siehst du es immer."
 
-#: lib/abuuba_web/live/admin_live.ex:917
+#: lib/abuuba_web/live/admin_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Mark as a memorial"
 msgstr "Als Gedenkseite markieren"
 
-#: lib/abuuba_web/live/admin_live.ex:904
+#: lib/abuuba_web/live/admin_live.ex:917
 #, elixir-autogen, elixir-format
 msgid "Marking an account as a memorial stops it being signed in to and marks the profile as one. Nothing is hidden and nothing is deleted."
 msgstr "Ein Konto als Gedenkseite zu markieren beendet die Anmeldung und kennzeichnet das Profil als solche. Nichts wird versteckt und nichts gelöscht."
 
-#: lib/abuuba_web/live/admin_live.ex:2306
+#: lib/abuuba_web/live/admin_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr "Das ließ sich nicht speichern."
 
-#: lib/abuuba_web/live/admin_live.ex:912
+#: lib/abuuba_web/live/admin_live.ex:925
 #, elixir-autogen, elixir-format
 msgid "This also disables their login. Go ahead?"
 msgstr "Damit endet auch die Anmeldung dieser Person. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:916
+#: lib/abuuba_web/live/admin_live.ex:929
 #, elixir-autogen, elixir-format
 msgid "This is not a memorial"
 msgstr "Das ist keine Gedenkseite"
@@ -3565,17 +3565,17 @@ msgstr "Worüber am meisten geschrieben wurde"
 msgid "Wrote things other people replied to."
 msgstr "Hat Dinge geschrieben, auf die andere geantwortet haben."
 
-#: lib/abuuba_web/live/admin_live.ex:2100
+#: lib/abuuba_web/live/admin_live.ex:2114
 #, elixir-autogen, elixir-format
 msgid "An http or https address. Anything else is refused and nothing is shown."
 msgstr "Eine http- oder https-Adresse. Alles andere wird abgelehnt und es wird nichts angezeigt."
 
-#: lib/abuuba_web/live/admin_live.ex:2079
+#: lib/abuuba_web/live/admin_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Asking for money"
 msgstr "Um Geld bitten"
 
-#: lib/abuuba_web/live/admin_live.ex:2081
+#: lib/abuuba_web/live/admin_live.ex:2095
 #, elixir-autogen, elixir-format
 msgid "Clients show this to people signed in here. Leave the message empty to show nothing."
 msgstr "Apps zeigen das den hier angemeldeten Leuten. Lass den Text leer, damit nichts angezeigt wird."
@@ -3595,7 +3595,7 @@ msgstr "Bestätige, dass du Neuigkeiten von %{name} bekommen möchtest"
 msgid "Donate"
 msgstr "Spenden"
 
-#: lib/abuuba_web/live/admin_live.ex:2074
+#: lib/abuuba_web/live/admin_live.ex:2088
 #, elixir-autogen, elixir-format
 msgid "Each person still has to turn it on for themselves, and every address has to confirm before anything is sent to it."
 msgstr "Jede Person muss es zusätzlich für sich selbst einschalten, und jede Adresse muss bestätigen, bevor irgendetwas dorthin geht."
@@ -3654,12 +3654,12 @@ msgstr "Dieser Link ist nicht mehr gültig."
 msgid "This address is getting updates. You can stop them at any time."
 msgstr "Diese Adresse bekommt Neuigkeiten. Du kannst das jederzeit beenden."
 
-#: lib/abuuba_web/live/admin_live.ex:2105
+#: lib/abuuba_web/live/admin_live.ex:2119
 #, elixir-autogen, elixir-format
 msgid "What the button says"
 msgstr "Was auf dem Knopf steht"
 
-#: lib/abuuba_web/live/admin_live.ex:2092
+#: lib/abuuba_web/live/admin_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Where the button goes"
 msgstr "Wohin der Knopf führt"
@@ -3674,7 +3674,7 @@ msgstr "Ja, bitte schicken"
 msgid "somebody gave this address to receive updates from %{name} on %{site}. If that was you, confirm it here:"
 msgstr "jemand hat diese Adresse angegeben, um Neuigkeiten von %{name} auf %{site} zu bekommen. Wenn du das warst, bestätige es hier:"
 
-#: lib/abuuba_web/live/admin_live.ex:2071
+#: lib/abuuba_web/live/admin_live.ex:2085
 #, elixir-autogen, elixir-format
 msgid "Let people collect email addresses for updates"
 msgstr "Erlaube es, E-Mail-Adressen für Neuigkeiten zu sammeln"
@@ -3832,25 +3832,25 @@ msgstr "das Passwort deines Kontos auf %{site} wurde gerade geändert, und über
 msgid "A copy of everything"
 msgstr "Eine Kopie von allem"
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr "Wird gebaut"
 
 #: lib/abuuba_web/live/settings_live.ex:810
-#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr "Blockierte Server"
 
-#: lib/abuuba_web/live/admin_live.ex:1303
-#: lib/abuuba_web/live/admin_live.ex:1318
-#: lib/abuuba_web/live/settings_live.ex:2230
+#: lib/abuuba_web/live/admin_live.ex:1316
+#: lib/abuuba_web/live/admin_live.ex:1331
+#: lib/abuuba_web/live/settings_live.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr "Blockierte"
 
-#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2246
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
@@ -3860,7 +3860,7 @@ msgstr "Lesezeichen"
 msgid "Build me a copy"
 msgstr "Bau mir eine Kopie"
 
-#: lib/abuuba_web/live/settings_live.ex:2241
+#: lib/abuuba_web/live/settings_live.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr "Hat nicht geklappt"
@@ -3875,7 +3875,7 @@ msgstr "Herunterladen"
 msgid "Export"
 msgstr "Exportieren"
 
-#: lib/abuuba_web/live/settings_live.ex:2231
+#: lib/abuuba_web/live/settings_live.ex:2243
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr "Stummgeschaltete"
@@ -3895,7 +3895,7 @@ msgstr "Eine wird gerade schon gebaut."
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr "Bilder und Videos sind nicht in der Datei. Sie enthält ihre Adressen, die funktionieren, solange dieser Server läuft."
 
-#: lib/abuuba_web/live/settings_live.ex:2240
+#: lib/abuuba_web/live/settings_live.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr "Fertig"
@@ -3915,7 +3915,7 @@ msgstr "Die Datei wird nach %{days} Tagen gelöscht, weil sie dein ganzes Konto 
 msgid "There is nothing of that kind to export."
 msgstr "So etwas gibt es hier nicht zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2250
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr "Wartet auf den Start"
@@ -4149,7 +4149,7 @@ msgstr "Was oben auf deinem Profil steht. Angeheftet wird vom Beitrag aus."
 msgid "Mail about your own account — password resets and the like — still comes."
 msgstr "Post zu deinem eigenen Konto, etwa zum Zurücksetzen des Passworts, kommt weiterhin."
 
-#: lib/abuuba_web/live/admin_live.ex:2143
+#: lib/abuuba_web/live/admin_live.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Served from this server and linked from every page. It goes out exactly as typed."
 msgstr "Wird von diesem Server ausgeliefert und auf jeder Seite eingebunden. Es geht genau so raus, wie es hier steht."
@@ -4175,7 +4175,7 @@ msgstr "Abstellen"
 msgid "You will not get that kind of email from us again."
 msgstr "Diese Art E-Mail bekommst du von uns nicht mehr."
 
-#: lib/abuuba_web/live/admin_live.ex:2141
+#: lib/abuuba_web/live/admin_live.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Your own CSS"
 msgstr "Eigenes CSS"
@@ -4195,649 +4195,649 @@ msgstr "alle E-Mails außer denen zu deinem Konto"
 msgid "the occasional summary of what you missed"
 msgstr "die gelegentliche Zusammenfassung dessen, was du verpasst hast"
 
-#: lib/abuuba_web/live/admin_live.ex:1590
+#: lib/abuuba_web/live/admin_live.ex:1603
 #, elixir-autogen, elixir-format
 msgid "A relay forwards every public post it is sent on to everybody subscribed to it. On a young server it is the quickest way to have a federated timeline with anything in it."
 msgstr "Ein Relay leitet jeden öffentlichen Beitrag, den es bekommt, an alle weiter, die es abonniert haben. Auf einem jungen Server ist das der schnellste Weg zu einer föderierten Timeline, in der überhaupt etwas steht."
 
-#: lib/abuuba_web/live/admin_live.ex:1513
-#: lib/abuuba_web/live/admin_live.ex:1625
+#: lib/abuuba_web/live/admin_live.ex:1526
+#: lib/abuuba_web/live/admin_live.ex:1638
 #, elixir-autogen, elixir-format
 msgid "Last error:"
 msgstr "Letzter Fehler:"
 
-#: lib/abuuba_web/live/admin_live.ex:1662
+#: lib/abuuba_web/live/admin_live.ex:1675
 #, elixir-autogen, elixir-format
 msgid "No relays yet."
 msgstr "Noch keine Relays."
 
-#: lib/abuuba_web/live/admin_live.ex:3666
+#: lib/abuuba_web/live/admin_live.ex:3681
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Aus"
 
-#: lib/abuuba_web/live/admin_live.ex:3668
+#: lib/abuuba_web/live/admin_live.ex:3683
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "An"
 
-#: lib/abuuba_web/live/admin_live.ex:3372
+#: lib/abuuba_web/live/admin_live.ex:3387
 #, elixir-autogen, elixir-format
 msgid "Relays"
 msgstr "Relays"
 
-#: lib/abuuba_web/live/admin_live.ex:1654
+#: lib/abuuba_web/live/admin_live.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Remove this relay?"
 msgstr "Dieses Relay entfernen?"
 
-#: lib/abuuba_web/live/admin_live.ex:2813
+#: lib/abuuba_web/live/admin_live.ex:2827
 #, elixir-autogen, elixir-format
 msgid "That is not an https inbox address, or it is already here."
 msgstr "Das ist keine https-Inbox-Adresse, oder sie ist schon da."
 
-#: lib/abuuba_web/live/admin_live.ex:3669
+#: lib/abuuba_web/live/admin_live.ex:3684
 #, elixir-autogen, elixir-format
 msgid "The relay refused"
 msgstr "Das Relay hat abgelehnt"
 
-#: lib/abuuba_web/live/admin_live.ex:1607
+#: lib/abuuba_web/live/admin_live.ex:1620
 #, elixir-autogen, elixir-format
 msgid "The relay's inbox address, which its operator publishes. Adding and turning on are separate steps, so a mistyped address can be corrected before anything is sent to it."
 msgstr "Die Inbox-Adresse des Relays, die dessen Betrieb veröffentlicht. Hinzufügen und Einschalten sind getrennte Schritte, damit eine vertippte Adresse korrigiert werden kann, bevor irgendetwas dorthin geht."
 
-#: lib/abuuba_web/live/admin_live.ex:1646
-#: lib/abuuba_web/live/admin_live.ex:1844
+#: lib/abuuba_web/live/admin_live.ex:1659
+#: lib/abuuba_web/live/admin_live.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Turn off"
 msgstr "Ausschalten"
 
-#: lib/abuuba_web/live/admin_live.ex:1636
-#: lib/abuuba_web/live/admin_live.ex:1844
+#: lib/abuuba_web/live/admin_live.ex:1649
+#: lib/abuuba_web/live/admin_live.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Turn on"
 msgstr "Einschalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3667
+#: lib/abuuba_web/live/admin_live.ex:3682
 #, elixir-autogen, elixir-format
 msgid "Waiting for the relay to answer"
 msgstr "Wartet auf die Antwort des Relays"
 
-#: lib/abuuba_web/live/admin_live.ex:1619
+#: lib/abuuba_web/live/admin_live.ex:1632
 #, elixir-autogen, elixir-format
 msgid "last sent %{when}"
 msgstr "zuletzt gesendet %{when}"
 
-#: lib/abuuba_web/live/admin_live.ex:1825
+#: lib/abuuba_web/live/admin_live.ex:1839
 #, elixir-autogen, elixir-format
 msgid "Added turned off, so a URL typed wrong can be corrected before anything goes to it."
 msgstr "Wird ausgeschaltet angelegt, damit eine vertippte Adresse korrigiert werden kann, bevor irgendetwas dorthin geht."
 
-#: lib/abuuba_web/live/admin_live.ex:1800
+#: lib/abuuba_web/live/admin_live.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Copy it now. It is not shown again."
 msgstr "Kopiere es jetzt. Es wird nicht noch einmal angezeigt."
 
-#: lib/abuuba_web/live/admin_live.ex:1854
+#: lib/abuuba_web/live/admin_live.ex:1868
 #, elixir-autogen, elixir-format
 msgid "New secret"
 msgstr "Neues Geheimnis"
 
-#: lib/abuuba_web/live/admin_live.ex:1896
+#: lib/abuuba_web/live/admin_live.ex:1910
 #, elixir-autogen, elixir-format
 msgid "No webhooks yet."
 msgstr "Noch keine Webhooks."
 
-#: lib/abuuba_web/live/admin_live.ex:1891
+#: lib/abuuba_web/live/admin_live.ex:1905
 #, elixir-autogen, elixir-format
 msgid "Nothing sent yet."
 msgstr "Noch nichts verschickt."
 
-#: lib/abuuba_web/live/admin_live.ex:1862
+#: lib/abuuba_web/live/admin_live.ex:1876
 #, elixir-autogen, elixir-format
 msgid "Remove this webhook?"
 msgstr "Diesen Webhook entfernen?"
 
-#: lib/abuuba_web/live/admin_live.ex:3094
-#: lib/abuuba_web/live/admin_live.ex:3662
+#: lib/abuuba_web/live/admin_live.ex:3109
+#: lib/abuuba_web/live/admin_live.ex:3677
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr "Das hat nicht geklappt."
 
-#: lib/abuuba_web/live/admin_live.ex:3659
+#: lib/abuuba_web/live/admin_live.ex:3674
 #, elixir-autogen, elixir-format
 msgid "That is not an event this server sends."
 msgstr "So ein Ereignis verschickt dieser Server nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3656
+#: lib/abuuba_web/live/admin_live.ex:3671
 #, elixir-autogen, elixir-format
 msgid "That is not an https address, or it is already here."
 msgstr "Das ist keine https-Adresse, oder sie ist schon da."
 
-#: lib/abuuba_web/live/admin_live.ex:1852
+#: lib/abuuba_web/live/admin_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "The old secret stops working immediately. Continue?"
 msgstr "Das alte Geheimnis funktioniert sofort nicht mehr. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:1798
+#: lib/abuuba_web/live/admin_live.ex:1812
 #, elixir-autogen, elixir-format
 msgid "The signing secret"
 msgstr "Das Signatur-Geheimnis"
 
-#: lib/abuuba_web/live/admin_live.ex:1792
+#: lib/abuuba_web/live/admin_live.ex:1806
 #, elixir-autogen, elixir-format
 msgid "This server posts to a webhook when something happens that a moderator would want to know about."
 msgstr "Dieser Server schickt etwas an einen Webhook, wenn etwas passiert, das die Moderation wissen möchte."
 
-#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/admin_live.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Webhooks"
 msgstr "Webhooks"
 
-#: lib/abuuba_web/live/admin_live.ex:1877
+#: lib/abuuba_web/live/admin_live.ex:1891
 #, elixir-autogen, elixir-format
 msgid "no answer"
 msgstr "keine Antwort"
 
-#: lib/abuuba_web/live/admin_live.ex:1674
+#: lib/abuuba_web/live/admin_live.ex:1688
 #, elixir-autogen, elixir-format
 msgid "A role is a set of permissions and a position. Position is what decides who may act on whom: nobody may edit a role at or above their own, and nobody may grant a permission they do not hold themselves."
 msgstr "Eine Rolle ist ein Satz Berechtigungen und eine Position. Die Position entscheidet, wer auf wen einwirken darf: niemand darf eine Rolle auf oder über der eigenen bearbeiten, und niemand darf eine Berechtigung vergeben, die er selbst nicht hat."
 
-#: lib/abuuba_web/live/admin_live.ex:1776
+#: lib/abuuba_web/live/admin_live.ex:1790
 #, elixir-autogen, elixir-format
 msgid "Above yours"
 msgstr "Über deiner"
 
-#: lib/abuuba_web/live/admin_live.ex:3575
+#: lib/abuuba_web/live/admin_live.ex:3590
 #, elixir-autogen, elixir-format
 msgid "Act on accounts"
 msgstr "Auf Konten einwirken"
 
-#: lib/abuuba_web/live/admin_live.ex:3579
+#: lib/abuuba_web/live/admin_live.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Answer appeals"
 msgstr "Einsprüche beantworten"
 
-#: lib/abuuba_web/live/admin_live.ex:3605
+#: lib/abuuba_web/live/admin_live.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Approve registrations, and turn two-factor off for somebody locked out."
 msgstr "Anmeldungen freigeben und die Zwei-Faktor-Anmeldung für Ausgesperrte abschalten."
 
-#: lib/abuuba_web/live/admin_live.ex:3583
+#: lib/abuuba_web/live/admin_live.ex:3598
 #, elixir-autogen, elixir-format
 msgid "Approve what trends"
 msgstr "Freigeben, was in den Trends erscheint"
 
-#: lib/abuuba_web/live/admin_live.ex:3613
+#: lib/abuuba_web/live/admin_live.ex:3628
 #, elixir-autogen, elixir-format
 msgid "Block and unblock other servers, and set up relays."
 msgstr "Andere Server blockieren und freigeben, und Relays einrichten."
 
-#: lib/abuuba_web/live/admin_live.ex:3581
+#: lib/abuuba_web/live/admin_live.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Block sign-ups"
 msgstr "Anmeldungen blockieren"
 
-#: lib/abuuba_web/live/admin_live.ex:3582
+#: lib/abuuba_web/live/admin_live.ex:3597
 #, elixir-autogen, elixir-format
 msgid "Change the server's settings"
 msgstr "Die Einstellungen des Servers ändern"
 
-#: lib/abuuba_web/live/admin_live.ex:1699
+#: lib/abuuba_web/live/admin_live.ex:1713
 #, elixir-autogen, elixir-format
 msgid "Colour"
 msgstr "Farbe"
 
-#: lib/abuuba_web/live/admin_live.ex:1738
+#: lib/abuuba_web/live/admin_live.ex:1752
 #, elixir-autogen, elixir-format
 msgid "Create the role"
 msgstr "Rolle anlegen"
 
-#: lib/abuuba_web/live/admin_live.ex:3580
+#: lib/abuuba_web/live/admin_live.ex:3595
 #, elixir-autogen, elixir-format
 msgid "Decide about other servers"
 msgstr "Über andere Server entscheiden"
 
-#: lib/abuuba_web/live/admin_live.ex:3619
+#: lib/abuuba_web/live/admin_live.ex:3634
 #, elixir-autogen, elixir-format
 msgid "Decide which hashtags, links and posts may appear in what is trending."
 msgstr "Entscheiden, welche Hashtags, Links und Beiträge in den Trends erscheinen dürfen."
 
-#: lib/abuuba_web/live/admin_live.ex:3577
+#: lib/abuuba_web/live/admin_live.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Delete an account's data"
 msgstr "Die Daten eines Kontos löschen"
 
-#: lib/abuuba_web/live/admin_live.ex:3608
+#: lib/abuuba_web/live/admin_live.ex:3623
 #, elixir-autogen, elixir-format
 msgid "Delete somebody's posts and files. This cannot be undone."
 msgstr "Beiträge und Dateien einer Person löschen. Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/admin_live.ex:3594
+#: lib/abuuba_web/live/admin_live.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Every permission below, including ones added later. Give it to very few people."
 msgstr "Alle Berechtigungen unten, auch später hinzugekommene. Gib sie nur ganz wenigen Leuten."
 
-#: lib/abuuba_web/live/admin_live.ex:3578
+#: lib/abuuba_web/live/admin_live.ex:3593
 #, elixir-autogen, elixir-format
 msgid "Handle reports"
 msgstr "Meldungen bearbeiten"
 
-#: lib/abuuba_web/live/admin_live.ex:3576
+#: lib/abuuba_web/live/admin_live.ex:3591
 #, elixir-autogen, elixir-format
 msgid "Let people in and out"
 msgstr "Leute hereinlassen und hinauslassen"
 
-#: lib/abuuba_web/live/admin_live.ex:3623
+#: lib/abuuba_web/live/admin_live.ex:3638
 #, elixir-autogen, elixir-format
 msgid "Make and change roles, never above their own and never granting more than they hold."
 msgstr "Rollen anlegen und ändern, nie über der eigenen und nie mit mehr, als man selbst hat."
 
-#: lib/abuuba_web/live/admin_live.ex:3588
+#: lib/abuuba_web/live/admin_live.ex:3603
 #, elixir-autogen, elixir-format
 msgid "Manage custom emoji"
 msgstr "Eigene Emojis verwalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3584
+#: lib/abuuba_web/live/admin_live.ex:3599
 #, elixir-autogen, elixir-format
 msgid "Manage everybody's invites"
 msgstr "Die Einladungen aller verwalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3590
+#: lib/abuuba_web/live/admin_live.ex:3605
 #, elixir-autogen, elixir-format
 msgid "Manage roles"
 msgstr "Rollen verwalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3589
+#: lib/abuuba_web/live/admin_live.ex:3604
 #, elixir-autogen, elixir-format
 msgid "Manage webhooks"
 msgstr "Webhooks verwalten"
 
-#: lib/abuuba_web/live/admin_live.ex:1684
+#: lib/abuuba_web/live/admin_live.ex:1698
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Name"
 
-#: lib/abuuba_web/live/admin_live.ex:1781
+#: lib/abuuba_web/live/admin_live.ex:1795
 #, elixir-autogen, elixir-format
 msgid "No roles yet."
 msgstr "Noch keine Rollen."
 
-#: lib/abuuba_web/live/admin_live.ex:1689
+#: lib/abuuba_web/live/admin_live.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Position"
 msgstr "Position"
 
-#: lib/abuuba_web/live/admin_live.ex:1752
+#: lib/abuuba_web/live/admin_live.ex:1766
 #, elixir-autogen, elixir-format
 msgid "Position %{position}"
 msgstr "Position %{position}"
 
-#: lib/abuuba_web/live/admin_live.ex:3574
+#: lib/abuuba_web/live/admin_live.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Read the audit log"
 msgstr "Das Protokoll lesen"
 
-#: lib/abuuba_web/live/admin_live.ex:3610
+#: lib/abuuba_web/live/admin_live.ex:3625
 #, elixir-autogen, elixir-format
 msgid "Read the queue, resolve and reopen."
 msgstr "Die Warteschlange lesen, erledigen und wieder öffnen."
 
-#: lib/abuuba_web/live/admin_live.ex:1770
+#: lib/abuuba_web/live/admin_live.ex:1784
 #, elixir-autogen, elixir-format
 msgid "Remove this role? Anybody holding it keeps their account."
 msgstr "Diese Rolle entfernen? Wer sie hat, behält sein Konto."
 
-#: lib/abuuba_web/live/admin_live.ex:3377
+#: lib/abuuba_web/live/admin_live.ex:3392
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr "Rollen"
 
-#: lib/abuuba_web/live/admin_live.ex:1738
+#: lib/abuuba_web/live/admin_live.ex:1752
 #, elixir-autogen, elixir-format
 msgid "Save the role"
 msgstr "Rolle speichern"
 
-#: lib/abuuba_web/live/admin_live.ex:3573
+#: lib/abuuba_web/live/admin_live.ex:3588
 #, elixir-autogen, elixir-format
 msgid "See the admin area"
 msgstr "Den Administrationsbereich sehen"
 
-#: lib/abuuba_web/live/admin_live.ex:3602
+#: lib/abuuba_web/live/admin_live.ex:3617
 #, elixir-autogen, elixir-format
 msgid "Silence, suspend, approve and reject accounts on this server."
 msgstr "Konten auf diesem Server einschränken, sperren, freigeben und ablehnen."
 
-#: lib/abuuba_web/live/admin_live.ex:3487
-#: lib/abuuba_web/live/admin_live.ex:3513
+#: lib/abuuba_web/live/admin_live.ex:3502
+#: lib/abuuba_web/live/admin_live.ex:3528
 #, elixir-autogen, elixir-format
 msgid "That role could not be saved."
 msgstr "Diese Rolle konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3599
+#: lib/abuuba_web/live/admin_live.ex:3614
 #, elixir-autogen, elixir-format
 msgid "What every moderator has done, including this person's own actions."
 msgstr "Was jede moderierende Person getan hat, auch die eigenen Aktionen."
 
-#: lib/abuuba_web/live/admin_live.ex:1711
+#: lib/abuuba_web/live/admin_live.ex:1725
 #, elixir-autogen, elixir-format
 msgid "What this role may do"
 msgstr "Was diese Rolle darf"
 
-#: lib/abuuba_web/live/admin_live.ex:3616
+#: lib/abuuba_web/live/admin_live.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Who may sign up, the server's name and description, and the rest."
 msgstr "Wer sich anmelden darf, Name und Beschreibung des Servers, und der Rest."
 
-#: lib/abuuba_web/live/admin_live.ex:3596
+#: lib/abuuba_web/live/admin_live.ex:3611
 #, elixir-autogen, elixir-format
 msgid "Without this the admin area is closed."
 msgstr "Ohne das ist der Administrationsbereich zu."
 
-#: lib/abuuba_web/live/admin_live.ex:3587
+#: lib/abuuba_web/live/admin_live.ex:3602
 #, elixir-autogen, elixir-format
 msgid "Write announcements"
 msgstr "Ankündigungen schreiben"
 
-#: lib/abuuba_web/live/admin_live.ex:3585
+#: lib/abuuba_web/live/admin_live.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Write invites"
 msgstr "Einladungen schreiben"
 
-#: lib/abuuba_web/live/admin_live.ex:3586
+#: lib/abuuba_web/live/admin_live.ex:3601
 #, elixir-autogen, elixir-format
 msgid "Write the server rules"
 msgstr "Die Serverregeln schreiben"
 
-#: lib/abuuba_web/live/admin_live.ex:3566
+#: lib/abuuba_web/live/admin_live.ex:3581
 #, elixir-autogen, elixir-format
 msgid "You cannot make a role at or above your own position, or grant a permission you do not hold."
 msgstr "Du kannst keine Rolle auf oder über deiner eigenen Position anlegen und keine Berechtigung vergeben, die du selbst nicht hast."
 
-#: lib/abuuba_web/live/admin_live.ex:1731
+#: lib/abuuba_web/live/admin_live.ex:1745
 #, elixir-autogen, elixir-format
 msgid "You do not hold this yourself, so you cannot grant it."
 msgstr "Das hast du selbst nicht, also kannst du es nicht vergeben."
 
-#: lib/abuuba_web/live/admin_live.ex:3636
+#: lib/abuuba_web/live/admin_live.ex:3651
 #, elixir-autogen, elixir-format
 msgid "nothing in particular"
 msgstr "nichts Bestimmtes"
 
-#: lib/abuuba_web/live/admin_live.ex:922
-#: lib/abuuba_web/live/admin_live.ex:1571
+#: lib/abuuba_web/live/admin_live.ex:935
+#: lib/abuuba_web/live/admin_live.ex:1584
 #, elixir-autogen, elixir-format
 msgid "A note for the other moderators"
 msgstr "Eine Notiz für die anderen Moderierenden"
 
-#: lib/abuuba_web/live/admin_live.ex:1548
+#: lib/abuuba_web/live/admin_live.ex:1561
 #, elixir-autogen, elixir-format
 msgid "Blocked: %{severity}"
 msgstr "Blockiert: %{severity}"
 
-#: lib/abuuba_web/live/admin_live.ex:1506
+#: lib/abuuba_web/live/admin_live.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Delivering"
 msgstr "Zustellung läuft"
 
-#: lib/abuuba_web/live/admin_live.ex:1492
+#: lib/abuuba_web/live/admin_live.ex:1505
 #, elixir-autogen, elixir-format
 msgid "Delivery stopped by a moderator"
 msgstr "Zustellung von der Moderation gestoppt"
 
-#: lib/abuuba_web/live/admin_live.ex:1459
+#: lib/abuuba_web/live/admin_live.ex:1472
 #, elixir-autogen, elixir-format
 msgid "Every server this one has heard from, busiest first. A peer that has quietly stopped accepting deliveries looks exactly like a peer whose people have gone quiet, and this is where the two are told apart."
 msgstr "Jeder Server, von dem dieser hier gehört hat, der geschäftigste zuerst. Ein Gegenüber, das stillschweigend nichts mehr annimmt, sieht genauso aus wie eines, dessen Leute einfach ruhig geworden sind — hier lassen sich die beiden auseinanderhalten."
 
-#: lib/abuuba_web/live/admin_live.ex:1544
+#: lib/abuuba_web/live/admin_live.ex:1557
 #, elixir-autogen, elixir-format
 msgid "Forget the failures"
 msgstr "Fehlschläge vergessen"
 
-#: lib/abuuba_web/live/admin_live.ex:1580
+#: lib/abuuba_web/live/admin_live.ex:1593
 #, elixir-autogen, elixir-format
 msgid "No other servers yet."
 msgstr "Noch keine anderen Server."
 
-#: lib/abuuba_web/live/admin_live.ex:1484
+#: lib/abuuba_web/live/admin_live.ex:1497
 #, elixir-autogen, elixir-format
 msgid "One account"
 msgid_plural "%{count} accounts"
 msgstr[0] "Ein Konto"
 msgstr[1] "%{count} Konten"
 
-#: lib/abuuba_web/live/admin_live.ex:3376
+#: lib/abuuba_web/live/admin_live.ex:3391
 #, elixir-autogen, elixir-format
 msgid "Other servers"
 msgstr "Andere Server"
 
-#: lib/abuuba_web/live/admin_live.ex:1561
+#: lib/abuuba_web/live/admin_live.ex:1574
 #, elixir-autogen, elixir-format
 msgid "Silence this server"
 msgstr "Diesen Server stummschalten"
 
-#: lib/abuuba_web/live/admin_live.ex:1558
+#: lib/abuuba_web/live/admin_live.ex:1571
 #, elixir-autogen, elixir-format
 msgid "Silence this server? Its posts stop appearing in public timelines."
 msgstr "Diesen Server stummschalten? Seine Beiträge erscheinen dann nicht mehr in öffentlichen Timelines."
 
-#: lib/abuuba_web/live/admin_live.ex:1534
+#: lib/abuuba_web/live/admin_live.ex:1547
 #, elixir-autogen, elixir-format
 msgid "Start again"
 msgstr "Wieder starten"
 
-#: lib/abuuba_web/live/admin_live.ex:1524
+#: lib/abuuba_web/live/admin_live.ex:1537
 #, elixir-autogen, elixir-format
 msgid "Stop delivering"
 msgstr "Zustellung stoppen"
 
-#: lib/abuuba_web/live/admin_live.ex:2670
+#: lib/abuuba_web/live/admin_live.ex:2684
 #, elixir-autogen, elixir-format
 msgid "That server could not be blocked."
 msgstr "Dieser Server konnte nicht blockiert werden."
 
-#: lib/abuuba_web/live/admin_live.ex:1498
+#: lib/abuuba_web/live/admin_live.ex:1511
 #, elixir-autogen, elixir-format
 msgid "Treated as down since %{when}"
 msgstr "Gilt seit %{when} als nicht erreichbar"
 
-#: lib/abuuba_web/live/admin_live.ex:1509
+#: lib/abuuba_web/live/admin_live.ex:1522
 #, elixir-autogen, elixir-format
 msgid "one bad day"
 msgid_plural "%{count} bad days"
 msgstr[0] "ein schlechter Tag"
 msgstr[1] "%{count} schlechte Tage"
 
-#: lib/abuuba_web/live/admin_live.ex:1484
+#: lib/abuuba_web/live/admin_live.ex:1497
 #, elixir-autogen, elixir-format
 msgid "one post"
 msgid_plural "%{count} posts"
 msgstr[0] "ein Beitrag"
 msgstr[1] "%{count} Beiträge"
 
-#: lib/abuuba_web/live/admin_live.ex:955
+#: lib/abuuba_web/live/admin_live.ex:968
 #, elixir-autogen, elixir-format
 msgid "Ask their server for it again. Worth doing when the name or picture here is out of date and waiting for their next post is waiting for something that may not come."
 msgstr "Frag ihren Server noch einmal danach. Sinnvoll, wenn Name oder Bild hier veraltet sind und das Warten auf den nächsten Beitrag ein Warten auf etwas ist, das vielleicht nie kommt."
 
-#: lib/abuuba_web/live/admin_live.ex:982
+#: lib/abuuba_web/live/admin_live.ex:995
 #, elixir-autogen, elixir-format
 msgid "Delete this post? Other servers are told to delete it too."
 msgstr "Diesen Beitrag löschen? Andere Server werden aufgefordert, ihre Kopie ebenfalls zu löschen."
 
-#: lib/abuuba_web/live/admin_live.ex:967
+#: lib/abuuba_web/live/admin_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "Deleting one from here is the same delete they would do themselves."
 msgstr "Von hier aus zu löschen ist dasselbe Löschen, das die Person selbst machen würde."
 
-#: lib/abuuba_web/live/admin_live.ex:960
+#: lib/abuuba_web/live/admin_live.ex:973
 #, elixir-autogen, elixir-format
 msgid "Fetch it again"
 msgstr "Noch einmal holen"
 
-#: lib/abuuba_web/live/admin_live.ex:948
+#: lib/abuuba_web/live/admin_live.ex:961
 #, elixir-autogen, elixir-format
 msgid "Force a password reset"
 msgstr "Passwort-Zurücksetzen erzwingen"
 
-#: lib/abuuba_web/live/admin_live.ex:936
+#: lib/abuuba_web/live/admin_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Locked out, or somebody else is in"
 msgstr "Ausgesperrt, oder jemand anderes ist drin"
 
-#: lib/abuuba_web/live/admin_live.ex:924
+#: lib/abuuba_web/live/admin_live.ex:937
 #, elixir-autogen, elixir-format
 msgid "Nobody is told and nothing is applied. This is for the context that otherwise lives in one person's head: that this is the third report about the same joke, or that somebody spoke to them and they understood."
 msgstr "Niemand wird benachrichtigt und nichts wird angewendet. Das hier ist für den Zusammenhang, der sonst nur in einem Kopf steckt: dass dies die dritte Meldung zum selben Witz ist, oder dass jemand mit ihnen gesprochen hat und sie es verstanden haben."
 
-#: lib/abuuba_web/live/admin_live.ex:991
+#: lib/abuuba_web/live/admin_live.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Nothing posted."
 msgstr "Nichts geschrieben."
 
-#: lib/abuuba_web/live/admin_live.ex:945
+#: lib/abuuba_web/live/admin_live.ex:958
 #, elixir-autogen, elixir-format
 msgid "Sign them out everywhere and send a reset link?"
 msgstr "Überall abmelden und einen Link zum Zurücksetzen schicken?"
 
-#: lib/abuuba_web/live/admin_live.ex:2688
+#: lib/abuuba_web/live/admin_live.ex:2702
 #, elixir-autogen, elixir-format
 msgid "That account has nobody to sign in as."
 msgstr "Zu diesem Konto gibt es niemanden, der sich anmelden könnte."
 
-#: lib/abuuba_web/live/admin_live.ex:965
+#: lib/abuuba_web/live/admin_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "Their most recent posts"
 msgstr "Ihre letzten Beiträge"
 
-#: lib/abuuba_web/live/admin_live.ex:953
+#: lib/abuuba_web/live/admin_live.ex:966
 #, elixir-autogen, elixir-format
 msgid "Their profile here is a copy"
 msgstr "Ihr Profil ist hier nur eine Kopie"
 
-#: lib/abuuba_web/live/admin_live.ex:2701
+#: lib/abuuba_web/live/admin_live.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Their server did not answer."
 msgstr "Ihr Server hat nicht geantwortet."
 
-#: lib/abuuba_web/live/admin_live.ex:938
+#: lib/abuuba_web/live/admin_live.ex:951
 #, elixir-autogen, elixir-format
 msgid "This ends every session and every app, and emails them a link to set a new password. It does not choose one for them: a password a moderator picked is a password a moderator knows."
 msgstr "Das beendet jede Sitzung und jede App und schickt ihnen per E-Mail einen Link, um ein neues Passwort zu setzen. Es wählt keines für sie aus: ein Passwort, das die Moderation vergeben hat, ist ein Passwort, das die Moderation kennt."
 
-#: lib/abuuba_web/live/admin_live.ex:2137
+#: lib/abuuba_web/live/admin_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "%{latest} is out."
 msgstr "%{latest} ist draußen."
 
-#: lib/abuuba_web/live/admin_live.ex:1289
+#: lib/abuuba_web/live/admin_live.ex:1302
 #, elixir-autogen, elixir-format
 msgid "A server that has decided about four hundred domains has made four hundred decisions, and the way those get shared is a list somebody publishes. This reads and writes those lists."
 msgstr "Ein Server, der über vierhundert Domains entschieden hat, hat vierhundert Entscheidungen getroffen, und weitergegeben werden die als Liste, die jemand veröffentlicht. Hier werden solche Listen gelesen und geschrieben."
 
-#: lib/abuuba_web/live/admin_live.ex:2757
+#: lib/abuuba_web/live/admin_live.ex:2771
 #, elixir-autogen, elixir-format
 msgid "Added %{added}. %{skipped} were already decided about."
 msgstr "%{added} hinzugefügt. Über %{skipped} war schon entschieden."
 
-#: lib/abuuba_web/live/admin_live.ex:1431
+#: lib/abuuba_web/live/admin_live.ex:1444
 #, elixir-autogen, elixir-format
 msgid "Addresses that asked one account here to write to them. Only the confirmed ones are counted: an unconfirmed address is a claim somebody typed, not a subscriber."
 msgstr "Adressen, die ein Konto hier gebeten haben, ihnen zu schreiben. Gezählt werden nur die bestätigten: eine unbestätigte Adresse ist eine Behauptung, die jemand eingetippt hat, kein Abonnement."
 
-#: lib/abuuba_web/live/admin_live.ex:1304
-#: lib/abuuba_web/live/admin_live.ex:1319
+#: lib/abuuba_web/live/admin_live.ex:1317
+#: lib/abuuba_web/live/admin_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Allows"
 msgstr "Erlaubte"
 
-#: lib/abuuba_web/live/admin_live.ex:2114
+#: lib/abuuba_web/live/admin_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Checking for updates"
 msgstr "Nach Aktualisierungen sehen"
 
-#: lib/abuuba_web/live/admin_live.ex:3375
+#: lib/abuuba_web/live/admin_live.ex:3390
 #, elixir-autogen, elixir-format
 msgid "Domain lists"
 msgstr "Domain-Listen"
 
-#: lib/abuuba_web/live/admin_live.ex:1309
+#: lib/abuuba_web/live/admin_live.ex:1322
 #, elixir-autogen, elixir-format
 msgid "Domains this server has already decided about are left exactly as they are. An import adds and never removes: one paste should not be able to undo every decision made here, silently and unrecoverably."
 msgstr "Domains, über die dieser Server schon entschieden hat, bleiben genau so, wie sie sind. Ein Import fügt hinzu und entfernt nie: ein einziges Einfügen soll nicht jede hier getroffene Entscheidung stillschweigend und unwiederbringlich rückgängig machen können."
 
-#: lib/abuuba_web/live/admin_live.ex:3373
+#: lib/abuuba_web/live/admin_live.ex:3388
 #, elixir-autogen, elixir-format
 msgid "Email subscriptions"
 msgstr "E-Mail-Abos"
 
-#: lib/abuuba_web/live/admin_live.ex:1448
+#: lib/abuuba_web/live/admin_live.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Nobody here has any subscribers."
 msgstr "Niemand hier hat Abonnenten."
 
-#: lib/abuuba_web/live/admin_live.ex:1421
+#: lib/abuuba_web/live/admin_live.ex:1434
 #, elixir-autogen, elixir-format
 msgid "Nobody is being suggested yet. It needs a few follows to work from."
 msgstr "Es wird noch niemand vorgeschlagen. Dafür braucht es erst ein paar Folge-Beziehungen."
 
-#: lib/abuuba_web/live/admin_live.ex:1403
+#: lib/abuuba_web/live/admin_live.ex:1416
 #, elixir-autogen, elixir-format
 msgid "Not suggested"
 msgstr "Wird nicht vorgeschlagen"
 
-#: lib/abuuba_web/live/admin_live.ex:2116
+#: lib/abuuba_web/live/admin_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. It asks %{url} whether there is a newer abuuba. What that tells them is what any web request tells anybody: this server's address, a user agent, and that somebody asked. Nothing about the accounts here, their number or their posts is sent, and there is nowhere in the request for it to go."
 msgstr "Aus, solange du es nicht einschaltest. Es fragt %{url}, ob es ein neueres abuuba gibt. Was das dort verrät, ist das, was jede Web-Anfrage verrät: die Adresse dieses Servers, einen User-Agent und dass jemand gefragt hat. Nichts über die Konten hier, ihre Zahl oder ihre Beiträge wird gesendet, und in der Anfrage ist auch kein Platz dafür."
 
-#: lib/abuuba_web/live/admin_live.ex:1442
+#: lib/abuuba_web/live/admin_live.ex:1455
 #, elixir-autogen, elixir-format
 msgid "One address"
 msgid_plural "%{count} addresses"
 msgstr[0] "Eine Adresse"
 msgstr[1] "%{count} Adressen"
 
-#: lib/abuuba_web/live/admin_live.ex:1296
+#: lib/abuuba_web/live/admin_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "One blocked domain"
 msgid_plural "%{count} blocked domains"
 msgstr[0] "Eine blockierte Domain"
 msgstr[1] "%{count} blockierte Domains"
 
-#: lib/abuuba_web/live/admin_live.ex:1330
+#: lib/abuuba_web/live/admin_live.ex:1343
 #, elixir-autogen, elixir-format
 msgid "Read it in"
 msgstr "Einlesen"
 
-#: lib/abuuba_web/live/admin_live.ex:1307
+#: lib/abuuba_web/live/admin_live.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Read one in"
 msgstr "Eine einlesen"
 
-#: lib/abuuba_web/live/admin_live.ex:2135
+#: lib/abuuba_web/live/admin_live.ex:2149
 #, elixir-autogen, elixir-format
 msgid "Running %{version}."
 msgstr "Läuft mit %{version}."
 
-#: lib/abuuba_web/live/admin_live.ex:1415
+#: lib/abuuba_web/live/admin_live.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Stop suggesting"
 msgstr "Nicht mehr vorschlagen"
 
-#: lib/abuuba_web/live/admin_live.ex:1414
+#: lib/abuuba_web/live/admin_live.ex:1427
 #, elixir-autogen, elixir-format
 msgid "Suggest again"
 msgstr "Wieder vorschlagen"
 
-#: lib/abuuba_web/live/admin_live.ex:1294
+#: lib/abuuba_web/live/admin_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Take a copy"
 msgstr "Eine Kopie mitnehmen"
 
-#: lib/abuuba_web/live/admin_live.ex:2131
+#: lib/abuuba_web/live/admin_live.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Tell me when there is a newer version"
 msgstr "Sag mir Bescheid, wenn es eine neuere Version gibt"
@@ -4847,104 +4847,104 @@ msgstr "Sag mir Bescheid, wenn es eine neuere Version gibt"
 msgid "There is no list of that kind."
 msgstr "So eine Liste gibt es nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:1316
+#: lib/abuuba_web/live/admin_live.ex:1329
 #, elixir-autogen, elixir-format
 msgid "Which list"
 msgstr "Welche Liste"
 
-#: lib/abuuba_web/live/admin_live.ex:1391
+#: lib/abuuba_web/live/admin_live.ex:1404
 #, elixir-autogen, elixir-format
 msgid "Who this server puts in front of a newcomer. Taking somebody out is not a block and not a silence: their account carries on exactly as before and nobody is told."
 msgstr "Wen dieser Server Neuankömmlingen zeigt. Jemanden herauszunehmen ist keine Blockade und keine Stummschaltung: das Konto läuft genau wie vorher weiter, und niemand wird benachrichtigt."
 
-#: lib/abuuba_web/live/admin_live.ex:1296
+#: lib/abuuba_web/live/admin_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "one allowed domain"
 msgid_plural "%{count} allowed domains"
 msgstr[0] "eine erlaubte Domain"
 msgstr[1] "%{count} erlaubte Domains"
 
-#: lib/abuuba_web/live/admin_live.ex:344
+#: lib/abuuba_web/live/admin_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "%{label}, highest %{top}"
 msgstr "%{label}, höchster Wert %{top}"
 
-#: lib/abuuba_web/live/admin_live.ex:3690
+#: lib/abuuba_web/live/admin_live.ex:3705
 #, elixir-autogen, elixir-format
 msgid "Favourites, boosts and replies"
 msgstr "Favoriten, Boosts und Antworten"
 
-#: lib/abuuba_web/live/admin_live.ex:3695
+#: lib/abuuba_web/live/admin_live.ex:3710
 #, elixir-autogen, elixir-format
 msgid "Languages people write in"
 msgstr "Sprachen, in denen geschrieben wird"
 
-#: lib/abuuba_web/live/admin_live.ex:3688
+#: lib/abuuba_web/live/admin_live.ex:3703
 #, elixir-autogen, elixir-format
 msgid "New accounts"
 msgstr "Neue Konten"
 
-#: lib/abuuba_web/live/admin_live.ex:425
+#: lib/abuuba_web/live/admin_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Of the people who signed up in a given week, how many were still posting in the weeks after. A number that only means something once the server has been running a while."
 msgstr "Von den Leuten, die sich in einer bestimmten Woche angemeldet haben: wie viele in den Wochen danach noch geschrieben haben. Eine Zahl, die erst etwas bedeutet, wenn der Server eine Weile läuft."
 
-#: lib/abuuba_web/live/admin_live.ex:3687
+#: lib/abuuba_web/live/admin_live.ex:3702
 #, elixir-autogen, elixir-format
 msgid "People who posted"
 msgstr "Leute, die geschrieben haben"
 
-#: lib/abuuba_web/live/admin_live.ex:3689
+#: lib/abuuba_web/live/admin_live.ex:3704
 #, elixir-autogen, elixir-format
 msgid "Posts written here"
 msgstr "Hier geschriebene Beiträge"
 
-#: lib/abuuba_web/live/admin_live.ex:3691
+#: lib/abuuba_web/live/admin_live.ex:3706
 #, elixir-autogen, elixir-format
 msgid "Reports opened"
 msgstr "Eröffnete Meldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3692
+#: lib/abuuba_web/live/admin_live.ex:3707
 #, elixir-autogen, elixir-format
 msgid "Reports resolved"
 msgstr "Erledigte Meldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3697
+#: lib/abuuba_web/live/admin_live.ex:3712
 #, elixir-autogen, elixir-format
 msgid "Servers we hear most from"
 msgstr "Server, von denen wir am meisten hören"
 
-#: lib/abuuba_web/live/admin_live.ex:389
+#: lib/abuuba_web/live/admin_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "The last thirty days"
 msgstr "Die letzten dreißig Tage"
 
-#: lib/abuuba_web/live/admin_live.ex:391
+#: lib/abuuba_web/live/admin_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "The same numbers a moderation client draws from the API, so what you see here and what it shows are the same figures rather than two answers to one question."
 msgstr "Dieselben Zahlen, die sich ein Moderations-Client über die API holt — was du hier siehst und was der anzeigt, sind also dieselben Werte und nicht zwei Antworten auf eine Frage."
 
-#: lib/abuuba_web/live/admin_live.ex:3698
+#: lib/abuuba_web/live/admin_live.ex:3713
 #, elixir-autogen, elixir-format
 msgid "What those servers run"
 msgstr "Was auf diesen Servern läuft"
 
-#: lib/abuuba_web/live/admin_live.ex:3696
+#: lib/abuuba_web/live/admin_live.ex:3711
 #, elixir-autogen, elixir-format
 msgid "Where accounts signed up from"
 msgstr "Woher sich Konten angemeldet haben"
 
-#: lib/abuuba_web/live/admin_live.ex:404
+#: lib/abuuba_web/live/admin_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Where things come from"
 msgstr "Woher die Dinge kommen"
 
-#: lib/abuuba_web/live/admin_live.ex:423
+#: lib/abuuba_web/live/admin_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Who stayed"
 msgstr "Wer geblieben ist"
 
-#: lib/abuuba_web/live/admin_live.ex:434
+#: lib/abuuba_web/live/admin_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "one signed up"
 msgid_plural "%{count} signed up"
@@ -4966,7 +4966,7 @@ msgstr "Titelbild"
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr "JPEG, PNG, GIF oder WebP, bis %{size}. Größere werden schon vor dem Hochladen abgelehnt und nicht erst danach, und was du schickst, wird hier verkleinert, damit niemand ein ganzes Foto lädt, um es bei vierzig Pixeln zu sehen."
 
-#: lib/abuuba_web/live/admin_live.ex:552
+#: lib/abuuba_web/live/admin_live.ex:565
 #: lib/abuuba_web/live/settings_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "None yet."
@@ -5118,222 +5118,222 @@ msgstr "Nachricht"
 msgid "On its way."
 msgstr "Unterwegs."
 
-#: lib/abuuba_web/live/admin_live.ex:2423
+#: lib/abuuba_web/live/admin_live.ex:2437
 #, elixir-autogen, elixir-format
 msgid "A preset needs both."
 msgstr "Ein Baustein braucht beides."
 
-#: lib/abuuba_web/live/admin_live.ex:494
-#: lib/abuuba_web/live/admin_live.ex:710
+#: lib/abuuba_web/live/admin_live.ex:507
+#: lib/abuuba_web/live/admin_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "Add it"
 msgstr "Hinzufügen"
 
-#: lib/abuuba_web/live/admin_live.ex:570
+#: lib/abuuba_web/live/admin_live.ex:583
 #, elixir-autogen, elixir-format
 msgid "All of them"
 msgstr "Alle"
 
-#: lib/abuuba_web/live/admin_live.ex:568
+#: lib/abuuba_web/live/admin_live.ex:581
 #, elixir-autogen, elixir-format
 msgid "Dealt with"
 msgstr "Erledigt"
 
-#: lib/abuuba_web/live/admin_live.ex:777
+#: lib/abuuba_web/live/admin_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "Do it to all of them"
 msgstr "Auf alle anwenden"
 
-#: lib/abuuba_web/live/admin_live.ex:629
+#: lib/abuuba_web/live/admin_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "Filed as %{category} on %{date}."
 msgstr "Am %{date} unter %{category} gemeldet."
 
-#: lib/abuuba_web/live/admin_live.ex:687
+#: lib/abuuba_web/live/admin_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "For whoever picks this up next. The person reported never sees any of it, and neither does whoever filed it."
 msgstr "Für die Person, die das als Nächstes übernimmt. Weder die gemeldete Person noch die meldende sieht davon etwas."
 
-#: lib/abuuba_web/live/admin_live.ex:663
+#: lib/abuuba_web/live/admin_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "I am on this"
 msgstr "Ich kümmere mich"
 
-#: lib/abuuba_web/live/admin_live.ex:2173
+#: lib/abuuba_web/live/admin_live.ex:2187
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Speichern"
 
-#: lib/abuuba_web/live/admin_live.ex:3295
+#: lib/abuuba_web/live/admin_live.ex:3310
 #, elixir-autogen, elixir-format
 msgid "Limit them"
 msgstr "Einschränken"
 
-#: lib/abuuba_web/live/admin_live.ex:672
+#: lib/abuuba_web/live/admin_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "Mark it dealt with"
 msgstr "Als erledigt markieren"
 
-#: lib/abuuba_web/live/admin_live.ex:601
+#: lib/abuuba_web/live/admin_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Nothing waiting."
 msgstr "Nichts offen."
 
-#: lib/abuuba_web/live/admin_live.ex:855
+#: lib/abuuba_web/live/admin_live.ex:868
 #, elixir-autogen, elixir-format
 msgid "Nothing, I will write it"
 msgstr "Nichts, ich schreibe selbst"
 
-#: lib/abuuba_web/live/admin_live.ex:757
+#: lib/abuuba_web/live/admin_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "One account ticked."
 msgid_plural "%{count} accounts ticked."
 msgstr[0] "Ein Konto ausgewählt."
 msgstr[1] "%{count} Konten ausgewählt."
 
-#: lib/abuuba_web/live/admin_live.ex:681
+#: lib/abuuba_web/live/admin_live.ex:694
 #, elixir-autogen, elixir-format
 msgid "Put it back in the queue"
 msgstr "Zurück in die Warteschlange"
 
-#: lib/abuuba_web/live/admin_live.ex:2155
+#: lib/abuuba_web/live/admin_live.ex:2169
 #, elixir-autogen, elixir-format
 msgid "Ready-made texts a moderator picks instead of retyping. Kept for the server rather than for one moderator, so two people writing about the same thing say the same thing."
 msgstr "Fertige Texte, die man auswählt, statt sie neu zu tippen. Sie gehören zum Server und nicht zu einer einzelnen moderierenden Person, damit zwei Leute zur selben Sache dasselbe schreiben."
 
-#: lib/abuuba_web/live/admin_live.ex:3367
+#: lib/abuuba_web/live/admin_live.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr "Meldung"
 
-#: lib/abuuba_web/live/admin_live.ex:578
+#: lib/abuuba_web/live/admin_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "Report %{id}"
 msgstr "Meldung %{id}"
 
-#: lib/abuuba_web/live/admin_live.ex:3365
+#: lib/abuuba_web/live/admin_live.ex:3380
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr "Meldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:853
+#: lib/abuuba_web/live/admin_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "Start from"
 msgstr "Ausgehen von"
 
-#: lib/abuuba_web/live/admin_live.ex:566
+#: lib/abuuba_web/live/admin_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Still open"
 msgstr "Noch offen"
 
-#: lib/abuuba_web/live/admin_live.ex:3297
+#: lib/abuuba_web/live/admin_live.ex:3312
 #, elixir-autogen, elixir-format
 msgid "Stop them signing in"
 msgstr "Anmeldung sperren"
 
-#: lib/abuuba_web/live/admin_live.ex:3296
+#: lib/abuuba_web/live/admin_live.ex:3311
 #, elixir-autogen, elixir-format
 msgid "Suspend them"
 msgstr "Sperren"
 
-#: lib/abuuba_web/live/admin_live.ex:639
+#: lib/abuuba_web/live/admin_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "The posts it names"
 msgstr "Die genannten Beiträge"
 
-#: lib/abuuba_web/live/admin_live.ex:770
+#: lib/abuuba_web/live/admin_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "This does the same thing to one account and tells them. Go ahead?"
 msgid_plural "This does the same thing to all %{count} accounts and tells each of them. Go ahead?"
 msgstr[0] "Das tut dasselbe mit einem Konto und teilt es ihm mit. Fortfahren?"
 msgstr[1] "Das tut dasselbe mit allen %{count} Konten und teilt es jedem einzeln mit. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:788
+#: lib/abuuba_web/live/admin_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "Tick %{name}"
 msgstr "%{name} auswählen"
 
-#: lib/abuuba_web/live/admin_live.ex:755
+#: lib/abuuba_web/live/admin_live.ex:768
 #, elixir-autogen, elixir-format
 msgid "Tick some accounts to do one thing to all of them."
 msgstr "Konten auswählen, um dasselbe mit allen zu tun."
 
-#: lib/abuuba_web/live/admin_live.ex:2153
+#: lib/abuuba_web/live/admin_live.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Warning presets"
 msgstr "Verwarnungs-Bausteine"
 
-#: lib/abuuba_web/live/admin_live.ex:2170
+#: lib/abuuba_web/live/admin_live.ex:2184
 #, elixir-autogen, elixir-format
 msgid "What it says"
 msgstr "Was darin steht"
 
-#: lib/abuuba_web/live/admin_live.ex:685
+#: lib/abuuba_web/live/admin_live.ex:698
 #, elixir-autogen, elixir-format
 msgid "What moderators have written here"
 msgstr "Was die Moderation hier notiert hat"
 
-#: lib/abuuba_web/live/admin_live.ex:707
+#: lib/abuuba_web/live/admin_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "What you found"
 msgstr "Was du herausgefunden hast"
 
-#: lib/abuuba_web/live/admin_live.ex:564
+#: lib/abuuba_web/live/admin_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Which ones"
 msgstr "Welche"
 
-#: lib/abuuba_web/live/admin_live.ex:582
+#: lib/abuuba_web/live/admin_live.ex:595
 #, elixir-autogen, elixir-format
 msgid "about"
 msgstr "über"
 
-#: lib/abuuba_web/live/admin_live.ex:589
+#: lib/abuuba_web/live/admin_live.ex:602
 #, elixir-autogen, elixir-format
 msgid "dealt with"
 msgstr "erledigt"
 
-#: lib/abuuba_web/live/admin_live.ex:582
-#: lib/abuuba_web/live/admin_live.ex:624
+#: lib/abuuba_web/live/admin_live.ex:595
+#: lib/abuuba_web/live/admin_live.ex:637
 #, elixir-autogen, elixir-format
 msgid "from"
 msgstr "von"
 
-#: lib/abuuba_web/live/admin_live.ex:3313
+#: lib/abuuba_web/live/admin_live.ex:3328
 #, elixir-autogen, elixir-format
 msgid "somebody who is gone"
 msgstr "jemand, den es nicht mehr gibt"
 
-#: lib/abuuba_web/live/admin_live.ex:591
+#: lib/abuuba_web/live/admin_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "taken"
 msgstr "übernommen"
 
-#: lib/abuuba_web/live/admin_live.ex:3272
+#: lib/abuuba_web/live/admin_live.ex:3287
 #, elixir-autogen, elixir-format
 msgid "One account could not be changed."
 msgid_plural "%{count} accounts could not be changed."
 msgstr[0] "Ein Konto konnte nicht geändert werden."
 msgstr[1] "%{count} Konten konnten nicht geändert werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3265
+#: lib/abuuba_web/live/admin_live.ex:3280
 #, elixir-autogen, elixir-format
 msgid "One account was left alone because it outranks yours."
 msgid_plural "%{count} accounts were left alone because they outrank yours."
 msgstr[0] "Ein Konto blieb unangetastet, weil es über deinem steht."
 msgstr[1] "%{count} Konten blieben unangetastet, weil sie über deinem stehen."
 
-#: lib/abuuba_web/live/admin_live.ex:605
+#: lib/abuuba_web/live/admin_live.ex:618
 #, elixir-autogen, elixir-format
 msgid "Showing the newest %{count}. Deal with some to see the ones that have waited longest."
 msgstr "Es werden die neuesten %{count} gezeigt. Arbeite welche ab, um die am längsten wartenden zu sehen."
 
-#: lib/abuuba_web/live/admin_live.ex:3230
+#: lib/abuuba_web/live/admin_live.ex:3245
 #, elixir-autogen, elixir-format
 msgid "That is not something this list can do."
 msgstr "Das kann diese Liste nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:644
+#: lib/abuuba_web/live/admin_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Warning:"
 msgstr "Warnung:"
@@ -5344,7 +5344,7 @@ msgstr "Warnung:"
 msgid "Your account may not do that."
 msgstr "Dein Konto darf das nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:650
+#: lib/abuuba_web/live/admin_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "has pictures or video"
 msgstr "mit Bild oder Video"
@@ -5454,95 +5454,95 @@ msgstr "Gefiltert: %{title}"
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
 
-#: lib/abuuba_web/live/admin_live.ex:490
+#: lib/abuuba_web/live/admin_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "A PNG or a GIF, at most %{size}."
 msgstr "Ein PNG oder ein GIF, höchstens %{size}."
 
-#: lib/abuuba_web/live/admin_live.ex:3197
+#: lib/abuuba_web/live/admin_live.ex:3212
 #, elixir-autogen, elixir-format
 msgid "A shortcode is letters, numbers and underscores, and nothing else."
 msgstr "Ein Kurzname besteht aus Buchstaben, Ziffern und Unterstrichen, sonst nichts."
 
-#: lib/abuuba_web/live/admin_live.ex:3133
-#: lib/abuuba_web/live/admin_live.ex:3179
+#: lib/abuuba_web/live/admin_live.ex:3148
+#: lib/abuuba_web/live/admin_live.ex:3194
 #, elixir-autogen, elixir-format
 msgid "An emoji has to be a PNG or a GIF."
 msgstr "Ein Emoji muss ein PNG oder ein GIF sein."
 
-#: lib/abuuba_web/live/admin_live.ex:3123
-#: lib/abuuba_web/live/admin_live.ex:3157
+#: lib/abuuba_web/live/admin_live.ex:3138
+#: lib/abuuba_web/live/admin_live.ex:3172
 #, elixir-autogen, elixir-format
 msgid "Choose a picture for it."
 msgstr "Wähle ein Bild dafür aus."
 
-#: lib/abuuba_web/live/admin_live.ex:3366
+#: lib/abuuba_web/live/admin_live.ex:3381
 #, elixir-autogen, elixir-format
 msgid "Custom emoji"
 msgstr "Eigene Emojis"
 
-#: lib/abuuba_web/live/admin_live.ex:543
+#: lib/abuuba_web/live/admin_live.ex:556
 #, elixir-autogen, elixir-format
 msgid "Every post that used it loses its picture. Go ahead?"
 msgstr "Jeder Beitrag, der es benutzt hat, verliert sein Bild. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:481
+#: lib/abuuba_web/live/admin_live.ex:494
 #, elixir-autogen, elixir-format
 msgid "Group it under"
 msgstr "Einordnen unter"
 
-#: lib/abuuba_web/live/admin_live.ex:518
+#: lib/abuuba_web/live/admin_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "Offer it"
 msgstr "Anbieten"
 
-#: lib/abuuba_web/live/admin_live.ex:468
+#: lib/abuuba_web/live/admin_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Pictures people here can type into a post by name. One uploaded here is held on this server, so it outlives whoever made it."
 msgstr "Bilder, die man hier über ihren Namen in einen Beitrag schreiben kann. Ein hier hochgeladenes liegt auf diesem Server und überlebt damit den, von dem es stammt."
 
-#: lib/abuuba_web/live/admin_live.ex:476
+#: lib/abuuba_web/live/admin_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Shortcode"
 msgstr "Kurzname"
 
-#: lib/abuuba_web/live/admin_live.ex:517
+#: lib/abuuba_web/live/admin_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Stop offering it"
 msgstr "Nicht mehr anbieten"
 
-#: lib/abuuba_web/live/admin_live.ex:3199
+#: lib/abuuba_web/live/admin_live.ex:3214
 #, elixir-autogen, elixir-format
 msgid "That emoji could not be saved."
 msgstr "Dieses Emoji konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3185
+#: lib/abuuba_web/live/admin_live.ex:3200
 #, elixir-autogen, elixir-format
 msgid "That picture could not be stored."
 msgstr "Dieses Bild konnte nicht abgelegt werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3139
+#: lib/abuuba_web/live/admin_live.ex:3154
 #, elixir-autogen, elixir-format
 msgid "That picture could not be used."
 msgstr "Dieses Bild konnte nicht verwendet werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3136
-#: lib/abuuba_web/live/admin_live.ex:3182
+#: lib/abuuba_web/live/admin_live.ex:3151
+#: lib/abuuba_web/live/admin_live.ex:3197
 #, elixir-autogen, elixir-format
 msgid "That picture is too large for an emoji."
 msgstr "Dieses Bild ist zu groß für ein Emoji."
 
-#: lib/abuuba_web/live/admin_live.ex:487
+#: lib/abuuba_web/live/admin_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "The picture"
 msgstr "Das Bild"
 
-#: lib/abuuba_web/live/admin_live.ex:3120
+#: lib/abuuba_web/live/admin_live.ex:3135
 #, elixir-autogen, elixir-format
 msgid "The picture is still uploading. Try again in a moment."
 msgstr "Das Bild wird noch hochgeladen. Gleich noch einmal versuchen."
 
-#: lib/abuuba_web/live/admin_live.ex:505
+#: lib/abuuba_web/live/admin_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "not offered"
 msgstr "nicht angeboten"
@@ -5632,22 +5632,22 @@ msgstr "Dein Jahr auf diesem Server ist fertig zum Lesen"
 msgid "Quotes"
 msgstr "Zitate"
 
-#: lib/abuuba_web/live/admin_live.ex:2019
+#: lib/abuuba_web/live/admin_live.ex:2033
 #, elixir-autogen, elixir-format
 msgid "Days to keep other servers' files"
 msgstr "Tage, die Dateien anderer Server bleiben"
 
-#: lib/abuuba_web/live/admin_live.ex:2028
+#: lib/abuuba_web/live/admin_live.ex:2042
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them indefinitely. Anything older goes off this server's disk each night. The posts stay, and a file is fetched again if somebody opens it."
 msgstr "Null behält sie unbegrenzt. Alles Ältere verschwindet jede Nacht von der Platte dieses Servers. Die Beiträge bleiben, und eine Datei wird neu geholt, wenn jemand sie öffnet."
 
-#: lib/abuuba_web/live/admin_live.ex:530
+#: lib/abuuba_web/live/admin_live.ex:543
 #, elixir-autogen, elixir-format
 msgid "Every post that used it loses its picture until you turn it back on. Go ahead?"
 msgstr "Jeder Beitrag, der es benutzt hat, verliert sein Bild, bis du es wieder einschaltest. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:503
+#: lib/abuuba_web/live/admin_live.ex:516
 #, elixir-autogen, elixir-format
 msgid "turned off"
 msgstr "ausgeschaltet"
@@ -5684,69 +5684,69 @@ msgstr "Die letzte Nachricht wurde gelöscht."
 msgid "This takes it out of your inbox only. Nobody else loses anything, and a later message brings it back. Go ahead?"
 msgstr "Das nimmt es nur aus deinem Posteingang. Niemand sonst verliert etwas, und eine spätere Nachricht holt es zurück. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:2035
+#: lib/abuuba_web/live/admin_live.ex:2049
 #, elixir-autogen, elixir-format
 msgid "Days to keep other servers' posts"
 msgstr "Tage, die Beiträge anderer Server bleiben"
 
-#: lib/abuuba_web/live/admin_live.ex:2044
+#: lib/abuuba_web/live/admin_live.ex:2058
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them for ever. Anything older is deleted each night, except a post somebody here favourited, bookmarked, pinned, boosted, quoted, replied to or was mentioned in."
 msgstr "Null behält sie für immer. Alles Ältere wird jede Nacht gelöscht, außer einem Beitrag, den hier jemand favorisiert, als Lesezeichen gesetzt, angeheftet, geteilt, zitiert oder beantwortet hat oder in dem jemand von hier erwähnt wird."
 
-#: lib/abuuba_web/live/admin_live.ex:1919
+#: lib/abuuba_web/live/admin_live.ex:1933
 #, elixir-autogen, elixir-format
 msgid "The longer version, for the about page"
 msgstr "Die längere Fassung, für die Über-Seite"
 
-#: lib/abuuba_web/live/admin_live.ex:1970
-#: lib/abuuba_web/live/admin_live.ex:1979
+#: lib/abuuba_web/live/admin_live.ex:1984
+#: lib/abuuba_web/live/admin_live.ex:1993
 #, elixir-autogen, elixir-format
 msgid "Anybody, including people with no account"
 msgstr "Alle, auch ohne Konto"
 
-#: lib/abuuba_web/live/admin_live.ex:1985
+#: lib/abuuba_web/live/admin_live.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Nobody: turn them off"
 msgstr "Niemand: ganz abschalten"
 
-#: lib/abuuba_web/live/admin_live.ex:1967
-#: lib/abuuba_web/live/admin_live.ex:1982
+#: lib/abuuba_web/live/admin_live.ex:1981
+#: lib/abuuba_web/live/admin_live.ex:1996
 #, elixir-autogen, elixir-format
 msgid "Only people signed in here"
 msgstr "Nur hier angemeldete Personen"
 
-#: lib/abuuba_web/live/admin_live.ex:1976
+#: lib/abuuba_web/live/admin_live.ex:1990
 #, elixir-autogen, elixir-format
 msgid "Who may read the public timelines"
 msgstr "Wer die öffentlichen Timelines lesen darf"
 
-#: lib/abuuba_web/live/admin_live.ex:1951
+#: lib/abuuba_web/live/admin_live.ex:1965
 #, elixir-autogen, elixir-format
 msgid "The privacy policy takes effect on"
 msgstr "Die Datenschutzerklärung gilt ab"
 
-#: lib/abuuba_web/live/admin_live.ex:1935
+#: lib/abuuba_web/live/admin_live.ex:1949
 #, elixir-autogen, elixir-format
 msgid "The account to write to"
 msgstr "Das Konto, an das man schreiben kann"
 
-#: lib/abuuba_web/live/admin_live.ex:1940
+#: lib/abuuba_web/live/admin_live.ex:1954
 #, elixir-autogen, elixir-format
 msgid "a username on this server"
 msgstr "ein Benutzername auf diesem Server"
 
-#: lib/abuuba_web/live/admin_live.ex:1924
+#: lib/abuuba_web/live/admin_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "Status page"
 msgstr "Statusseite"
 
-#: lib/abuuba_web/live/admin_live.ex:1964
+#: lib/abuuba_web/live/admin_live.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Nobody: the server does not say"
 msgstr "Niemand: der Server sagt es nicht"
 
-#: lib/abuuba_web/live/admin_live.ex:1961
+#: lib/abuuba_web/live/admin_live.ex:1975
 #, elixir-autogen, elixir-format
 msgid "Who may read the blocklist"
 msgstr "Wer die Sperrliste lesen darf"
@@ -5782,62 +5782,68 @@ msgstr "Zu viele Anmeldungen von hier im Moment. Bitte versuche es später noch 
 msgid "Too many follows today. Try again tomorrow."
 msgstr "Zu viele Follows für heute. Versuche es morgen noch einmal."
 
-#: lib/abuuba_web/live/admin_live.ex:3355
+#: lib/abuuba_web/live/admin_live.ex:3370
 #, elixir-autogen, elixir-format
 msgid "Account disabled"
 msgstr "Konto deaktiviert"
 
-#: lib/abuuba_web/live/admin_live.ex:3358
+#: lib/abuuba_web/live/admin_live.ex:3373
 #, elixir-autogen, elixir-format
 msgid "Account limited"
 msgstr "Konto eingeschränkt"
 
-#: lib/abuuba_web/live/admin_live.ex:3359
+#: lib/abuuba_web/live/admin_live.ex:3374
 #, elixir-autogen, elixir-format
 msgid "Account suspended"
 msgstr "Konto gesperrt"
 
-#: lib/abuuba_web/live/admin_live.ex:3368
+#: lib/abuuba_web/live/admin_live.ex:3383
 #, elixir-autogen, elixir-format
 msgid "Appeals"
 msgstr "Einsprüche"
 
-#: lib/abuuba_web/live/admin_live.ex:1381
+#: lib/abuuba_web/live/admin_live.ex:1394
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting. Appeals against a strike show up here."
 msgstr "Es wartet nichts. Einsprüche gegen eine Maßnahme erscheinen hier."
 
-#: lib/abuuba_web/live/admin_live.ex:3357
+#: lib/abuuba_web/live/admin_live.ex:3372
 #, elixir-autogen, elixir-format
 msgid "Posts deleted"
 msgstr "Beiträge gelöscht"
 
-#: lib/abuuba_web/live/admin_live.ex:3356
+#: lib/abuuba_web/live/admin_live.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Posts marked sensitive"
 msgstr "Beiträge als sensibel markiert"
 
-#: lib/abuuba_web/live/admin_live.ex:1340
+#: lib/abuuba_web/live/admin_live.ex:1353
 #, elixir-autogen, elixir-format
 msgid "Somebody who was warned, silenced or suspended saying it was a mistake. Upholding an appeal undoes the action where it can be undone; where it cannot, the appeal is still recorded as upheld. Either way the account's owner is told."
 msgstr "Jemand, der verwarnt, eingeschränkt oder gesperrt wurde und sagt, dass das ein Fehler war. Wird einem Einspruch stattgegeben, wird die Maßnahme rückgängig gemacht, soweit das geht; wo nicht, gilt der Einspruch trotzdem als angenommen. In beiden Fällen wird die Person benachrichtigt."
 
-#: lib/abuuba_web/live/admin_live.ex:3070
+#: lib/abuuba_web/live/admin_live.ex:3085
 #, elixir-autogen, elixir-format
 msgid "That appeal is no longer waiting."
 msgstr "Dieser Einspruch wartet nicht mehr."
 
-#: lib/abuuba_web/live/admin_live.ex:1374
+#: lib/abuuba_web/live/admin_live.ex:1387
 #, elixir-autogen, elixir-format
 msgid "Turn down"
 msgstr "Ablehnen"
 
-#: lib/abuuba_web/live/admin_live.ex:1366
+#: lib/abuuba_web/live/admin_live.ex:1379
 #, elixir-autogen, elixir-format
 msgid "Uphold and undo"
 msgstr "Stattgeben und rückgängig machen"
 
-#: lib/abuuba_web/live/admin_live.ex:3354
+#: lib/abuuba_web/live/admin_live.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Warned"
 msgstr "Verwarnt"
+
+#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2237
+#, elixir-autogen, elixir-format
+msgid "%{size} MB"
+msgstr "%{size} MB"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -51,7 +51,7 @@ msgid "Change"
 msgstr "Ändern"
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:723
+#: lib/abuuba_web/live/compose_component.ex:713
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr "Sprache"
@@ -420,7 +420,7 @@ msgstr "Einschalten"
 msgid "Turn off two-factor authentication?"
 msgstr "Zwei-Faktor-Authentifizierung ausschalten?"
 
-#: lib/abuuba_web/live/settings_live.ex:900
+#: lib/abuuba_web/live/settings_live.ex:901
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -468,8 +468,8 @@ msgstr "%{app} autorisieren"
 
 #: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:397
-#: lib/abuuba_web/live/compose_component.ex:410
+#: lib/abuuba_web/live/compose_component.ex:387
+#: lib/abuuba_web/live/compose_component.ex:400
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -663,8 +663,8 @@ msgstr "Entdecken"
 
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
-#: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2310
+#: lib/abuuba_web/live/home_live.ex:55
+#: lib/abuuba_web/live/settings_live.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
@@ -690,15 +690,15 @@ msgstr "Hauptnavigation"
 
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
-#: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2311
+#: lib/abuuba_web/live/notifications_live.ex:57
+#: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr "Mitteilungen"
 
 #: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:119
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:120
+#: lib/abuuba_web/live/settings_live.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -713,7 +713,7 @@ msgstr "Tastaturkürzel wirken nicht, während du in ein Textfeld schreibst."
 msgid "Skip to content"
 msgstr "Zum Inhalt springen"
 
-#: lib/abuuba_web/live/home_live.ex:85
+#: lib/abuuba_web/live/home_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "%{count} new post"
 msgid_plural "%{count} new posts"
@@ -757,13 +757,13 @@ msgstr "Beendet"
 msgid "Favourite"
 msgstr "Favorisieren"
 
-#: lib/abuuba_web/live/home_live.ex:104
+#: lib/abuuba_web/live/home_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Follow some people and their posts will appear here."
 msgstr "Folge ein paar Menschen, dann erscheinen ihre Beiträge hier."
 
 #: lib/abuuba_web/components/status_component.ex:267
-#: lib/abuuba_web/live/compose_component.ex:603
+#: lib/abuuba_web/live/compose_component.ex:593
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Umfrage"
@@ -773,7 +773,7 @@ msgstr "Umfrage"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/abuuba_web/live/home_live.ex:304
+#: lib/abuuba_web/live/home_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "That vote could not be counted."
 msgstr "Diese Stimme konnte nicht gezählt werden."
@@ -783,7 +783,7 @@ msgstr "Diese Stimme konnte nicht gezählt werden."
 msgid "Vote"
 msgstr "Abstimmen"
 
-#: lib/abuuba_web/live/home_live.ex:100
+#: lib/abuuba_web/live/home_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "You have reached the end."
 msgstr "Du bist am Ende angekommen."
@@ -793,96 +793,96 @@ msgstr "Du bist am Ende angekommen."
 msgid "Your choice"
 msgstr "Deine Wahl"
 
-#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/compose_component.ex:1657
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr "1 Tag"
 
-#: lib/abuuba_web/live/compose_component.ex:1664
+#: lib/abuuba_web/live/compose_component.ex:1655
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr "1 Stunde"
 
-#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/compose_component.ex:1658
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr "3 Tage"
 
-#: lib/abuuba_web/live/compose_component.ex:1663
+#: lib/abuuba_web/live/compose_component.ex:1654
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr "30 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1662
+#: lib/abuuba_web/live/compose_component.ex:1653
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr "5 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1665
+#: lib/abuuba_web/live/compose_component.ex:1656
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr "6 Stunden"
 
-#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/compose_component.ex:1659
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr "7 Tage"
 
-#: lib/abuuba_web/live/compose_component.ex:1141
+#: lib/abuuba_web/live/compose_component.ex:1131
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr "Eine Umfrage braucht mindestens zwei Antworten."
 
-#: lib/abuuba_web/live/compose_component.ex:638
+#: lib/abuuba_web/live/compose_component.ex:628
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr "Antwort hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:709
+#: lib/abuuba_web/live/compose_component.ex:699
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr "Umfrage hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:650
+#: lib/abuuba_web/live/compose_component.ex:640
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr "Mehrfachauswahl erlauben"
 
-#: lib/abuuba_web/live/compose_component.ex:1683
-#: lib/abuuba_web/live/settings_live.ex:2305
+#: lib/abuuba_web/live/compose_component.ex:1674
+#: lib/abuuba_web/live/settings_live.ex:2306
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr "Alle"
 
-#: lib/abuuba_web/live/compose_component.ex:1674
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/compose_component.ex:1665
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr "Alle, und überall gelistet"
 
-#: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr "Alle, aber nicht in öffentlichen Timelines"
 
-#: lib/abuuba_web/live/compose_component.ex:614
+#: lib/abuuba_web/live/compose_component.ex:604
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr "Antwort %{number}"
 
-#: lib/abuuba_web/live/compose_component.ex:438
-#: lib/abuuba_web/live/compose_component.ex:699
+#: lib/abuuba_web/live/compose_component.ex:428
+#: lib/abuuba_web/live/compose_component.ex:689
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/abuuba_web/live/compose_component.ex:800
+#: lib/abuuba_web/live/compose_component.ex:790
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr "Strg + Enter veröffentlicht"
 
-#: lib/abuuba_web/live/compose_component.ex:433
+#: lib/abuuba_web/live/compose_component.ex:423
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr "Diese Person nicht mit anschreiben"
@@ -893,325 +893,325 @@ msgstr "Diese Person nicht mit anschreiben"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/abuuba_web/live/compose_component.ex:403
+#: lib/abuuba_web/live/compose_component.ex:393
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/abuuba_web/live/compose_component.ex:654
+#: lib/abuuba_web/live/compose_component.ex:644
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr "Endet nach"
 
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/profile_live.ex:837
+#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/profile_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr "Erwähnte Personen"
 
 #: lib/abuuba_web/live/admin_live.ex:3428
-#: lib/abuuba_web/live/compose_component.ex:1685
-#: lib/abuuba_web/live/settings_live.ex:2307
+#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/settings_live.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr "Niemand"
 
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2302
+#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/settings_live.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr "Nur die Leute, die dir folgen"
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr "Nur die Leute, die du nennst"
 
-#: lib/abuuba_web/live/compose_component.ex:1684
-#: lib/abuuba_web/live/settings_live.ex:2306
+#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/settings_live.ex:2307
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr "Leute, die dir folgen"
 
-#: lib/abuuba_web/live/compose_component.ex:1441
+#: lib/abuuba_web/live/compose_component.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/compose_component.ex:683
+#: lib/abuuba_web/live/compose_component.ex:673
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/abuuba_web/live/compose_component.ex:1674
-#: lib/abuuba_web/live/compose_component.ex:1692
+#: lib/abuuba_web/live/compose_component.ex:1665
+#: lib/abuuba_web/live/compose_component.ex:1683
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/compose_component.ex:1666
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr "Still öffentlich"
 
-#: lib/abuuba_web/live/compose_component.ex:719
+#: lib/abuuba_web/live/compose_component.ex:709
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr "Umfrage entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:626
+#: lib/abuuba_web/live/compose_component.ex:616
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr "Diese Antwort entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:390
+#: lib/abuuba_web/live/compose_component.ex:380
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr "Antwort an %{name}"
 
-#: lib/abuuba_web/live/compose_component.ex:1439
+#: lib/abuuba_web/live/compose_component.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
 #: lib/abuuba_web/live/admin_live.ex:3389
-#: lib/abuuba_web/live/compose_component.ex:465
+#: lib/abuuba_web/live/compose_component.ex:455
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr "Vorschläge"
 
-#: lib/abuuba_web/live/compose_component.ex:1103
+#: lib/abuuba_web/live/compose_component.ex:1093
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr "Das ist %{count} Zeichen zu lang."
 
-#: lib/abuuba_web/live/compose_component.ex:1165
-#: lib/abuuba_web/live/compose_component.ex:1200
-#: lib/abuuba_web/live/compose_component.ex:1395
+#: lib/abuuba_web/live/compose_component.ex:1155
+#: lib/abuuba_web/live/compose_component.ex:1190
+#: lib/abuuba_web/live/compose_component.ex:1386
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr "Der Beitrag konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/compose_component.ex:449
-#: lib/abuuba_web/live/compose_component.ex:455
+#: lib/abuuba_web/live/compose_component.ex:439
+#: lib/abuuba_web/live/compose_component.ex:445
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr "Was beschäftigt dich?"
 
-#: lib/abuuba_web/live/compose_component.ex:443
+#: lib/abuuba_web/live/compose_component.ex:433
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr "Wovor sollen die Leute gewarnt werden?"
 
-#: lib/abuuba_web/live/compose_component.ex:759
+#: lib/abuuba_web/live/compose_component.ex:749
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr "Wer das zitieren darf"
 
-#: lib/abuuba_web/live/compose_component.ex:739
+#: lib/abuuba_web/live/compose_component.ex:729
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr "Wer das sehen darf"
 
-#: lib/abuuba_web/live/compose_component.ex:1099
+#: lib/abuuba_web/live/compose_component.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr "Schreib erst mal etwas."
 
-#: lib/abuuba_web/live/compose_component.ex:1197
+#: lib/abuuba_web/live/compose_component.ex:1187
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr "Du hast gerade viel veröffentlicht. Versuch es später noch einmal."
 
-#: lib/abuuba_web/live/compose_component.ex:1635
+#: lib/abuuba_web/live/compose_component.ex:1626
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr "jemanden"
 
-#: lib/abuuba_web/live/compose_component.ex:806
+#: lib/abuuba_web/live/compose_component.ex:796
 #, elixir-autogen, elixir-format
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] "%{count} Entwurf"
 msgstr[1] "%{count} Entwürfe"
 
-#: lib/abuuba_web/live/compose_component.ex:838
+#: lib/abuuba_web/live/compose_component.ex:828
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] "%{count} Beitrag wartet auf den Versand"
 msgstr[1] "%{count} Beiträge warten auf den Versand"
 
-#: lib/abuuba_web/live/compose_component.ex:1145
+#: lib/abuuba_web/live/compose_component.ex:1135
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr "Eine Antwort ist zu lang. Halte jede unter %{count} Zeichen."
 
-#: lib/abuuba_web/live/compose_component.ex:869
+#: lib/abuuba_web/live/compose_component.ex:859
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr "Absagen"
 
-#: lib/abuuba_web/live/compose_component.ex:830
+#: lib/abuuba_web/live/compose_component.ex:820
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: lib/abuuba_web/live/compose_component.ex:669
+#: lib/abuuba_web/live/compose_component.ex:659
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr "Geht raus am"
 
-#: lib/abuuba_web/live/compose_component.ex:820
-#: lib/abuuba_web/live/compose_component.ex:859
+#: lib/abuuba_web/live/compose_component.ex:810
+#: lib/abuuba_web/live/compose_component.ex:849
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr "Öffnen"
 
-#: lib/abuuba_web/live/compose_component.ex:1116
-#: lib/abuuba_web/live/compose_component.ex:1386
+#: lib/abuuba_web/live/compose_component.ex:1106
+#: lib/abuuba_web/live/compose_component.ex:1377
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr "Sag, wann der Beitrag rausgehen soll."
 
-#: lib/abuuba_web/live/compose_component.ex:791
+#: lib/abuuba_web/live/compose_component.ex:781
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr "Planen"
 
-#: lib/abuuba_web/live/compose_component.ex:1440
+#: lib/abuuba_web/live/compose_component.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr "Einplanen"
 
-#: lib/abuuba_web/live/compose_component.ex:304
+#: lib/abuuba_web/live/compose_component.ex:305
 #, elixir-autogen, elixir-format
 msgid "That draft could not be saved."
 msgstr "Der Entwurf konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/home_live.ex:202
+#: lib/abuuba_web/live/home_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "That post is scheduled."
 msgstr "Der Beitrag ist eingeplant."
 
-#: lib/abuuba_web/live/compose_component.ex:1150
+#: lib/abuuba_web/live/compose_component.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr "Zwei Antworten sind gleich. Mach sie unterschiedlich."
 
-#: lib/abuuba_web/live/compose_component.ex:300
+#: lib/abuuba_web/live/compose_component.ex:301
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr "Du hast zu viele Entwürfe für einen weiteren. Verwirf erst einen."
 
-#: lib/abuuba_web/live/compose_component.ex:1434
+#: lib/abuuba_web/live/compose_component.ex:1425
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr "ein leerer Beitrag"
 
-#: lib/abuuba_web/live/compose_component.ex:676
+#: lib/abuuba_web/live/compose_component.ex:666
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr "deine eigene Zeit, mindestens %{count} Minuten ab jetzt"
 
-#: lib/abuuba_web/live/compose_component.ex:1113
+#: lib/abuuba_web/live/compose_component.ex:1103
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr "Ein Bild geht ohne Beschreibung raus. Schick noch einmal ab, um es trotzdem zu veröffentlichen."
 
-#: lib/abuuba_web/live/compose_component.ex:484
+#: lib/abuuba_web/live/compose_component.ex:474
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr "Bild, Video oder Ton hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:579
+#: lib/abuuba_web/live/compose_component.ex:569
 #, elixir-autogen, elixir-format
 msgid "Add a still"
 msgstr "Standbild hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:529
+#: lib/abuuba_web/live/compose_component.ex:519
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr "Klick auf den wichtigsten Teil"
 
-#: lib/abuuba_web/live/compose_component.ex:546
-#: lib/abuuba_web/live/compose_component.ex:554
+#: lib/abuuba_web/live/compose_component.ex:536
+#: lib/abuuba_web/live/compose_component.ex:544
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr "Beschreibe das für Leute, die es nicht sehen können"
 
-#: lib/abuuba_web/live/compose_component.ex:568
+#: lib/abuuba_web/live/compose_component.ex:558
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr "Nach vorne"
 
-#: lib/abuuba_web/live/compose_component.ex:583
+#: lib/abuuba_web/live/compose_component.ex:573
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr "Standbild auswählen"
 
-#: lib/abuuba_web/live/compose_component.ex:541
+#: lib/abuuba_web/live/compose_component.ex:531
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr "Bildmittelpunkt festlegen"
 
-#: lib/abuuba_web/live/compose_component.ex:509
+#: lib/abuuba_web/live/compose_component.ex:499
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr "Abbrechen"
 
-#: lib/abuuba_web/live/compose_component.ex:594
+#: lib/abuuba_web/live/compose_component.ex:584
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:239
-#: lib/abuuba_web/live/compose_component.ex:1430
+#: lib/abuuba_web/live/compose_component.ex:240
+#: lib/abuuba_web/live/compose_component.ex:1421
 #, elixir-autogen, elixir-format
 msgid "That file could not be uploaded."
 msgstr "Die Datei konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/compose_component.ex:1427
+#: lib/abuuba_web/live/compose_component.ex:1418
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/compose_component.ex:226
+#: lib/abuuba_web/live/compose_component.ex:227
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr "Mehr als %{count} Bilder trägt ein Beitrag nicht."
 
-#: lib/abuuba_web/live/compose_component.ex:1428
+#: lib/abuuba_web/live/compose_component.ex:1419
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr "Das sind mehr Dateien, als ein Beitrag tragen kann."
 
-#: lib/abuuba_web/live/compose_component.ex:1429
+#: lib/abuuba_web/live/compose_component.ex:1420
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr "Dieser Server nimmt keine Dateien dieser Art."
 
-#: lib/abuuba_web/live/compose_component.ex:488
+#: lib/abuuba_web/live/compose_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr "oder zieh eine ins Feld oder füg sie ein"
 
-#: lib/abuuba_web/live/status_live.ex:279
+#: lib/abuuba_web/live/status_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr "%{name} auf %{server}"
 
-#: lib/abuuba_web/live/profile_live.ex:292
+#: lib/abuuba_web/live/profile_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr "Eine Notiz, die nur du liest"
 
-#: lib/abuuba_web/live/profile_live.ex:189
+#: lib/abuuba_web/live/profile_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr "Blockieren"
@@ -1233,29 +1233,29 @@ msgstr "Zum neuen Konto"
 msgid "Look for more replies on the other server"
 msgstr "Auf dem anderen Server nach weiteren Antworten suchen"
 
-#: lib/abuuba_web/live/profile_live.ex:836
+#: lib/abuuba_web/live/profile_live.ex:865
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr "Medien"
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr "Stummschalten"
 
-#: lib/abuuba_web/live/profile_live.ex:363
+#: lib/abuuba_web/live/profile_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr "Hier ist noch nichts."
 
-#: lib/abuuba_web/live/profile_live.ex:338
-#: lib/abuuba_web/live/profile_live.ex:339
+#: lib/abuuba_web/live/profile_live.ex:347
+#: lib/abuuba_web/live/profile_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr "Angeheftet"
 
-#: lib/abuuba_web/live/explore_live.ex:288
-#: lib/abuuba_web/live/profile_live.ex:834
+#: lib/abuuba_web/live/explore_live.ex:304
+#: lib/abuuba_web/live/profile_live.ex:863
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:122
 #: lib/abuuba_web/live/search_live.ex:264
@@ -1263,18 +1263,18 @@ msgstr "Angeheftet"
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/abuuba_web/live/profile_live.ex:835
+#: lib/abuuba_web/live/profile_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr "Beiträge und Antworten"
 
 #: lib/abuuba_web/live/admin_live.ex:944
-#: lib/abuuba_web/live/profile_live.ex:296
+#: lib/abuuba_web/live/profile_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr "Notiz speichern"
 
-#: lib/abuuba_web/live/status_live.ex:320
+#: lib/abuuba_web/live/status_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "That server could not be reached, so this is all there is."
 msgstr "Der Server war nicht erreichbar, mehr gibt es also nicht."
@@ -1284,19 +1284,19 @@ msgstr "Der Server war nicht erreichbar, mehr gibt es also nicht."
 msgid "This account has moved to %{handle}."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
-#: lib/abuuba_web/live/profile_live.ex:189
-#: lib/abuuba_web/live/settings_live.ex:826
+#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/settings_live.ex:827
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr "Blockierung aufheben"
 
-#: lib/abuuba_web/live/profile_live.ex:155
+#: lib/abuuba_web/live/profile_live.ex:164
 #: lib/abuuba_web/live/tag_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Entfolgen"
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr "Stummschaltung aufheben"
@@ -1306,109 +1306,109 @@ msgstr "Stummschaltung aufheben"
 msgid "Verified"
 msgstr "Bestätigt"
 
-#: lib/abuuba_web/live/profile_live.ex:300
+#: lib/abuuba_web/live/profile_live.ex:309
 #: lib/abuuba_web/live/search_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "What to show"
 msgstr "Was gezeigt wird"
 
-#: lib/abuuba_web/live/notifications_live.ex:83
+#: lib/abuuba_web/live/notifications_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] "%{count} neu"
 msgstr[1] "%{count} neu"
 
-#: lib/abuuba_web/live/notifications_live.ex:133
+#: lib/abuuba_web/live/notifications_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] "%{count} Mitteilung"
 msgstr[1] "%{count} Mitteilungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:380
+#: lib/abuuba_web/live/notifications_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] "%{count} Person hat deinen Beitrag geteilt"
 msgstr[1] "%{count} Leute haben deinen Beitrag geteilt"
 
-#: lib/abuuba_web/live/notifications_live.ex:384
+#: lib/abuuba_web/live/notifications_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] "%{count} Person hat deinen Beitrag favorisiert"
 msgstr[1] "%{count} Leute haben deinen Beitrag favorisiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:391
+#: lib/abuuba_web/live/notifications_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] "%{count} Person folgt dir jetzt"
 msgstr[1] "%{count} Leute folgen dir jetzt"
 
-#: lib/abuuba_web/live/notifications_live.ex:394
+#: lib/abuuba_web/live/notifications_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] "%{count} Person hat dich erwähnt"
 msgstr[1] "%{count} Leute haben dich erwähnt"
 
-#: lib/abuuba_web/live/notifications_live.ex:118
+#: lib/abuuba_web/live/notifications_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] "%{count} Person wartet darauf, dich zu erreichen"
 msgstr[1] "%{count} Leute warten darauf, dich zu erreichen"
 
-#: lib/abuuba_web/live/notifications_live.ex:398
+#: lib/abuuba_web/live/notifications_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] "%{name} und %{count} weitere Person"
 msgstr[1] "%{name} und %{count} weitere Leute"
 
-#: lib/abuuba_web/live/notifications_live.ex:347
+#: lib/abuuba_web/live/notifications_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr "%{name} möchte dir folgen"
 
-#: lib/abuuba_web/live/notifications_live.ex:345
+#: lib/abuuba_web/live/notifications_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "%{name} boosted your post"
 msgstr "%{name} hat deinen Beitrag geteilt"
 
-#: lib/abuuba_web/live/notifications_live.ex:350
+#: lib/abuuba_web/live/notifications_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr "%{name} hat einen Beitrag bearbeitet, den du geteilt hast"
 
-#: lib/abuuba_web/live/notifications_live.ex:348
+#: lib/abuuba_web/live/notifications_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr "%{name} hat deinen Beitrag favorisiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:346
+#: lib/abuuba_web/live/notifications_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr "%{name} folgt dir jetzt"
 
-#: lib/abuuba_web/live/notifications_live.ex:344
+#: lib/abuuba_web/live/notifications_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr "%{name} hat dich erwähnt"
 
-#: lib/abuuba_web/live/notifications_live.ex:351
+#: lib/abuuba_web/live/notifications_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "%{name} posted"
 msgstr "%{name} hat etwas veröffentlicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:352
+#: lib/abuuba_web/live/notifications_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr "%{name} hat deinen Beitrag zitiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:349
+#: lib/abuuba_web/live/notifications_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr "Eine Umfrage von %{name} ist beendet"
@@ -1433,7 +1433,7 @@ msgstr "Konten, die eine Moderation eingeschränkt hat"
 msgid "Accounts made very recently"
 msgstr "Ganz neu angelegte Konten"
 
-#: lib/abuuba_web/live/notifications_live.ex:430
+#: lib/abuuba_web/live/notifications_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr "Alle"
@@ -1463,17 +1463,17 @@ msgstr "Alle, denen du nicht folgst."
 msgid "Automated accounts"
 msgstr "Automatische Konten"
 
-#: lib/abuuba_web/live/notifications_live.ex:439
+#: lib/abuuba_web/live/notifications_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Boosts"
 msgstr "Geteilte Beiträge"
 
-#: lib/abuuba_web/live/notifications_live.ex:111
+#: lib/abuuba_web/live/notifications_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr "Alle löschen"
 
-#: lib/abuuba_web/live/notifications_live.ex:178
+#: lib/abuuba_web/live/notifications_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr "Ausblenden"
@@ -1483,12 +1483,12 @@ msgstr "Ausblenden"
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr "Jede Zeile beschreibt eine Art von Absender. Annehmen lässt sie durch, Filtern legt sie in die Warteliste auf deiner Mitteilungsseite, und Ignorieren verwirft sie."
 
-#: lib/abuuba_web/live/notifications_live.ex:444
+#: lib/abuuba_web/live/notifications_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Edits"
 msgstr "Bearbeitungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:442
+#: lib/abuuba_web/live/notifications_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Favourites"
 msgstr "Favoriten"
@@ -1498,15 +1498,15 @@ msgstr "Favoriten"
 msgid "Filter"
 msgstr "Filtern"
 
-#: lib/abuuba_web/live/notifications_live.ex:441
+#: lib/abuuba_web/live/notifications_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr "Folgeanfragen"
 
-#: lib/abuuba_web/live/notifications_live.ex:440
-#: lib/abuuba_web/live/profile_live.ex:838
-#: lib/abuuba_web/live/settings_live.ex:2103
-#: lib/abuuba_web/live/settings_live.ex:2241
+#: lib/abuuba_web/live/notifications_live.ex:441
+#: lib/abuuba_web/live/profile_live.ex:867
+#: lib/abuuba_web/live/settings_live.ex:2104
+#: lib/abuuba_web/live/settings_live.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folge ich"
@@ -1521,28 +1521,28 @@ msgstr "Ignorieren"
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr "Bei Ignorieren ist Vorsicht geboten: nichts wird irgendwo abgelegt und es lässt sich nicht wiederherstellen. Filtern ist die umkehrbare Wahl."
 
-#: lib/abuuba_web/live/notifications_live.ex:147
+#: lib/abuuba_web/live/notifications_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr "Durchlassen"
 
-#: lib/abuuba_web/live/notifications_live.ex:107
+#: lib/abuuba_web/live/notifications_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
-#: lib/abuuba_web/live/notifications_live.ex:430
-#: lib/abuuba_web/live/notifications_live.ex:438
+#: lib/abuuba_web/live/notifications_live.ex:431
+#: lib/abuuba_web/live/notifications_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr "Erwähnungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:156
+#: lib/abuuba_web/live/notifications_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:192
+#: lib/abuuba_web/live/notifications_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr "Es ist noch nichts passiert."
@@ -1557,7 +1557,7 @@ msgstr "Leute, die dir nicht folgen"
 msgid "People you do not follow"
 msgstr "Leute, denen du nicht folgst"
 
-#: lib/abuuba_web/live/notifications_live.ex:443
+#: lib/abuuba_web/live/notifications_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "Polls"
 msgstr "Umfragen"
@@ -1573,28 +1573,28 @@ msgstr "Private Erwähnungen aus dem Nichts"
 #: lib/abuuba_web/live/admin_live.ex:1587
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:255
-#: lib/abuuba_web/live/settings_live.ex:294
-#: lib/abuuba_web/live/settings_live.ex:388
-#: lib/abuuba_web/live/settings_live.ex:425
-#: lib/abuuba_web/live/settings_live.ex:489
-#: lib/abuuba_web/live/settings_live.ex:596
-#: lib/abuuba_web/live/settings_live.ex:641
-#: lib/abuuba_web/live/settings_live.ex:674
-#: lib/abuuba_web/live/settings_live.ex:996
+#: lib/abuuba_web/live/profile_live.ex:264
+#: lib/abuuba_web/live/settings_live.ex:295
+#: lib/abuuba_web/live/settings_live.ex:389
+#: lib/abuuba_web/live/settings_live.ex:426
+#: lib/abuuba_web/live/settings_live.ex:490
+#: lib/abuuba_web/live/settings_live.ex:597
+#: lib/abuuba_web/live/settings_live.ex:642
+#: lib/abuuba_web/live/settings_live.ex:675
+#: lib/abuuba_web/live/settings_live.ex:997
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Speichern"
 
 #: lib/abuuba_web/live/admin_live.ex:245
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:136
+#: lib/abuuba_web/live/settings_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr "Gespeichert."
 
-#: lib/abuuba_web/live/notifications_live.ex:342
-#: lib/abuuba_web/live/notifications_live.ex:407
+#: lib/abuuba_web/live/notifications_live.ex:343
+#: lib/abuuba_web/live/notifications_live.ex:408
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr "Jemand"
@@ -1604,7 +1604,7 @@ msgstr "Jemand"
 msgid "Somebody a moderator here has already restricted."
 msgstr "Jemand, den eine Moderation hier bereits eingeschränkt hat."
 
-#: lib/abuuba_web/live/notifications_live.ex:377
+#: lib/abuuba_web/live/notifications_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr "Etwas ist passiert, das %{name} betrifft"
@@ -1614,7 +1614,7 @@ msgstr "Etwas ist passiert, das %{name} betrifft"
 msgid "That could not be saved. Try again."
 msgstr "Das konnte nicht gespeichert werden. Versuch es noch einmal."
 
-#: lib/abuuba_web/live/notifications_live.ex:72
+#: lib/abuuba_web/live/notifications_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr "Welche Mitteilungen"
@@ -1624,7 +1624,7 @@ msgstr "Welche Mitteilungen"
 msgid "Who can reach you"
 msgstr "Wer dich erreichen kann"
 
-#: lib/abuuba_web/live/notifications_live.ex:125
+#: lib/abuuba_web/live/notifications_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr "Deine Einstellungen haben diese abgelegt, statt sie zu zeigen."
@@ -1647,7 +1647,7 @@ msgstr "Ein Name, ein #Tag oder ein paar Wörter"
 msgid "Everything"
 msgstr "Alles"
 
-#: lib/abuuba_web/live/explore_live.ex:289
+#: lib/abuuba_web/live/explore_live.ex:305
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:113
 #: lib/abuuba_web/live/search_live.ex:263
@@ -1680,7 +1680,7 @@ msgstr "Hier hat noch niemand öffentlich etwas veröffentlicht."
 msgid "Nobody has posted under this tag yet."
 msgstr "Unter diesem Tag hat noch niemand etwas veröffentlicht."
 
-#: lib/abuuba_web/live/explore_live.ex:119
+#: lib/abuuba_web/live/explore_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht haben."
@@ -1690,7 +1690,7 @@ msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht habe
 msgid "Nothing matched that."
 msgstr "Dazu gab es keine Treffer."
 
-#: lib/abuuba_web/live/explore_live.ex:290
+#: lib/abuuba_web/live/explore_live.ex:306
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:103
 #: lib/abuuba_web/live/search_live.ex:262
@@ -1757,220 +1757,220 @@ msgstr "Beiträge nach einem Datum"
 msgid "posts older than a date"
 msgstr "Beiträge vor einem Datum"
 
-#: lib/abuuba_web/live/settings_live.ex:891
+#: lib/abuuba_web/live/settings_live.ex:892
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr "Ein neues Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:234
+#: lib/abuuba_web/live/settings_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Über dich"
 
 #: lib/abuuba_web/live/admin_live.ex:3379
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Konto"
 
-#: lib/abuuba_web/live/settings_live.ex:290
+#: lib/abuuba_web/live/settings_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Add a field"
 msgstr "Feld hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:807
+#: lib/abuuba_web/live/settings_live.ex:808
 #, elixir-autogen, elixir-format
 msgid "Add a filter"
 msgstr "Filter hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/abuuba_web/live/settings_live.ex:2277
+#: lib/abuuba_web/live/settings_live.ex:2278
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr "Gilt nur für deine öffentlichen Beiträge."
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/abuuba_web/live/settings_live.ex:2130
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr "Apps, die in dein Konto gelassen wurden."
 
-#: lib/abuuba_web/live/settings_live.ex:947
+#: lib/abuuba_web/live/settings_live.ex:948
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr "Apps, bei denen du angemeldet bist. Eine wieder hinauszunehmen meldet sie sofort ab."
 
-#: lib/abuuba_web/live/settings_live.ex:2272
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr "Vor jedem Follow fragen"
 
-#: lib/abuuba_web/live/settings_live.ex:895
+#: lib/abuuba_web/live/settings_live.ex:896
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr "Passwort ändern"
 
 #: lib/abuuba_web/live/admin_live.ex:998
-#: lib/abuuba_web/live/settings_live.ex:754
+#: lib/abuuba_web/live/settings_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:223
+#: lib/abuuba_web/live/settings_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr "Anzeigename"
 
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr "Medien nicht von selbst abspielen"
 
-#: lib/abuuba_web/live/settings_live.ex:1600
+#: lib/abuuba_web/live/settings_live.ex:1601
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr "Jede Zeile muss eine Webadresse sein, eine pro Zeile."
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr "Jeder Follow wird zu einer Anfrage, die du beantwortest."
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr "Allen, denen du folgst, und ein Weg, damit aufzuhören."
 
-#: lib/abuuba_web/live/settings_live.ex:201
+#: lib/abuuba_web/live/settings_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr "Alles zu deinem Konto ist hier. Wähl einen Bereich."
 
-#: lib/abuuba_web/live/settings_live.ex:239
+#: lib/abuuba_web/live/settings_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr "Felder"
 
-#: lib/abuuba_web/live/settings_live.ex:2102
-#: lib/abuuba_web/live/settings_live.ex:2247
+#: lib/abuuba_web/live/settings_live.ex:2103
+#: lib/abuuba_web/live/settings_live.ex:2248
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/abuuba_web/live/settings_live.ex:2329
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr "Hinter einer Warnung zusammenklappen"
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr "Ganz ausblenden"
 
-#: lib/abuuba_web/live/settings_live.ex:2278
+#: lib/abuuba_web/live/settings_live.ex:2279
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr "Verbergen, wem ich folge und wer mir folgt"
 
-#: lib/abuuba_web/live/settings_live.ex:2286
+#: lib/abuuba_web/live/settings_live.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr "Mehr Kontrast"
 
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr "Wie sich die Oberfläche verhält und liest."
 
-#: lib/abuuba_web/live/settings_live.ex:254
+#: lib/abuuba_web/live/settings_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr "Suchmaschinen meine Beiträge indexieren lassen"
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr "Mich im Verzeichnis listen"
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2282
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr "Markiert das Konto als Bot, worauf manche Leute filtern."
 
-#: lib/abuuba_web/live/settings_live.ex:272
+#: lib/abuuba_web/live/settings_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/abuuba_web/live/settings_live.ex:976
+#: lib/abuuba_web/live/settings_live.ex:977
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr "Es wurde keine App hereingelassen."
 
-#: lib/abuuba_web/live/settings_live.ex:990
+#: lib/abuuba_web/live/settings_live.ex:991
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr "Eine Webadresse pro Zeile. Ein Konto hier zu nennen erlaubt dir später den Umzug dorthin, und es muss dieses hier zurücknennen."
 
-#: lib/abuuba_web/live/settings_live.ex:449
+#: lib/abuuba_web/live/settings_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr "Nur die genannten Leute fehlt mit Absicht: als Voreinstellung wird jeder Beitrag, den du zu ändern vergisst, zu einer Nachricht an niemanden."
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr "Deine anderen Konten und der Umzug zwischen ihnen."
 
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr "Überschreibt deine Systemeinstellung, wenn sie für dich falsch ist."
 
-#: lib/abuuba_web/live/settings_live.ex:2097
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Überblick"
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2315
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
-#: lib/abuuba_web/live/settings_live.ex:2312
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr "Öffentliche Timelines"
 
-#: lib/abuuba_web/live/settings_live.ex:2285
+#: lib/abuuba_web/live/settings_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr "Bewegung reduzieren"
@@ -1981,165 +1981,165 @@ msgstr "Bewegung reduzieren"
 #: lib/abuuba_web/live/admin_live.ex:1878
 #: lib/abuuba_web/live/admin_live.ex:2202
 #: lib/abuuba_web/live/conversations_live.ex:112
-#: lib/abuuba_web/live/settings_live.ex:280
-#: lib/abuuba_web/live/settings_live.ex:315
+#: lib/abuuba_web/live/settings_live.ex:281
+#: lib/abuuba_web/live/settings_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2104
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr "Sicherheit"
 
-#: lib/abuuba_web/live/settings_live.ex:908
+#: lib/abuuba_web/live/settings_live.ex:909
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr "Überall abmelden"
 
-#: lib/abuuba_web/live/settings_live.ex:904
+#: lib/abuuba_web/live/settings_live.ex:905
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr "Überall abmelden beendet jede Sitzung, auch diese."
 
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr "Hält das erste Absenden an, wenn ein Bild keine Beschreibung hat."
 
-#: lib/abuuba_web/live/settings_live.ex:970
+#: lib/abuuba_web/live/settings_live.ex:971
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr "Wieder hinausnehmen"
 
 #: lib/abuuba_web/live/admin_live.ex:3750
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2094
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr "Das konnte nicht gespeichert werden. Prüf, was du eingegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1575
+#: lib/abuuba_web/live/settings_live.ex:1576
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr "Das aktuelle Passwort stimmt nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:468
+#: lib/abuuba_web/live/settings_live.ex:469
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr "Die Sprache, in der du meistens schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:2279
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr "Die Listen sind nicht mehr öffentlich; die Follows selbst funktionieren weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr "Dieses Konto veröffentlicht automatisch"
 
-#: lib/abuuba_web/live/settings_live.ex:2313
+#: lib/abuuba_web/live/settings_live.ex:2314
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr "Threads"
 
-#: lib/abuuba_web/live/settings_live.ex:849
+#: lib/abuuba_web/live/settings_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr "Hak alle an, denen du nicht mehr folgen willst, und drück dann einmal den Knopf."
 
-#: lib/abuuba_web/live/settings_live.ex:874
+#: lib/abuuba_web/live/settings_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr "Den angehakten entfolgen"
 
-#: lib/abuuba_web/live/settings_live.ex:241
+#: lib/abuuba_web/live/settings_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr "Bis zu vier Zeilen auf deinem Profil. Die Reihenfolge hier ist die Reihenfolge dort."
 
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr "Die Schrift meines Systems verwenden"
 
-#: lib/abuuba_web/live/settings_live.ex:261
+#: lib/abuuba_web/live/settings_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr "Wert"
 
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/settings_live.ex:2290
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr "Mich auf fehlende Beschreibungen hinweisen"
 
-#: lib/abuuba_web/live/settings_live.ex:799
+#: lib/abuuba_web/live/settings_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr "Was er tut"
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2126
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr "Womit das Schreibfeld beginnt."
 
 #: lib/abuuba_web/live/admin_live.ex:2178
-#: lib/abuuba_web/live/settings_live.ex:761
+#: lib/abuuba_web/live/settings_live.ex:762
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr "Wie er heißen soll"
 
-#: lib/abuuba_web/live/settings_live.ex:766
+#: lib/abuuba_web/live/settings_live.ex:767
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr "Wo er gilt"
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr "Wer dich finden kann und wer fragen muss, um zu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:455
+#: lib/abuuba_web/live/settings_live.ex:456
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr "Wer neue Beiträge zitieren darf"
 
-#: lib/abuuba_web/live/settings_live.ex:436
+#: lib/abuuba_web/live/settings_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr "An wen neue Beiträge gehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr "Wörter und Wendungen, die du lieber nicht siehst."
 
-#: lib/abuuba_web/live/settings_live.ex:870
+#: lib/abuuba_web/live/settings_live.ex:871
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr "Du folgst noch niemandem."
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr "Dein Konto erscheint auf der öffentlichen Verzeichnisseite dieses Servers."
 
-#: lib/abuuba_web/live/settings_live.ex:886
+#: lib/abuuba_web/live/settings_live.ex:887
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr "Dein aktuelles Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr "Dein Name, was du über dich sagst, deine Felder."
 
-#: lib/abuuba_web/live/settings_live.ex:987
+#: lib/abuuba_web/live/settings_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr "Deine anderen Konten"
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr "Dein Passwort, Zwei-Faktor und das Abmelden."
@@ -2295,110 +2295,110 @@ msgstr "Beiträge"
 msgid "servers known"
 msgstr "bekannte Server"
 
-#: lib/abuuba_web/live/settings_live.ex:1858
+#: lib/abuuba_web/live/settings_live.ex:1859
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr "Eine Verwarnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr "Alles, was eine Moderatorin oder ein Moderator hier über dein Konto entschieden hat."
 
-#: lib/abuuba_web/live/settings_live.ex:1196
+#: lib/abuuba_web/live/settings_live.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr "Einspruch einlegen"
 
-#: lib/abuuba_web/live/settings_live.ex:2107
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr "Moderation"
 
-#: lib/abuuba_web/live/settings_live.ex:1226
+#: lib/abuuba_web/live/settings_live.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr "Hier ist nichts. Niemand aus der Moderation hat etwas gegen dein Konto unternommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1842
+#: lib/abuuba_web/live/settings_live.ex:1843
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr "Schreib bitte etwas dazu, warum du das für falsch hältst."
 
-#: lib/abuuba_web/live/settings_live.ex:1193
+#: lib/abuuba_web/live/settings_live.ex:1194
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr "Warum hältst du das für falsch?"
 
-#: lib/abuuba_web/live/settings_live.ex:1861
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr "Einige deiner Beiträge wurden gelöscht"
 
-#: lib/abuuba_web/live/settings_live.ex:1200
-#: lib/abuuba_web/live/settings_live.ex:1838
+#: lib/abuuba_web/live/settings_live.ex:1201
+#: lib/abuuba_web/live/settings_live.ex:1839
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr "Die Frist für einen Einspruch ist abgelaufen."
 
-#: lib/abuuba_web/live/settings_live.ex:1171
+#: lib/abuuba_web/live/settings_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr "Was die Moderation hier über dein Konto entschieden hat und was dir dazu gesagt wurde."
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr "Du hast Einspruch eingelegt, er wurde abgelehnt."
 
-#: lib/abuuba_web/live/settings_live.ex:1852
+#: lib/abuuba_web/live/settings_live.ex:1853
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr "Du hast Einspruch eingelegt, ihm wurde stattgegeben."
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1855
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr "Du hast Einspruch eingelegt. Entschieden ist noch nichts."
 
-#: lib/abuuba_web/live/settings_live.ex:1859
+#: lib/abuuba_web/live/settings_live.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr "Dein Konto wurde deaktiviert"
 
-#: lib/abuuba_web/live/settings_live.ex:1862
+#: lib/abuuba_web/live/settings_live.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr "Dein Konto wurde eingeschränkt"
 
-#: lib/abuuba_web/live/settings_live.ex:1863
+#: lib/abuuba_web/live/settings_live.ex:1864
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr "Dein Konto wurde gesperrt"
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1861
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr "Deine Beiträge wurden als sensibel markiert"
 
-#: lib/abuuba_web/live/settings_live.ex:1179
+#: lib/abuuba_web/live/settings_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr "inzwischen aufgehoben"
 
-#: lib/abuuba_web/live/settings_live.ex:1217
+#: lib/abuuba_web/live/settings_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] "%{count} Verbindung verloren"
 msgstr[1] "%{count} Verbindungen verloren"
 
-#: lib/abuuba_web/live/settings_live.ex:1206
+#: lib/abuuba_web/live/settings_live.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr "Verbindungen, die dich die Entscheidungen dieses Servers gekostet haben"
 
-#: lib/abuuba_web/live/settings_live.ex:1208
+#: lib/abuuba_web/live/settings_live.ex:1209
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr "Wenn dieser Server die Verbindung zu einem anderen abbricht, gehen die Folgebeziehungen zwischen dir und den Leuten dort verloren. Von hier aus lassen sie sich nicht wiederherstellen, weil die andere Seite nicht mehr erreichbar ist."
@@ -2694,7 +2694,7 @@ msgstr "Das ist keine Adresse."
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3340
-#: lib/abuuba_web/live/settings_live.ex:1628
+#: lib/abuuba_web/live/settings_live.ex:1629
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr "Das kann dein Konto nicht."
@@ -2833,12 +2833,12 @@ msgstr "Was gerade im Trend liegt"
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr "Worüber gerade mehr Leute als sonst schreiben, danach alles Übrige, das Neueste zuerst."
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr "%{uses} von %{max} genutzt"
 
-#: lib/abuuba_web/live/settings_live.ex:1242
+#: lib/abuuba_web/live/settings_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr "Ein Code, mit dem sich jemand anmelden kann, auch wenn Anmeldungen geschlossen sind. Lass die Anzahl leer für beliebig viele."
@@ -2853,7 +2853,7 @@ msgstr "Eine Ankündigung braucht einen Text."
 msgid "Announcements"
 msgstr "Ankündigungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2136
+#: lib/abuuba_web/live/settings_live.ex:2137
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr "Codes, mit denen sich Bekannte von dir anmelden können."
@@ -2878,7 +2878,7 @@ msgstr "Darüber wurden bereits alle informiert."
 msgid "Goes up"
 msgstr "Erscheint"
 
-#: lib/abuuba_web/live/settings_live.ex:1253
+#: lib/abuuba_web/live/settings_live.ex:1254
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr "Wie viele Personen"
@@ -2893,12 +2893,12 @@ msgstr "Gültig ab"
 msgid "In effect from %{date}"
 msgstr "Gültig ab %{date}"
 
-#: lib/abuuba_web/live/settings_live.ex:2108
+#: lib/abuuba_web/live/settings_live.ex:2109
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr "Einladungen"
 
-#: lib/abuuba_web/live/settings_live.ex:1237
+#: lib/abuuba_web/live/settings_live.ex:1238
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
@@ -2908,7 +2908,7 @@ msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
 msgid "Leave this empty to publish it now."
 msgstr "Leer lassen, um sofort zu veröffentlichen."
 
-#: lib/abuuba_web/live/settings_live.ex:1260
+#: lib/abuuba_web/live/settings_live.ex:1261
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr "Erstellen"
@@ -2938,7 +2938,7 @@ msgstr "Veröffentlicht"
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr "Etwas, das hier alle lesen sollten. Mit einer Uhrzeit veröffentlicht es sich selbst, sodass ein Hinweis auf Sonntag schon am Donnerstag geschrieben werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1274
+#: lib/abuuba_web/live/settings_live.ex:1275
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr "Zurücknehmen"
@@ -2953,12 +2953,12 @@ msgstr "Alle informieren"
 msgid "Terms need some text and a day they take effect."
 msgstr "Nutzungsbedingungen brauchen einen Text und einen Tag, ab dem sie gelten."
 
-#: lib/abuuba_web/live/settings_live.ex:1258
+#: lib/abuuba_web/live/settings_live.ex:1259
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr "Sie folgen dir"
 
-#: lib/abuuba_web/live/settings_live.ex:1249
+#: lib/abuuba_web/live/settings_live.ex:1250
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr "Wofür sie ist"
@@ -2979,7 +2979,7 @@ msgstr "Wann es veröffentlicht wird"
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr "Du meldest dich auf eine Einladung hin an, eine Freigabe brauchst du deshalb nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:1280
+#: lib/abuuba_web/live/settings_live.ex:1281
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr "Du hast noch keine erstellt."
@@ -2989,7 +2989,7 @@ msgstr "Du hast noch keine erstellt."
 msgid "everybody was told"
 msgstr "alle wurden informiert"
 
-#: lib/abuuba_web/live/settings_live.ex:2088
+#: lib/abuuba_web/live/settings_live.ex:2089
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3103,9 +3103,9 @@ msgstr "nur mit Freigabe"
 msgid "by %{name}"
 msgstr "von %{name}"
 
-#: lib/abuuba_web/live/explore_live.ex:204
-#: lib/abuuba_web/live/home_live.ex:337
-#: lib/abuuba_web/live/profile_live.ex:518
+#: lib/abuuba_web/live/explore_live.ex:208
+#: lib/abuuba_web/live/home_live.ex:338
+#: lib/abuuba_web/live/profile_live.ex:529
 #: lib/abuuba_web/live/search_live.ex:195
 #: lib/abuuba_web/live/status_live.ex:185
 #: lib/abuuba_web/live/tag_live.ex:153
@@ -3128,245 +3128,245 @@ msgstr "Übersetzt von %{provider}. Lade die Seite neu für das Original."
 msgid "This account has been disabled. Contact the moderators."
 msgstr "Dieses Konto wurde deaktiviert. Wende dich an die Moderation."
 
-#: lib/abuuba_web/live/settings_live.ex:1987
+#: lib/abuuba_web/live/settings_live.ex:1988
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr "%{count} konnten nicht übernommen werden"
 
-#: lib/abuuba_web/live/settings_live.ex:1978
+#: lib/abuuba_web/live/settings_live.ex:1979
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr "%{done} von %{total} gelesen, %{imported} übernommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1894
+#: lib/abuuba_web/live/settings_live.ex:1895
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr "Boosts und Umfragen. Ein Boost verweist auf den Beitrag einer anderen Person, den das Archiv nicht enthält, und die Stimmen einer Umfrage wären hier nicht mehr richtig."
 
-#: lib/abuuba_web/live/settings_live.ex:2051
+#: lib/abuuba_web/live/settings_live.ex:2052
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr "Wähle zuerst ein Archiv aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1875
+#: lib/abuuba_web/live/settings_live.ex:1876
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr "Jeder Fediverse-Server gibt dir ein ZIP mit allem, was du geschrieben hast. Lade es hier hoch, und deine Beiträge kommen zurück, mit ihren Bildern und ihrem ursprünglichen Datum."
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr "Fertig."
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2110
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
 
-#: lib/abuuba_web/live/settings_live.ex:1900
+#: lib/abuuba_web/live/settings_live.ex:1901
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr "Importierte Beiträge tauchen in keiner Timeline auf und gehen nicht ins Netzwerk. Sie stehen in deinem Profil, in der Reihenfolge, in der du sie geschrieben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr "Ein Archiv auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:2139
+#: lib/abuuba_web/live/settings_live.ex:2140
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr "Ein Archiv deiner Beiträge von einem anderen Server wieder einlesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr "Dein Archiv wird gelesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2076
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr "Das Archiv konnte nicht gelesen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2047
+#: lib/abuuba_web/live/settings_live.ex:2048
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr "Das konnte nicht gelesen werden. Lade das Archiv hoch, das dir dein alter Server gegeben hat."
 
-#: lib/abuuba_web/live/settings_live.ex:2062
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2063
+#: lib/abuuba_web/live/settings_live.ex:2068
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr "Das konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2064
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2066
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr "Das ist keine Archivdatei."
 
-#: lib/abuuba_web/live/settings_live.ex:1884
+#: lib/abuuba_web/live/settings_live.ex:1885
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr "Die alten Adressen. Deine Beiträge lagen auf einer anderen Domain und können dort nicht wieder liegen, also bleibt jeder Link darauf tot."
 
-#: lib/abuuba_web/live/settings_live.ex:2072
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr "Wartet auf den Start."
 
-#: lib/abuuba_web/live/settings_live.ex:1881
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr "Was nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:1889
+#: lib/abuuba_web/live/settings_live.ex:1890
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr "Deine Follower. Ein Follow ist eine Abmachung zwischen zwei Servern, und einer davon ist weg; sie müssen diesem Konto neu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:2078
+#: lib/abuuba_web/live/settings_live.ex:2079
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr "ein Boost, der nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2080
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr "eine Umfrage, die nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2082
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr "kein Datum, also kein Platz dafür"
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2085
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr "die Datei ist kein Archiv"
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2083
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr "der Beitrag wurde nicht gefunden"
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr "dieser Server hat ihn nicht angenommen"
 
-#: lib/abuuba_web/live/settings_live.ex:1045
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr "Alle annehmen"
 
-#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:1934
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr "Dazu hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:1040
+#: lib/abuuba_web/live/settings_live.ex:1041
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr "Nach einem Umzug kommen alle, die dir gefolgt sind, auf einmal an. Das nimmt sie alle an, was dieselbe Antwort ist, die du ihnen schon gegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1951
+#: lib/abuuba_web/live/settings_live.ex:1952
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr "Ein Archiv deiner Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:1050
+#: lib/abuuba_web/live/settings_live.ex:1051
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr "Für den Export deiner Daten und das Löschen des Kontos steht die Arbeit noch aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1038
+#: lib/abuuba_web/live/settings_live.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr "Wartende Folgeanfragen"
 
-#: lib/abuuba_web/live/settings_live.ex:1007
+#: lib/abuuba_web/live/settings_live.ex:1008
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr "Ich bin zurück"
 
-#: lib/abuuba_web/live/settings_live.ex:1964
+#: lib/abuuba_web/live/settings_live.ex:1965
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr "Archiv importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1941
+#: lib/abuuba_web/live/settings_live.ex:1942
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr "Liste importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1064
-#: lib/abuuba_web/live/settings_live.ex:1913
-#: lib/abuuba_web/live/settings_live.ex:2244
+#: lib/abuuba_web/live/settings_live.ex:1065
+#: lib/abuuba_web/live/settings_live.ex:1914
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr "Listen"
 
-#: lib/abuuba_web/live/settings_live.ex:1034
+#: lib/abuuba_web/live/settings_live.ex:1035
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr "Umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:1018
+#: lib/abuuba_web/live/settings_live.ex:1019
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr "Zu einem anderen Konto umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2037
+#: lib/abuuba_web/live/settings_live.ex:2038
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr "Unter dieser Adresse war niemand zu finden."
 
-#: lib/abuuba_web/live/settings_live.ex:1002
+#: lib/abuuba_web/live/settings_live.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr "Anderen Servern wird gesagt, dass sie stattdessen dem neuen Konto folgen sollen. Wer dir von diesem Server aus folgt, ist bereits umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1937
+#: lib/abuuba_web/live/settings_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr "Durch die Datei ersetzen"
 
-#: lib/abuuba_web/live/settings_live.ex:2027
+#: lib/abuuba_web/live/settings_live.ex:2028
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr "Dieses Konto nennt dieses hier nicht als eines von deinen. Trage die Adresse dieses Kontos zuerst dort bei den Aliassen ein."
 
-#: lib/abuuba_web/live/settings_live.ex:2038
+#: lib/abuuba_web/live/settings_live.ex:2039
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr "Das ist dieses Konto."
 
-#: lib/abuuba_web/live/settings_live.ex:1915
+#: lib/abuuba_web/live/settings_live.ex:1916
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr "Die CSV-Dateien, die dir dein alter Server gibt: Follows, Blocks, Stummschaltungen, Domain-Blocks, Listen, Lesezeichen, Filter. Lade sie einzeln hoch, unter dem Namen, unter dem sie kamen."
 
-#: lib/abuuba_web/live/settings_live.ex:1028
+#: lib/abuuba_web/live/settings_live.ex:1029
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr "Das andere Konto muss dieses hier zuerst in seinen eigenen Aliassen nennen. Deine Follower hier ziehen mit um, und alle anderen Server werden benachrichtigt; ein Konto kann nur alle %{days} Tage umziehen."
 
-#: lib/abuuba_web/live/settings_live.ex:1000
+#: lib/abuuba_web/live/settings_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1930
+#: lib/abuuba_web/live/settings_live.ex:1931
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr "Was mit dem passieren soll, was schon da ist"
 
-#: lib/abuuba_web/live/settings_live.ex:2033
+#: lib/abuuba_web/live/settings_live.ex:2034
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr "Du bist vor Kurzem umgezogen. Ein Konto kann nur alle %{days} Tage umziehen."
@@ -3376,27 +3376,27 @@ msgstr "Du bist vor Kurzem umgezogen. Ein Konto kann nur alle %{days} Tage umzie
 msgid "No such post here."
 msgstr "So einen Beitrag gibt es hier nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:244
+#: lib/abuuba_web/live/settings_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr "Ein Link bekommt einen Haken, sobald die Seite, auf die er zeigt, mit rel=\"me\" auf dein Profil zurückverweist. Wir schauen etwa einmal pro Woche wieder nach."
 
-#: lib/abuuba_web/live/settings_live.ex:782
+#: lib/abuuba_web/live/settings_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr "Ein Wort pro Zeile. Ein Beitrag passt, wenn eines davon darin vorkommt."
 
-#: lib/abuuba_web/live/settings_live.ex:795
+#: lib/abuuba_web/live/settings_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr "Nur ganze Wörter, damit „Katze“ nicht auf „Katzenklo“ passt"
 
-#: lib/abuuba_web/live/settings_live.ex:779
+#: lib/abuuba_web/live/settings_live.ex:780
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr "Wonach gesucht wird"
 
-#: lib/abuuba_web/live/settings_live.ex:1514
+#: lib/abuuba_web/live/settings_live.ex:1515
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr "Ein Filter braucht mindestens ein Wort, nach dem er suchen soll."
@@ -3406,54 +3406,54 @@ msgstr "Ein Filter braucht mindestens ein Wort, nach dem er suchen soll."
 msgid "Why they want to join:"
 msgstr "Warum die Person mitmachen möchte:"
 
-#: lib/abuuba_web/live/settings_live.ex:307
+#: lib/abuuba_web/live/settings_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] "%{count} Beitrag"
 msgstr[1] "%{count} Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:324
+#: lib/abuuba_web/live/settings_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr "Ein Hashtag, ohne das #"
 
-#: lib/abuuba_web/live/settings_live.ex:327
+#: lib/abuuba_web/live/settings_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "Feature it"
 msgstr "Hervorheben"
 
-#: lib/abuuba_web/live/settings_live.ex:298
+#: lib/abuuba_web/live/settings_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr "Hervorgehobene Hashtags"
 
-#: lib/abuuba_web/live/settings_live.ex:300
+#: lib/abuuba_web/live/settings_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr "Stehen auf deinem Profil als Abkürzung zu dem, worüber du schreibst."
 
-#: lib/abuuba_web/live/settings_live.ex:1497
+#: lib/abuuba_web/live/settings_live.ex:1498
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr "Das ist kein Hashtag, den man benutzen kann."
 
-#: lib/abuuba_web/live/settings_live.ex:331
+#: lib/abuuba_web/live/settings_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr "Du schreibst oft über:"
 
-#: lib/abuuba_web/live/settings_live.ex:1491
+#: lib/abuuba_web/live/settings_live.ex:1492
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr "Ein Profil kann %{count} Hashtags tragen. Nimm zuerst einen weg."
 
-#: lib/abuuba_web/live/settings_live.ex:482
+#: lib/abuuba_web/live/settings_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr "Sagen, aus welcher App du schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:484
+#: lib/abuuba_web/live/settings_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr "Steht für alle anderen unter deinen Beiträgen. An deinen eigenen siehst du es immer."
@@ -3483,29 +3483,29 @@ msgstr "Damit endet auch die Anmeldung dieser Person. Fortfahren?"
 msgid "This is not a memorial"
 msgstr "Das ist keine Gedenkseite"
 
-#: lib/abuuba_web/live/collection_live.ex:64
+#: lib/abuuba_web/live/collection_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{count} account"
 msgid_plural "%{count} accounts"
 msgstr[0] "%{count} Konto"
 msgstr[1] "%{count} Konten"
 
-#: lib/abuuba_web/live/collection_live.ex:112
+#: lib/abuuba_web/live/collection_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "A collection by %{name}"
 msgstr "Eine Sammlung von %{name}"
 
-#: lib/abuuba_web/live/collection_live.ex:60
+#: lib/abuuba_web/live/collection_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "By"
 msgstr "Von"
 
-#: lib/abuuba_web/live/collection_live.ex:52
+#: lib/abuuba_web/live/collection_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Collection"
 msgstr "Sammlung"
 
-#: lib/abuuba_web/live/collection_live.ex:87
+#: lib/abuuba_web/live/collection_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this list yet."
 msgstr "Auf dieser Liste steht noch niemand."
@@ -3601,7 +3601,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr "Jede Person muss es zusätzlich für sich selbst einschalten, und jede Adresse muss bestätigen, bevor irgendetwas dorthin geht."
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:645
+#: lib/abuuba_web/live/settings_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "Email updates"
 msgstr "Neuigkeiten per E-Mail"
@@ -3616,7 +3616,7 @@ msgstr "Neuigkeiten per E-Mail von %{name}"
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr "Wenn du das nicht warst, kannst du diese Nachricht ignorieren. An diese Adresse geht dann nichts weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:663
+#: lib/abuuba_web/live/settings_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr "Leute dürfen meine Neuigkeiten per E-Mail abonnieren"
@@ -3626,7 +3626,7 @@ msgstr "Leute dürfen meine Neuigkeiten per E-Mail abonnieren"
 msgid "No, remove my address"
 msgstr "Nein, meine Adresse löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:665
+#: lib/abuuba_web/live/settings_live.ex:666
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3679,7 +3679,7 @@ msgstr "jemand hat diese Adresse angegeben, um Neuigkeiten von %{name} auf %{sit
 msgid "Let people collect email addresses for updates"
 msgstr "Erlaube es, E-Mail-Adressen für Neuigkeiten zu sammeln"
 
-#: lib/abuuba_web/live/settings_live.ex:647
+#: lib/abuuba_web/live/settings_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr "Wer hier kein Konto möchte, kann stattdessen eine E-Mail-Adresse angeben. Die Adresse bestätigt selbst und kann die Neuigkeiten aus jeder Nachricht heraus wieder abbestellen. Verschickt wird noch nichts; das hier sammelt die Liste."
@@ -3827,75 +3827,75 @@ msgstr "jemand hat für dein Konto auf %{site} ein neues Passwort angefordert. W
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr "das Passwort deines Kontos auf %{site} wurde gerade geändert, und überall, wo du angemeldet warst, wurdest du abgemeldet."
 
-#: lib/abuuba_web/live/settings_live.ex:1077
+#: lib/abuuba_web/live/settings_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr "Eine Kopie von allem"
 
-#: lib/abuuba_web/live/settings_live.ex:2251
+#: lib/abuuba_web/live/settings_live.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr "Wird gebaut"
 
-#: lib/abuuba_web/live/settings_live.ex:810
-#: lib/abuuba_web/live/settings_live.ex:2245
+#: lib/abuuba_web/live/settings_live.ex:811
+#: lib/abuuba_web/live/settings_live.ex:2246
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr "Blockierte Server"
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2242
+#: lib/abuuba_web/live/settings_live.ex:2243
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr "Blockierte"
 
-#: lib/abuuba_web/live/settings_live.ex:2246
+#: lib/abuuba_web/live/settings_live.ex:2247
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/abuuba_web/live/settings_live.ex:1119
+#: lib/abuuba_web/live/settings_live.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr "Bau mir eine Kopie"
 
-#: lib/abuuba_web/live/settings_live.ex:2253
+#: lib/abuuba_web/live/settings_live.ex:2254
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr "Hat nicht geklappt"
 
-#: lib/abuuba_web/live/settings_live.ex:1102
+#: lib/abuuba_web/live/settings_live.ex:1103
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr "Herunterladen"
 
-#: lib/abuuba_web/live/settings_live.ex:2110
+#: lib/abuuba_web/live/settings_live.ex:2111
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr "Exportieren"
 
-#: lib/abuuba_web/live/settings_live.ex:2243
+#: lib/abuuba_web/live/settings_live.ex:2244
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr "Stummgeschaltete"
 
-#: lib/abuuba_web/live/settings_live.ex:1066
+#: lib/abuuba_web/live/settings_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr "Je eine Datei, im Format, das der Import dieses Servers liest. Ein Export von hier ist ein Import anderswo."
 
-#: lib/abuuba_web/live/settings_live.ex:1387
+#: lib/abuuba_web/live/settings_live.ex:1388
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr "Eine wird gerade schon gebaut."
 
-#: lib/abuuba_web/live/settings_live.ex:1084
+#: lib/abuuba_web/live/settings_live.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr "Bilder und Videos sind nicht in der Datei. Sie enthält ihre Adressen, die funktionieren, solange dieser Server läuft."
 
-#: lib/abuuba_web/live/settings_live.ex:2252
+#: lib/abuuba_web/live/settings_live.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr "Fertig"
@@ -3915,13 +3915,13 @@ msgstr "Die Datei wird nach %{days} Tagen gelöscht, weil sie dein ganzes Konto 
 msgid "There is nothing of that kind to export."
 msgstr "So etwas gibt es hier nicht zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:2250
+#: lib/abuuba_web/live/settings_live.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr "Wartet auf den Start"
 
-#: lib/abuuba_web/live/settings_live.ex:1108
-#: lib/abuuba_web/live/settings_live.ex:1393
+#: lib/abuuba_web/live/settings_live.ex:1109
+#: lib/abuuba_web/live/settings_live.ex:1394
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr "Ab %{date} kannst du eine neue anfordern."
@@ -3931,7 +3931,7 @@ msgstr "Ab %{date} kannst du eine neue anfordern."
 msgid "Your archive is ready"
 msgstr "Deine Kopie ist fertig"
 
-#: lib/abuuba_web/live/settings_live.ex:1079
+#: lib/abuuba_web/live/settings_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wird im Hintergrund gebaut; wir schicken dir eine E-Mail, wenn sie fertig ist."
@@ -3941,67 +3941,67 @@ msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wi
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr "die Kopie deines Kontos auf %{site}, die du angefordert hast, ist fertig. Hier herunterladen:"
 
-#: lib/abuuba_web/live/settings_live.ex:1158
+#: lib/abuuba_web/live/settings_live.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr "Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1156
+#: lib/abuuba_web/live/settings_live.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr "Das Konto endgültig schließen? Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1122
+#: lib/abuuba_web/live/settings_live.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr "Dieses Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1061
+#: lib/abuuba_web/live/settings_live.ex:1062
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr "Alles hier gehört dir, und das Konto zu schließen ist deine Entscheidung."
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr "Eine Kopie von allem mitnehmen, oder das Konto endgültig schließen."
 
-#: lib/abuuba_web/live/settings_live.ex:1139
+#: lib/abuuba_web/live/settings_live.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr "Hol dir vorher deine Kopie. Danach gibt es nichts mehr zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:1420
+#: lib/abuuba_web/live/settings_live.ex:1421
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr "Das hat nicht geklappt. Es wurde nichts gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:1417
+#: lib/abuuba_web/live/settings_live.ex:1418
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr "Das ist nicht dein Passwort."
 
-#: lib/abuuba_web/live/settings_live.ex:1129
+#: lib/abuuba_web/live/settings_live.ex:1130
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr "Das Konto verschwindet sofort. Die Datensätze werden kurz danach gelöscht, damit die Nachricht an die anderen Server noch signiert und verschickt werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1413
+#: lib/abuuba_web/live/settings_live.ex:1414
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr "Das Konto ist geschlossen. Danke, dass du hier warst."
 
-#: lib/abuuba_web/live/settings_live.ex:1144
+#: lib/abuuba_web/live/settings_live.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr "Dein Passwort, damit sicher ist, dass du es bist"
 
-#: lib/abuuba_web/live/settings_live.ex:1124
+#: lib/abuuba_web/live/settings_live.ex:1125
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr "Deine Beiträge, Folge-Beziehungen, Listen, Filter, Lesezeichen und Einstellungen werden gelöscht, und andere Server werden aufgefordert, ihre Kopien zu löschen. Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1134
+#: lib/abuuba_web/live/settings_live.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr "Dein Benutzername bleibt und niemand kann ihn je bekommen, damit alte Links und Erwähnungen von dir nie auf jemand anderen zeigen."
@@ -4011,7 +4011,7 @@ msgstr "Dein Benutzername bleibt und niemand kann ihn je bekommen, damit alte Li
 msgid "A post"
 msgstr "Ein Beitrag"
 
-#: lib/abuuba_web/live/profile_live.ex:390
+#: lib/abuuba_web/live/profile_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "Nobody yet."
 msgstr "Noch niemand."
@@ -4021,7 +4021,7 @@ msgstr "Noch niemand."
 msgid "Public posts tagged #%{tag}"
 msgstr "Öffentliche Beiträge mit #%{tag}"
 
-#: lib/abuuba_web/live/profile_live.ex:367
+#: lib/abuuba_web/live/profile_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr "Dieses Konto behält für sich, wem es folgt und wer ihm folgt."
@@ -4047,99 +4047,99 @@ msgstr "Diese Einladung kennen wir nicht."
 msgid "You can still sign up without one."
 msgstr "Du kannst dich trotzdem ohne eine anmelden."
 
-#: lib/abuuba_web/live/settings_live.ex:1449
+#: lib/abuuba_web/live/settings_live.ex:1450
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr "Ein Alter muss mindestens 7 Tage betragen, und die Anzahlen dürfen nicht negativ sein."
 
-#: lib/abuuba_web/live/settings_live.ex:914
+#: lib/abuuba_web/live/settings_live.ex:915
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr "Gescheiterte Versuche stehen hier ebenfalls. Dass jemand anderes dein Passwort probiert, sollte man früh mitbekommen, und nichts sonst würde es dir sagen."
 
-#: lib/abuuba_web/live/settings_live.ex:523
+#: lib/abuuba_web/live/settings_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr "Meine alten Beiträge löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:532
+#: lib/abuuba_web/live/settings_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr "Beiträge löschen, die älter sind als, in Tagen"
 
-#: lib/abuuba_web/live/settings_live.ex:551
+#: lib/abuuba_web/live/settings_live.ex:552
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr "Angeheftete Beiträge behalten"
 
-#: lib/abuuba_web/live/settings_live.ex:578
+#: lib/abuuba_web/live/settings_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr "Beiträge behalten, die mindestens so oft geboostet wurden"
 
-#: lib/abuuba_web/live/settings_live.ex:567
+#: lib/abuuba_web/live/settings_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr "Beiträge behalten, die mindestens so oft favorisiert wurden"
 
-#: lib/abuuba_web/live/settings_live.ex:563
+#: lib/abuuba_web/live/settings_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr "Beiträge mit Bildern oder Video behalten"
 
-#: lib/abuuba_web/live/settings_live.ex:937
+#: lib/abuuba_web/live/settings_live.ex:938
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr "Wird %{days} Tage aufgehoben und dann gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:520
+#: lib/abuuba_web/live/settings_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Nothing pinned."
 msgstr "Nichts angeheftet."
 
-#: lib/abuuba_web/live/settings_live.ex:933
+#: lib/abuuba_web/live/settings_live.ex:934
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr "Noch nichts aufgezeichnet."
 
-#: lib/abuuba_web/live/settings_live.ex:525
+#: lib/abuuba_web/live/settings_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr "Aus, solange du es nicht einschaltest. Lass das Alter leer, um es wieder auszuschalten; bis du eines setzt, wird nichts gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:589
+#: lib/abuuba_web/live/settings_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] "Ein Beitrag passt gerade auf diese Einstellungen."
 msgstr[1] "%{count} Beiträge passen gerade auf diese Einstellungen."
 
-#: lib/abuuba_web/live/settings_live.ex:500
+#: lib/abuuba_web/live/settings_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Pinned posts"
 msgstr "Angeheftete Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:912
+#: lib/abuuba_web/live/settings_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr "Letzte Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:922
+#: lib/abuuba_web/live/settings_live.ex:923
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr "Abgelehnt"
 
-#: lib/abuuba_web/live/settings_live.ex:922
+#: lib/abuuba_web/live/settings_live.ex:923
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr "Angemeldet"
 
-#: lib/abuuba_web/live/settings_live.ex:514
+#: lib/abuuba_web/live/settings_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr "Lösen"
 
-#: lib/abuuba_web/live/settings_live.ex:502
+#: lib/abuuba_web/live/settings_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr "Was oben auf deinem Profil steht. Angeheftet wird vom Beitrag aus."
@@ -4951,124 +4951,124 @@ msgid_plural "%{count} signed up"
 msgstr[0] "eine Anmeldung"
 msgstr[1] "%{count} Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2220
+#: lib/abuuba_web/live/settings_live.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr "Profilbild"
 
-#: lib/abuuba_web/live/settings_live.ex:2221
+#: lib/abuuba_web/live/settings_live.ex:2222
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr "Titelbild"
 
-#: lib/abuuba_web/live/settings_live.ex:346
+#: lib/abuuba_web/live/settings_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr "JPEG, PNG, GIF oder WebP, bis %{size}. Größere werden schon vor dem Hochladen abgelehnt und nicht erst danach, und was du schickst, wird hier verkleinert, damit niemand ein ganzes Foto lädt, um es bei vierzig Pixeln zu sehen."
 
 #: lib/abuuba_web/live/admin_live.ex:565
-#: lib/abuuba_web/live/settings_live.ex:364
+#: lib/abuuba_web/live/settings_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "None yet."
 msgstr "Noch keins."
 
-#: lib/abuuba_web/live/settings_live.ex:2061
+#: lib/abuuba_web/live/settings_live.ex:2062
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr "Ein Bild auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:344
+#: lib/abuuba_web/live/settings_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr "Bilder"
 
-#: lib/abuuba_web/live/settings_live.ex:396
+#: lib/abuuba_web/live/settings_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Take it off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2059
-#: lib/abuuba_web/live/settings_live.ex:2214
+#: lib/abuuba_web/live/settings_live.ex:2060
+#: lib/abuuba_web/live/settings_live.ex:2215
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr "Damit kann dieser Server nichts anfangen. Versuch es mit JPEG, PNG, GIF oder WebP."
 
-#: lib/abuuba_web/live/settings_live.ex:2209
-#: lib/abuuba_web/live/settings_live.ex:2216
+#: lib/abuuba_web/live/settings_live.ex:2210
+#: lib/abuuba_web/live/settings_live.ex:2217
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr "Dieses Bild konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr "Dieses Bild ist zu groß. Die Grenze steht eine Zeile weiter oben."
 
-#: lib/abuuba_web/live/profile_live.ex:164
+#: lib/abuuba_web/live/profile_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr "Auf meinem Profil hervorheben"
 
-#: lib/abuuba_web/live/profile_live.ex:313
-#: lib/abuuba_web/live/profile_live.ex:317
+#: lib/abuuba_web/live/profile_live.ex:322
+#: lib/abuuba_web/live/profile_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Featured accounts"
 msgstr "Hervorgehobene Konten"
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr "Nicht mehr hervorheben"
 
-#: lib/abuuba_web/live/profile_live.ex:544
+#: lib/abuuba_web/live/profile_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr "Schau in dieses Postfach: Dort liegt eine Nachricht mit der Bitte um Bestätigung."
 
-#: lib/abuuba_web/live/profile_live.ex:267
+#: lib/abuuba_web/live/profile_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr "Neuigkeiten von %{name} per E-Mail"
 
-#: lib/abuuba_web/live/settings_live.ex:680
+#: lib/abuuba_web/live/settings_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr "Geht an jede bestätigte Adresse, mit einem Link, der die Neuigkeiten beendet. Bis zu %{count} Nachrichten am Tag."
 
-#: lib/abuuba_web/live/profile_live.ex:270
+#: lib/abuuba_web/live/profile_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr "Kein Konto nötig. Wir schreiben einmal an die Adresse, um zu prüfen, ob sie dir gehört, und in jeder Nachricht steht ein Link, der die Neuigkeiten beendet."
 
-#: lib/abuuba_web/live/settings_live.ex:705
+#: lib/abuuba_web/live/settings_live.ex:706
 #, elixir-autogen, elixir-format
 msgid "Send it"
 msgstr "Abschicken"
 
-#: lib/abuuba_web/live/profile_live.ex:286
+#: lib/abuuba_web/live/profile_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr "Neuigkeiten schicken"
 
-#: lib/abuuba_web/live/settings_live.ex:714
+#: lib/abuuba_web/live/settings_live.ex:715
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] "Am %{date} an eine Adresse geschickt."
 msgstr[1] "Am %{date} an %{count} Adressen geschickt."
 
-#: lib/abuuba_web/live/settings_live.ex:691
-#: lib/abuuba_web/live/settings_live.ex:1788
+#: lib/abuuba_web/live/settings_live.ex:692
+#: lib/abuuba_web/live/settings_live.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Betreff"
 
-#: lib/abuuba_web/live/profile_live.ex:547
+#: lib/abuuba_web/live/profile_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr "Das sieht nicht nach einer gültigen E-Mail-Adresse aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1368
+#: lib/abuuba_web/live/settings_live.ex:1369
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr "Diese Liste ist nicht offen."
@@ -5078,17 +5078,17 @@ msgstr "Diese Liste ist nicht offen."
 msgid "To stop them, open this link:"
 msgstr "Zum Beenden diesen Link öffnen:"
 
-#: lib/abuuba_web/live/profile_live.ex:534
+#: lib/abuuba_web/live/profile_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr "Gerade zu viele Versuche von hier. Bitte später noch einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:698
+#: lib/abuuba_web/live/settings_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr "Was du ihnen sagen möchtest"
 
-#: lib/abuuba_web/live/settings_live.ex:678
+#: lib/abuuba_web/live/settings_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr "An sie schreiben"
@@ -5098,22 +5098,22 @@ msgstr "An sie schreiben"
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr "Du bekommst das, weil du auf %{site} um Neuigkeiten von %{name} gebeten hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1373
+#: lib/abuuba_web/live/settings_live.ex:1374
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr "Du hast heute schon so viele Nachrichten geschickt, wie du kannst."
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr "du@example.com"
 
-#: lib/abuuba_web/live/settings_live.ex:1789
+#: lib/abuuba_web/live/settings_live.ex:1790
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
 
-#: lib/abuuba_web/live/settings_live.ex:721
+#: lib/abuuba_web/live/settings_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr "Unterwegs."
@@ -5399,7 +5399,7 @@ msgstr "Deine Unterhaltungen als gelesen markieren"
 msgid "Mute and unmute people for you"
 msgstr "Leute für dich stummschalten und wieder lautstellen"
 
-#: lib/abuuba_web/live/settings_live.ex:960
+#: lib/abuuba_web/live/settings_live.ex:961
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr "Nichts. Sie sieht nur, dass du angemeldet bist, sonst nichts."
@@ -5547,22 +5547,22 @@ msgstr "Das Bild wird noch hochgeladen. Gleich noch einmal versuchen."
 msgid "not offered"
 msgstr "nicht angeboten"
 
-#: lib/abuuba_web/live/profile_live.ex:236
+#: lib/abuuba_web/live/profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr "Keine auszuwählen heißt: alles, was sie schreiben."
 
-#: lib/abuuba_web/live/profile_live.ex:234
+#: lib/abuuba_web/live/profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr "Nur diese Sprachen"
 
-#: lib/abuuba_web/live/profile_live.ex:213
+#: lib/abuuba_web/live/profile_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr "Ihre Weitergaben anderer Leute"
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr "Was du von ihnen siehst"
@@ -5587,47 +5587,47 @@ msgstr "Beendet die Benachrichtigungen und nimmt sie aus deiner Timeline. Nieman
 msgid "Unmute this conversation"
 msgstr "Stummschaltung dieser Unterhaltung aufheben"
 
-#: lib/abuuba_web/live/notifications_live.ex:450
+#: lib/abuuba_web/live/notifications_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr "Beiträge von Leuten, die du beobachtest"
 
-#: lib/abuuba_web/live/profile_live.ex:228
+#: lib/abuuba_web/live/profile_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr "Sag mir Bescheid, wenn sie etwas posten"
 
-#: lib/abuuba_web/live/notifications_live.ex:369
+#: lib/abuuba_web/live/notifications_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr "%{name} hat deinen Beitrag zu einer Sammlung hinzugefügt"
 
-#: lib/abuuba_web/live/notifications_live.ex:373
+#: lib/abuuba_web/live/notifications_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr "%{name} hat eine Meldung eingereicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:371
+#: lib/abuuba_web/live/notifications_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "%{name} signed up"
 msgstr "%{name} hat sich registriert"
 
-#: lib/abuuba_web/live/notifications_live.ex:362
+#: lib/abuuba_web/live/notifications_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr "Einige deiner Follows wurden entfernt, als dieser Server die Föderation mit einem anderen beendet hat"
 
-#: lib/abuuba_web/live/notifications_live.ex:358
+#: lib/abuuba_web/live/notifications_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr "Dein Konto hat eine Verwarnung der Moderation erhalten"
 
-#: lib/abuuba_web/live/notifications_live.ex:366
+#: lib/abuuba_web/live/notifications_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr "Dein Jahr auf diesem Server ist fertig zum Lesen"
 
-#: lib/abuuba_web/live/notifications_live.ex:445
+#: lib/abuuba_web/live/notifications_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "Quotes"
 msgstr "Zitate"
@@ -5751,22 +5751,22 @@ msgstr "Niemand: der Server sagt es nicht"
 msgid "Who may read the blocklist"
 msgstr "Wer die Sperrliste lesen darf"
 
-#: lib/abuuba_web/live/settings_live.ex:635
+#: lib/abuuba_web/live/settings_live.ex:636
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr "Eine Domain pro Zeile. Wird hier ein Link auf eine dieser Seiten geteilt, weist die Vorschau dich als Urheberin oder Urheber aus. Eine Seite, die du nicht eingetragen hast, kann dich nicht für sich beanspruchen, egal was in ihrer Seitenquelle steht."
 
-#: lib/abuuba_web/live/settings_live.ex:627
+#: lib/abuuba_web/live/settings_live.ex:628
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr "Seiten, die mich als Autorin oder Autor nennen dürfen"
 
-#: lib/abuuba_web/live/settings_live.ex:839
+#: lib/abuuba_web/live/settings_live.ex:840
 #, elixir-autogen, elixir-format
 msgid "Block a server"
 msgstr "Server blockieren"
 
-#: lib/abuuba_web/live/settings_live.ex:812
+#: lib/abuuba_web/live/settings_live.ex:813
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht deine Timelines, deine Suche, deine Threads oder deine Benachrichtigungen. Folge-Beziehungen in beide Richtungen werden aufgelöst, genau wie beim Blockieren einer einzelnen Person."
@@ -5776,8 +5776,8 @@ msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht d
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr "Zu viele Anmeldungen von hier im Moment. Bitte versuche es später noch einmal."
 
-#: lib/abuuba_web/live/explore_live.ex:144
-#: lib/abuuba_web/live/profile_live.ex:585
+#: lib/abuuba_web/live/explore_live.ex:148
+#: lib/abuuba_web/live/profile_live.ex:596
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr "Zu viele Follows für heute. Versuche es morgen noch einmal."
@@ -5842,8 +5842,23 @@ msgstr "Stattgeben und rückgängig machen"
 msgid "Warned"
 msgstr "Verwarnt"
 
-#: lib/abuuba_web/live/settings_live.ex:2234
-#: lib/abuuba_web/live/settings_live.ex:2237
+#: lib/abuuba_web/live/settings_live.ex:2235
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr "%{size} MB"
+
+#: lib/abuuba_web/live/profile_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Cancel follow request"
+msgstr "Folgeanfrage zurückziehen"
+
+#: lib/abuuba_web/live/explore_live.ex:117
+#, elixir-autogen, elixir-format
+msgid "Requested"
+msgstr "Angefragt"
+
+#: lib/abuuba_web/live/profile_live.ex:606
+#, elixir-autogen, elixir-format
+msgid "This account approves its followers. Your request is waiting for an answer."
+msgstr "Dieses Konto bestätigt seine Follower selbst. Deine Anfrage wartet auf eine Antwort."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -126,7 +126,7 @@ msgstr "Bestätige zuerst deine E-Mail-Adresse. Sieh in deinem Postfach nach."
 msgid "Create account"
 msgstr "Konto erstellen"
 
-#: lib/abuuba_web/live/landing_live.ex:80
+#: lib/abuuba_web/live/landing_live.ex:81
 #: lib/abuuba_web/live/registration_live.ex:37
 #: lib/abuuba_web/live/registration_live.ex:207
 #, elixir-autogen, elixir-format
@@ -332,12 +332,12 @@ msgstr "danke, dass du dich bei %{site} angemeldet hast. Hier liest ein Moderato
 msgid "you can now sign in to %{site}:"
 msgstr "du kannst dich jetzt bei %{site} anmelden:"
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:96
+#: lib/abuuba_web/live/two_factor_settings_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "A second factor means somebody who learns your password still cannot sign in as you."
 msgstr "Ein zweiter Faktor bedeutet: Wer dein Passwort erfährt, kann sich trotzdem nicht als du anmelden."
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:116
+#: lib/abuuba_web/live/two_factor_settings_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Cannot scan it? Type this in instead:"
 msgstr "Kannst du ihn nicht scannen? Gib stattdessen das hier ein:"
@@ -348,7 +348,7 @@ msgid "Checking…"
 msgstr "Wird geprüft …"
 
 #: lib/abuuba_web/live/two_factor_live.ex:40
-#: lib/abuuba_web/live/two_factor_settings_live.ex:124
+#: lib/abuuba_web/live/two_factor_settings_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr "Code"
@@ -363,7 +363,7 @@ msgstr "Weiter"
 msgid "Enter the code from your authenticator app, or one of your recovery codes."
 msgstr "Gib den Code aus deiner Authenticator-App ein oder einen deiner Wiederherstellungscodes."
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:146
+#: lib/abuuba_web/live/two_factor_settings_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Make new recovery codes"
 msgstr "Neue Wiederherstellungscodes erzeugen"
@@ -373,22 +373,22 @@ msgstr "Neue Wiederherstellungscodes erzeugen"
 msgid "One more step"
 msgstr "Noch ein Schritt"
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:83
+#: lib/abuuba_web/live/two_factor_settings_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Save these recovery codes now"
 msgstr "Sichere diese Wiederherstellungscodes jetzt"
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:110
+#: lib/abuuba_web/live/two_factor_settings_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Scan this with your authenticator app, then type the code it shows."
 msgstr "Scanne das mit deiner Authenticator-App und gib dann den Code ein, den sie anzeigt."
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:104
+#: lib/abuuba_web/live/two_factor_settings_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Set up an authenticator app"
 msgstr "Authenticator-App einrichten"
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:50
+#: lib/abuuba_web/live/two_factor_settings_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "That code is not right. Try again."
 msgstr "Dieser Code stimmt nicht. Versuch es noch einmal."
@@ -398,54 +398,54 @@ msgstr "Dieser Code stimmt nicht. Versuch es noch einmal."
 msgid "That code is not right. Try the next one."
 msgstr "Dieser Code stimmt nicht. Nimm den nächsten."
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:85
+#: lib/abuuba_web/live/two_factor_settings_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "This is the only time they are shown. Each one works once, and they are how you get back in if you lose your phone."
 msgstr "Sie werden nur dieses eine Mal angezeigt. Jeder funktioniert einmal, und damit kommst du wieder hinein, wenn du dein Telefon verlierst."
 
-#: lib/abuuba_web/live/admin_live.ex:534
-#: lib/abuuba_web/live/two_factor_settings_live.ex:154
+#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/two_factor_settings_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Turn it off"
 msgstr "Ausschalten"
 
-#: lib/abuuba_web/live/admin_live.ex:534
-#: lib/abuuba_web/live/two_factor_settings_live.ex:131
+#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/two_factor_settings_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Turn it on"
 msgstr "Einschalten"
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:151
+#: lib/abuuba_web/live/two_factor_settings_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Turn off two-factor authentication?"
 msgstr "Zwei-Faktor-Authentifizierung ausschalten?"
 
-#: lib/abuuba_web/live/settings_live.ex:899
+#: lib/abuuba_web/live/settings_live.ex:900
 #: lib/abuuba_web/live/two_factor_live.ex:16
-#: lib/abuuba_web/live/two_factor_settings_live.ex:21
-#: lib/abuuba_web/live/two_factor_settings_live.ex:80
+#: lib/abuuba_web/live/two_factor_settings_live.ex:20
+#: lib/abuuba_web/live/two_factor_settings_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication"
 msgstr "Zwei-Faktor-Authentifizierung"
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:72
+#: lib/abuuba_web/live/two_factor_settings_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication is off."
 msgstr "Die Zwei-Faktor-Authentifizierung ist aus."
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:47
+#: lib/abuuba_web/live/two_factor_settings_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication is on."
 msgstr "Die Zwei-Faktor-Authentifizierung ist an."
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:138
+#: lib/abuuba_web/live/two_factor_settings_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication is on. You have 1 recovery code left."
 msgid_plural "Two-factor authentication is on. You have %{count} recovery codes left."
 msgstr[0] "Die Zwei-Faktor-Authentifizierung ist an. Du hast noch 1 Wiederherstellungscode."
 msgstr[1] "Die Zwei-Faktor-Authentifizierung ist an. Du hast noch %{count} Wiederherstellungscodes."
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:61
+#: lib/abuuba_web/live/two_factor_settings_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Your old recovery codes no longer work."
 msgstr "Deine alten Wiederherstellungscodes funktionieren nicht mehr."
@@ -455,7 +455,7 @@ msgstr "Deine alten Wiederherstellungscodes funktionieren nicht mehr."
 msgid "Act as a moderator (%{scope})"
 msgstr "Als Moderator handeln (%{scope})"
 
-#: lib/abuuba_web/live/admin_live.ex:1049
+#: lib/abuuba_web/live/admin_live.ex:1051
 #: lib/abuuba_web/live/authorize_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Allow"
@@ -466,7 +466,7 @@ msgstr "Erlauben"
 msgid "Authorize %{app}"
 msgstr "%{app} autorisieren"
 
-#: lib/abuuba_web/live/admin_live.ex:1739
+#: lib/abuuba_web/live/admin_live.ex:1741
 #: lib/abuuba_web/live/authorize_live.ex:123
 #: lib/abuuba_web/live/compose_component.ex:410
 #: lib/abuuba_web/live/compose_component.ex:423
@@ -664,7 +664,7 @@ msgstr "Entdecken"
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
 #: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
@@ -677,7 +677,7 @@ msgid "Keyboard shortcuts"
 msgstr "Tastaturkürzel"
 
 #: lib/abuuba_web/components/layouts.ex:254
-#: lib/abuuba_web/live/landing_live.ex:82
+#: lib/abuuba_web/live/landing_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Anmelden"
@@ -691,14 +691,14 @@ msgstr "Hauptnavigation"
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr "Mitteilungen"
 
 #: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:118
-#: lib/abuuba_web/live/settings_live.ex:2112
+#: lib/abuuba_web/live/settings_live.ex:119
+#: lib/abuuba_web/live/settings_live.ex:2119
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -793,37 +793,37 @@ msgstr "Du bist am Ende angekommen."
 msgid "Your choice"
 msgstr "Deine Wahl"
 
-#: lib/abuuba_web/live/compose_component.ex:1682
+#: lib/abuuba_web/live/compose_component.ex:1679
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr "1 Tag"
 
-#: lib/abuuba_web/live/compose_component.ex:1680
+#: lib/abuuba_web/live/compose_component.ex:1677
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr "1 Stunde"
 
-#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/compose_component.ex:1680
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr "3 Tage"
 
-#: lib/abuuba_web/live/compose_component.ex:1679
+#: lib/abuuba_web/live/compose_component.ex:1676
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr "30 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1678
+#: lib/abuuba_web/live/compose_component.ex:1675
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr "5 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1681
+#: lib/abuuba_web/live/compose_component.ex:1678
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr "6 Stunden"
 
-#: lib/abuuba_web/live/compose_component.ex:1684
+#: lib/abuuba_web/live/compose_component.ex:1681
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr "7 Tage"
@@ -848,20 +848,20 @@ msgstr "Umfrage hinzufügen"
 msgid "Allow more than one choice"
 msgstr "Mehrfachauswahl erlauben"
 
-#: lib/abuuba_web/live/compose_component.ex:1699
-#: lib/abuuba_web/live/settings_live.ex:2292
+#: lib/abuuba_web/live/compose_component.ex:1696
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr "Alle"
 
-#: lib/abuuba_web/live/compose_component.ex:1690
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/compose_component.ex:1687
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr "Alle, und überall gelistet"
 
-#: lib/abuuba_web/live/compose_component.ex:1691
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/compose_component.ex:1688
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr "Alle, aber nicht in öffentlichen Timelines"
@@ -888,7 +888,7 @@ msgid "Do not reply to this person"
 msgstr "Diese Person nicht mit anschreiben"
 
 #: lib/abuuba_web/components/status_component.ex:432
-#: lib/abuuba_web/live/admin_live.ex:1759
+#: lib/abuuba_web/live/admin_live.ex:1761
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -903,37 +903,37 @@ msgstr "Beitrag bearbeiten"
 msgid "Ends after"
 msgstr "Endet nach"
 
-#: lib/abuuba_web/live/compose_component.ex:1692
-#: lib/abuuba_web/live/profile_live.ex:866
+#: lib/abuuba_web/live/compose_component.ex:1689
+#: lib/abuuba_web/live/profile_live.ex:837
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/abuuba_web/live/compose_component.ex:1693
+#: lib/abuuba_web/live/compose_component.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr "Erwähnte Personen"
 
-#: lib/abuuba_web/live/admin_live.ex:3419
-#: lib/abuuba_web/live/compose_component.ex:1701
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/admin_live.ex:3413
+#: lib/abuuba_web/live/compose_component.ex:1698
+#: lib/abuuba_web/live/settings_live.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr "Niemand"
 
-#: lib/abuuba_web/live/compose_component.ex:1692
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/compose_component.ex:1689
+#: lib/abuuba_web/live/settings_live.ex:2290
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr "Nur die Leute, die dir folgen"
 
-#: lib/abuuba_web/live/compose_component.ex:1693
+#: lib/abuuba_web/live/compose_component.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr "Nur die Leute, die du nennst"
 
-#: lib/abuuba_web/live/compose_component.ex:1700
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/compose_component.ex:1697
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr "Leute, die dir folgen"
@@ -948,13 +948,13 @@ msgstr "Veröffentlichen"
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/abuuba_web/live/compose_component.ex:1690
-#: lib/abuuba_web/live/compose_component.ex:1708
+#: lib/abuuba_web/live/compose_component.ex:1687
+#: lib/abuuba_web/live/compose_component.ex:1705
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/abuuba_web/live/compose_component.ex:1691
+#: lib/abuuba_web/live/compose_component.ex:1688
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr "Still öffentlich"
@@ -979,7 +979,7 @@ msgstr "Antwort an %{name}"
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/abuuba_web/live/admin_live.ex:3380
+#: lib/abuuba_web/live/admin_live.ex:3374
 #: lib/abuuba_web/live/compose_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
@@ -1201,17 +1201,17 @@ msgstr "Dieser Server nimmt keine Dateien dieser Art."
 msgid "or drop one on the box, or paste it"
 msgstr "oder zieh eine ins Feld oder füg sie ein"
 
-#: lib/abuuba_web/live/status_live.ex:278
+#: lib/abuuba_web/live/status_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr "%{name} auf %{server}"
 
-#: lib/abuuba_web/live/profile_live.ex:301
+#: lib/abuuba_web/live/profile_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr "Eine Notiz, die nur du liest"
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr "Blockieren"
@@ -1228,34 +1228,34 @@ msgstr "Folgen"
 msgid "Go to the new account"
 msgstr "Zum neuen Konto"
 
-#: lib/abuuba_web/live/status_live.ex:98
+#: lib/abuuba_web/live/status_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Look for more replies on the other server"
 msgstr "Auf dem anderen Server nach weiteren Antworten suchen"
 
-#: lib/abuuba_web/live/profile_live.ex:865
+#: lib/abuuba_web/live/profile_live.ex:836
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr "Medien"
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr "Stummschalten"
 
-#: lib/abuuba_web/live/profile_live.ex:372
+#: lib/abuuba_web/live/profile_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr "Hier ist noch nichts."
 
-#: lib/abuuba_web/live/profile_live.ex:347
-#: lib/abuuba_web/live/profile_live.ex:348
+#: lib/abuuba_web/live/profile_live.ex:338
+#: lib/abuuba_web/live/profile_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr "Angeheftet"
 
-#: lib/abuuba_web/live/explore_live.ex:304
-#: lib/abuuba_web/live/profile_live.ex:863
+#: lib/abuuba_web/live/explore_live.ex:288
+#: lib/abuuba_web/live/profile_live.ex:834
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:122
 #: lib/abuuba_web/live/search_live.ex:264
@@ -1263,18 +1263,18 @@ msgstr "Angeheftet"
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/abuuba_web/live/profile_live.ex:864
+#: lib/abuuba_web/live/profile_live.ex:835
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr "Beiträge und Antworten"
 
-#: lib/abuuba_web/live/admin_live.ex:929
-#: lib/abuuba_web/live/profile_live.ex:305
+#: lib/abuuba_web/live/admin_live.ex:931
+#: lib/abuuba_web/live/profile_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr "Notiz speichern"
 
-#: lib/abuuba_web/live/status_live.ex:322
+#: lib/abuuba_web/live/status_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "That server could not be reached, so this is all there is."
 msgstr "Der Server war nicht erreichbar, mehr gibt es also nicht."
@@ -1284,19 +1284,19 @@ msgstr "Der Server war nicht erreichbar, mehr gibt es also nicht."
 msgid "This account has moved to %{handle}."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
-#: lib/abuuba_web/live/profile_live.ex:198
-#: lib/abuuba_web/live/settings_live.ex:825
+#: lib/abuuba_web/live/profile_live.ex:189
+#: lib/abuuba_web/live/settings_live.ex:826
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr "Blockierung aufheben"
 
-#: lib/abuuba_web/live/profile_live.ex:164
+#: lib/abuuba_web/live/profile_live.ex:155
 #: lib/abuuba_web/live/tag_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Entfolgen"
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr "Stummschaltung aufheben"
@@ -1306,7 +1306,7 @@ msgstr "Stummschaltung aufheben"
 msgid "Verified"
 msgstr "Bestätigt"
 
-#: lib/abuuba_web/live/profile_live.ex:309
+#: lib/abuuba_web/live/profile_live.ex:300
 #: lib/abuuba_web/live/search_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "What to show"
@@ -1433,7 +1433,7 @@ msgstr "Konten, die eine Moderation eingeschränkt hat"
 msgid "Accounts made very recently"
 msgstr "Ganz neu angelegte Konten"
 
-#: lib/abuuba_web/live/notifications_live.ex:433
+#: lib/abuuba_web/live/notifications_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr "Alle"
@@ -1463,7 +1463,7 @@ msgstr "Alle, denen du nicht folgst."
 msgid "Automated accounts"
 msgstr "Automatische Konten"
 
-#: lib/abuuba_web/live/notifications_live.ex:442
+#: lib/abuuba_web/live/notifications_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Boosts"
 msgstr "Geteilte Beiträge"
@@ -1483,12 +1483,12 @@ msgstr "Ausblenden"
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr "Jede Zeile beschreibt eine Art von Absender. Annehmen lässt sie durch, Filtern legt sie in die Warteliste auf deiner Mitteilungsseite, und Ignorieren verwirft sie."
 
-#: lib/abuuba_web/live/notifications_live.ex:447
+#: lib/abuuba_web/live/notifications_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "Edits"
 msgstr "Bearbeitungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:445
+#: lib/abuuba_web/live/notifications_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "Favourites"
 msgstr "Favoriten"
@@ -1498,15 +1498,15 @@ msgstr "Favoriten"
 msgid "Filter"
 msgstr "Filtern"
 
-#: lib/abuuba_web/live/notifications_live.ex:444
+#: lib/abuuba_web/live/notifications_live.ex:441
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr "Folgeanfragen"
 
-#: lib/abuuba_web/live/notifications_live.ex:443
-#: lib/abuuba_web/live/profile_live.ex:867
-#: lib/abuuba_web/live/settings_live.ex:2096
-#: lib/abuuba_web/live/settings_live.ex:2228
+#: lib/abuuba_web/live/notifications_live.ex:440
+#: lib/abuuba_web/live/profile_live.ex:838
+#: lib/abuuba_web/live/settings_live.ex:2103
+#: lib/abuuba_web/live/settings_live.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folge ich"
@@ -1531,8 +1531,8 @@ msgstr "Durchlassen"
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
-#: lib/abuuba_web/live/notifications_live.ex:433
-#: lib/abuuba_web/live/notifications_live.ex:441
+#: lib/abuuba_web/live/notifications_live.ex:430
+#: lib/abuuba_web/live/notifications_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr "Erwähnungen"
@@ -1557,7 +1557,7 @@ msgstr "Leute, die dir nicht folgen"
 msgid "People you do not follow"
 msgstr "Leute, denen du nicht folgst"
 
-#: lib/abuuba_web/live/notifications_live.ex:446
+#: lib/abuuba_web/live/notifications_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Polls"
 msgstr "Umfragen"
@@ -1567,28 +1567,28 @@ msgstr "Umfragen"
 msgid "Private mentions out of nowhere"
 msgstr "Private Erwähnungen aus dem Nichts"
 
-#: lib/abuuba_web/live/admin_live.ex:1008
-#: lib/abuuba_web/live/admin_live.ex:1016
-#: lib/abuuba_web/live/admin_live.ex:1119
-#: lib/abuuba_web/live/admin_live.ex:1572
-#: lib/abuuba_web/live/admin_live.ex:2148
+#: lib/abuuba_web/live/admin_live.ex:1010
+#: lib/abuuba_web/live/admin_live.ex:1018
+#: lib/abuuba_web/live/admin_live.ex:1121
+#: lib/abuuba_web/live/admin_live.ex:1574
+#: lib/abuuba_web/live/admin_live.ex:2150
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:264
-#: lib/abuuba_web/live/settings_live.ex:293
-#: lib/abuuba_web/live/settings_live.ex:387
-#: lib/abuuba_web/live/settings_live.ex:424
-#: lib/abuuba_web/live/settings_live.ex:488
-#: lib/abuuba_web/live/settings_live.ex:595
-#: lib/abuuba_web/live/settings_live.ex:640
-#: lib/abuuba_web/live/settings_live.ex:673
-#: lib/abuuba_web/live/settings_live.ex:995
+#: lib/abuuba_web/live/profile_live.ex:255
+#: lib/abuuba_web/live/settings_live.ex:294
+#: lib/abuuba_web/live/settings_live.ex:388
+#: lib/abuuba_web/live/settings_live.ex:425
+#: lib/abuuba_web/live/settings_live.ex:489
+#: lib/abuuba_web/live/settings_live.ex:596
+#: lib/abuuba_web/live/settings_live.ex:641
+#: lib/abuuba_web/live/settings_live.ex:674
+#: lib/abuuba_web/live/settings_live.ex:996
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Speichern"
 
-#: lib/abuuba_web/live/admin_live.ex:237
+#: lib/abuuba_web/live/admin_live.ex:238
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:135
+#: lib/abuuba_web/live/settings_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr "Gespeichert."
@@ -1630,7 +1630,7 @@ msgid "Your settings filed these instead of showing them."
 msgstr "Deine Einstellungen haben diese abgelegt, statt sie zu zeigen."
 
 #: lib/abuuba_web/components/layouts.ex:186
-#: lib/abuuba_web/live/conversations_live.ex:86
+#: lib/abuuba_web/live/conversations_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "unread"
 msgstr "ungelesen"
@@ -1640,14 +1640,14 @@ msgstr "ungelesen"
 msgid "A name, a #tag, or some words"
 msgstr "Ein Name, ein #Tag oder ein paar Wörter"
 
-#: lib/abuuba_web/live/admin_live.ex:2261
-#: lib/abuuba_web/live/admin_live.ex:3585
+#: lib/abuuba_web/live/admin_live.ex:2263
+#: lib/abuuba_web/live/admin_live.ex:3572
 #: lib/abuuba_web/live/search_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr "Alles"
 
-#: lib/abuuba_web/live/explore_live.ex:305
+#: lib/abuuba_web/live/explore_live.ex:289
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:113
 #: lib/abuuba_web/live/search_live.ex:263
@@ -1655,12 +1655,12 @@ msgstr "Alles"
 msgid "Hashtags"
 msgstr "Hashtags"
 
-#: lib/abuuba_web/live/landing_live.ex:69
+#: lib/abuuba_web/live/landing_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "It runs %{software}, which is free software anybody may run."
 msgstr "Er läuft mit %{software}, freier Software, die jeder betreiben darf."
 
-#: lib/abuuba_web/live/landing_live.ex:83
+#: lib/abuuba_web/live/landing_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Look around first"
 msgstr "Erst mal umsehen"
@@ -1670,7 +1670,7 @@ msgstr "Erst mal umsehen"
 msgid "Narrowing a search"
 msgstr "Eine Suche eingrenzen"
 
-#: lib/abuuba_web/live/landing_live.ex:99
+#: lib/abuuba_web/live/landing_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted publicly here yet."
 msgstr "Hier hat noch niemand öffentlich etwas veröffentlicht."
@@ -1680,7 +1680,7 @@ msgstr "Hier hat noch niemand öffentlich etwas veröffentlicht."
 msgid "Nobody has posted under this tag yet."
 msgstr "Unter diesem Tag hat noch niemand etwas veröffentlicht."
 
-#: lib/abuuba_web/live/explore_live.ex:123
+#: lib/abuuba_web/live/explore_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht haben."
@@ -1690,7 +1690,7 @@ msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht habe
 msgid "Nothing matched that."
 msgstr "Dazu gab es keine Treffer."
 
-#: lib/abuuba_web/live/explore_live.ex:306
+#: lib/abuuba_web/live/explore_live.ex:290
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:103
 #: lib/abuuba_web/live/search_live.ex:262
@@ -1698,25 +1698,22 @@ msgstr "Dazu gab es keine Treffer."
 msgid "People"
 msgstr "Leute"
 
-#: lib/abuuba_web/live/landing_live.ex:88
+#: lib/abuuba_web/live/landing_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "Recently, from people here"
 msgstr "Neulich, von Leuten hier"
 
-#: lib/abuuba_web/live/about_live.ex:116
-#: lib/abuuba_web/live/landing_live.ex:112
+#: lib/abuuba_web/registration_words.ex:29
 #, elixir-autogen, elixir-format
 msgid "Registration is closed here, but any other server on the network will do."
 msgstr "Die Registrierung ist hier geschlossen, aber jeder andere Server im Netzwerk tut es auch."
 
-#: lib/abuuba_web/live/about_live.ex:110
-#: lib/abuuba_web/live/landing_live.ex:106
+#: lib/abuuba_web/registration_words.ex:23
 #, elixir-autogen, elixir-format
 msgid "Registration is open: anybody may sign up."
 msgstr "Die Registrierung ist offen: jeder darf sich anmelden."
 
-#: lib/abuuba_web/live/about_live.ex:113
-#: lib/abuuba_web/live/landing_live.ex:109
+#: lib/abuuba_web/registration_words.ex:26
 #, elixir-autogen, elixir-format
 msgid "Registration needs approval: you sign up and an admin reads your request."
 msgstr "Die Registrierung braucht eine Freigabe: du meldest dich an und eine Administration liest deine Anfrage."
@@ -1730,7 +1727,7 @@ msgstr "Die Registrierung braucht eine Freigabe: du meldest dich an und eine Adm
 msgid "Search"
 msgstr "Suche"
 
-#: lib/abuuba_web/live/landing_live.ex:63
+#: lib/abuuba_web/live/landing_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr "Dies ist ein Server im Fediverse: ein Netzwerk unabhängiger Server, deren Leute einander folgen und miteinander reden können, egal auf welchem sie sind. Ein Konto hier kann allen überall darin folgen."
@@ -1760,389 +1757,389 @@ msgstr "Beiträge nach einem Datum"
 msgid "posts older than a date"
 msgstr "Beiträge vor einem Datum"
 
-#: lib/abuuba_web/live/settings_live.ex:890
+#: lib/abuuba_web/live/settings_live.ex:891
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr "Ein neues Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:233
+#: lib/abuuba_web/live/settings_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Über dich"
 
-#: lib/abuuba_web/live/admin_live.ex:3370
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/admin_live.ex:3364
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Konto"
 
-#: lib/abuuba_web/live/settings_live.ex:289
+#: lib/abuuba_web/live/settings_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Add a field"
 msgstr "Feld hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:806
+#: lib/abuuba_web/live/settings_live.ex:807
 #, elixir-autogen, elixir-format
 msgid "Add a filter"
 msgstr "Filter hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr "Gilt nur für deine öffentlichen Beiträge."
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr "Apps, die in dein Konto gelassen wurden."
 
-#: lib/abuuba_web/live/settings_live.ex:946
+#: lib/abuuba_web/live/settings_live.ex:947
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr "Apps, bei denen du angemeldet bist. Eine wieder hinauszunehmen meldet sie sofort ab."
 
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/settings_live.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr "Vor jedem Follow fragen"
 
-#: lib/abuuba_web/live/settings_live.ex:894
+#: lib/abuuba_web/live/settings_live.ex:895
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr "Passwort ändern"
 
-#: lib/abuuba_web/live/admin_live.ex:983
-#: lib/abuuba_web/live/settings_live.ex:753
+#: lib/abuuba_web/live/admin_live.ex:985
+#: lib/abuuba_web/live/settings_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:222
+#: lib/abuuba_web/live/settings_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr "Anzeigename"
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr "Medien nicht von selbst abspielen"
 
-#: lib/abuuba_web/live/settings_live.ex:1599
+#: lib/abuuba_web/live/settings_live.ex:1600
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr "Jede Zeile muss eine Webadresse sein, eine pro Zeile."
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr "Jeder Follow wird zu einer Anfrage, die du beantwortest."
 
-#: lib/abuuba_web/live/settings_live.ex:2121
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr "Allen, denen du folgst, und ein Weg, damit aufzuhören."
 
-#: lib/abuuba_web/live/settings_live.ex:200
+#: lib/abuuba_web/live/settings_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr "Alles zu deinem Konto ist hier. Wähl einen Bereich."
 
-#: lib/abuuba_web/live/settings_live.ex:238
+#: lib/abuuba_web/live/settings_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr "Felder"
 
-#: lib/abuuba_web/live/settings_live.ex:2095
-#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/abuuba_web/live/settings_live.ex:2316
+#: lib/abuuba_web/live/settings_live.ex:2317
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr "Hinter einer Warnung zusammenklappen"
 
-#: lib/abuuba_web/live/settings_live.ex:2317
+#: lib/abuuba_web/live/settings_live.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr "Ganz ausblenden"
 
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr "Verbergen, wem ich folge und wer mir folgt"
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr "Mehr Kontrast"
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr "Wie sich die Oberfläche verhält und liest."
 
-#: lib/abuuba_web/live/settings_live.ex:253
+#: lib/abuuba_web/live/settings_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2264
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr "Suchmaschinen meine Beiträge indexieren lassen"
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr "Mich im Verzeichnis listen"
 
-#: lib/abuuba_web/live/settings_live.ex:2268
+#: lib/abuuba_web/live/settings_live.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr "Markiert das Konto als Bot, worauf manche Leute filtern."
 
-#: lib/abuuba_web/live/settings_live.ex:271
+#: lib/abuuba_web/live/settings_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/abuuba_web/live/settings_live.ex:975
+#: lib/abuuba_web/live/settings_live.ex:976
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr "Es wurde keine App hereingelassen."
 
-#: lib/abuuba_web/live/settings_live.ex:989
+#: lib/abuuba_web/live/settings_live.ex:990
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr "Eine Webadresse pro Zeile. Ein Konto hier zu nennen erlaubt dir später den Umzug dorthin, und es muss dieses hier zurücknennen."
 
-#: lib/abuuba_web/live/settings_live.ex:448
+#: lib/abuuba_web/live/settings_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr "Nur die genannten Leute fehlt mit Absicht: als Voreinstellung wird jeder Beitrag, den du zu ändern vergisst, zu einer Nachricht an niemanden."
 
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr "Deine anderen Konten und der Umzug zwischen ihnen."
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr "Überschreibt deine Systemeinstellung, wenn sie für dich falsch ist."
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2097
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Überblick"
 
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/settings_live.ex:2094
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr "Öffentliche Timelines"
 
-#: lib/abuuba_web/live/settings_live.ex:2272
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr "Bewegung reduzieren"
 
-#: lib/abuuba_web/live/admin_live.ex:544
-#: lib/abuuba_web/live/admin_live.ex:1654
-#: lib/abuuba_web/live/admin_live.ex:1770
-#: lib/abuuba_web/live/admin_live.ex:1862
-#: lib/abuuba_web/live/admin_live.ex:2186
-#: lib/abuuba_web/live/conversations_live.ex:111
-#: lib/abuuba_web/live/settings_live.ex:279
-#: lib/abuuba_web/live/settings_live.ex:314
+#: lib/abuuba_web/live/admin_live.ex:546
+#: lib/abuuba_web/live/admin_live.ex:1656
+#: lib/abuuba_web/live/admin_live.ex:1772
+#: lib/abuuba_web/live/admin_live.ex:1864
+#: lib/abuuba_web/live/admin_live.ex:2188
+#: lib/abuuba_web/live/conversations_live.ex:112
+#: lib/abuuba_web/live/settings_live.ex:280
+#: lib/abuuba_web/live/settings_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2097
+#: lib/abuuba_web/live/settings_live.ex:2104
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr "Sicherheit"
 
-#: lib/abuuba_web/live/settings_live.ex:907
+#: lib/abuuba_web/live/settings_live.ex:908
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr "Überall abmelden"
 
-#: lib/abuuba_web/live/settings_live.ex:903
+#: lib/abuuba_web/live/settings_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr "Überall abmelden beendet jede Sitzung, auch diese."
 
-#: lib/abuuba_web/live/settings_live.ex:2283
+#: lib/abuuba_web/live/settings_live.ex:2284
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr "Hält das erste Absenden an, wenn ein Bild keine Beschreibung hat."
 
-#: lib/abuuba_web/live/settings_live.ex:969
+#: lib/abuuba_web/live/settings_live.ex:970
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr "Wieder hinausnehmen"
 
-#: lib/abuuba_web/live/admin_live.ex:3748
-#: lib/abuuba_web/live/settings_live.ex:2086
+#: lib/abuuba_web/live/admin_live.ex:3735
+#: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr "Das konnte nicht gespeichert werden. Prüf, was du eingegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1574
+#: lib/abuuba_web/live/settings_live.ex:1575
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr "Das aktuelle Passwort stimmt nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:467
+#: lib/abuuba_web/live/settings_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr "Die Sprache, in der du meistens schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:2266
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr "Die Listen sind nicht mehr öffentlich; die Follows selbst funktionieren weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:2267
+#: lib/abuuba_web/live/settings_live.ex:2268
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr "Dieses Konto veröffentlicht automatisch"
 
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr "Threads"
 
-#: lib/abuuba_web/live/settings_live.ex:848
+#: lib/abuuba_web/live/settings_live.ex:849
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr "Hak alle an, denen du nicht mehr folgen willst, und drück dann einmal den Knopf."
 
-#: lib/abuuba_web/live/settings_live.ex:873
+#: lib/abuuba_web/live/settings_live.ex:874
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr "Den angehakten entfolgen"
 
-#: lib/abuuba_web/live/settings_live.ex:240
+#: lib/abuuba_web/live/settings_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr "Bis zu vier Zeilen auf deinem Profil. Die Reihenfolge hier ist die Reihenfolge dort."
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr "Die Schrift meines Systems verwenden"
 
-#: lib/abuuba_web/live/settings_live.ex:260
+#: lib/abuuba_web/live/settings_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr "Wert"
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr "Mich auf fehlende Beschreibungen hinweisen"
 
-#: lib/abuuba_web/live/settings_live.ex:798
+#: lib/abuuba_web/live/settings_live.ex:799
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr "Was er tut"
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr "Womit das Schreibfeld beginnt."
 
-#: lib/abuuba_web/live/admin_live.ex:2162
-#: lib/abuuba_web/live/settings_live.ex:760
+#: lib/abuuba_web/live/admin_live.ex:2164
+#: lib/abuuba_web/live/settings_live.ex:761
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr "Wie er heißen soll"
 
-#: lib/abuuba_web/live/settings_live.ex:765
+#: lib/abuuba_web/live/settings_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr "Wo er gilt"
 
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:2126
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr "Wer dich finden kann und wer fragen muss, um zu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:454
+#: lib/abuuba_web/live/settings_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr "Wer neue Beiträge zitieren darf"
 
-#: lib/abuuba_web/live/settings_live.ex:435
+#: lib/abuuba_web/live/settings_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr "An wen neue Beiträge gehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2120
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr "Wörter und Wendungen, die du lieber nicht siehst."
 
-#: lib/abuuba_web/live/settings_live.ex:869
+#: lib/abuuba_web/live/settings_live.ex:870
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr "Du folgst noch niemandem."
 
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:2263
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr "Dein Konto erscheint auf der öffentlichen Verzeichnisseite dieses Servers."
 
-#: lib/abuuba_web/live/settings_live.ex:885
+#: lib/abuuba_web/live/settings_live.ex:886
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr "Dein aktuelles Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2123
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr "Dein Name, was du über dich sagst, deine Felder."
 
-#: lib/abuuba_web/live/settings_live.ex:986
+#: lib/abuuba_web/live/settings_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr "Deine anderen Konten"
 
-#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr "Dein Passwort, Zwei-Faktor und das Abmelden."
@@ -2152,13 +2149,13 @@ msgstr "Dein Passwort, Zwei-Faktor und das Abmelden."
 msgid "A handle looks like name@server."
 msgstr "Ein Handle sieht aus wie name@server."
 
-#: lib/abuuba_web/live/about_live.ex:44
+#: lib/abuuba_web/live/about_live.ex:45
 #, elixir-autogen, elixir-format
 msgid "A server on the fediverse, running %{software}."
 msgstr "Ein Server im Fediverse, betrieben mit %{software}."
 
-#: lib/abuuba_web/live/about_live.ex:23
-#: lib/abuuba_web/live/admin_live.ex:619
+#: lib/abuuba_web/live/about_live.ex:24
+#: lib/abuuba_web/live/admin_live.ex:621
 #: lib/abuuba_web/live/document_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "About"
@@ -2174,7 +2171,7 @@ msgstr "Über diesen Server"
 msgid "Do this from your own server"
 msgstr "Mach das von deinem eigenen Server aus"
 
-#: lib/abuuba_web/live/about_live.ex:79
+#: lib/abuuba_web/live/about_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Getting in touch"
 msgstr "Kontakt"
@@ -2189,8 +2186,8 @@ msgstr "In Kraft seit %{date}"
 msgid "No password is asked for and nothing is done on your behalf: you are simply sent to your own server's search with this address filled in."
 msgstr "Es wird kein Passwort abgefragt und nichts in deinem Namen getan: du wirst nur zur Suche deines eigenen Servers geschickt, mit dieser Adresse eingetragen."
 
-#: lib/abuuba_web/live/about_live.ex:92
-#: lib/abuuba_web/live/admin_live.ex:1944
+#: lib/abuuba_web/live/about_live.ex:93
+#: lib/abuuba_web/live/admin_live.ex:1946
 #: lib/abuuba_web/live/document_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
@@ -2206,7 +2203,7 @@ msgstr "Auf %{server} lesen"
 msgid "Share"
 msgstr "Teilen"
 
-#: lib/abuuba_web/live/about_live.ex:62
+#: lib/abuuba_web/live/about_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Signing up"
 msgstr "Registrierung"
@@ -2226,8 +2223,8 @@ msgstr "Bring mich nach Hause"
 msgid "Take me to my server"
 msgstr "Bring mich zu meinem Server"
 
-#: lib/abuuba_web/live/about_live.ex:91
-#: lib/abuuba_web/live/admin_live.ex:2191
+#: lib/abuuba_web/live/about_live.ex:92
+#: lib/abuuba_web/live/admin_live.ex:2193
 #: lib/abuuba_web/live/document_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
@@ -2238,17 +2235,17 @@ msgstr "Nutzungsbedingungen"
 msgid "That is this server. Use the buttons on the post itself once you are signed in."
 msgstr "Das ist dieser Server. Nutz die Knöpfe am Beitrag selbst, sobald du angemeldet bist."
 
-#: lib/abuuba_web/live/about_live.ex:52
+#: lib/abuuba_web/live/about_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "The numbers"
 msgstr "Die Zahlen"
 
-#: lib/abuuba_web/live/about_live.ex:67
+#: lib/abuuba_web/live/about_live.ex:68
 #, elixir-autogen, elixir-format
 msgid "The rules"
 msgstr "Die Regeln"
 
-#: lib/abuuba_web/live/about_live.ex:89
+#: lib/abuuba_web/live/about_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "The small print"
 msgstr "Das Kleingedruckte"
@@ -2258,7 +2255,7 @@ msgstr "Das Kleingedruckte"
 msgid "This has not been written yet. Whoever runs this server can add it in the admin settings."
 msgstr "Das wurde noch nicht geschrieben. Wer diesen Server betreibt, kann es in den Administrationseinstellungen ergänzen."
 
-#: lib/abuuba_web/live/about_live.ex:84
+#: lib/abuuba_web/live/about_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Whoever runs this server has not published an address yet."
 msgstr "Wer diesen Server betreibt, hat noch keine Adresse veröffentlicht."
@@ -2273,560 +2270,560 @@ msgstr "Dein Konto liegt woanders, also passieren Folgen, Antworten und Teilen d
 msgid "Your handle"
 msgstr "Dein Handle"
 
-#: lib/abuuba_web/live/about_live.ex:102
+#: lib/abuuba_web/live/about_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "people"
 msgstr "Leute"
 
-#: lib/abuuba_web/live/about_live.ex:106
+#: lib/abuuba_web/live/about_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "people active this half-year"
 msgstr "Leute in diesem Halbjahr aktiv"
 
-#: lib/abuuba_web/live/about_live.ex:105
+#: lib/abuuba_web/live/about_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "people active this month"
 msgstr "Leute in diesem Monat aktiv"
 
-#: lib/abuuba_web/live/about_live.ex:103
+#: lib/abuuba_web/live/about_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "posts"
 msgstr "Beiträge"
 
-#: lib/abuuba_web/live/about_live.ex:104
+#: lib/abuuba_web/live/about_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "servers known"
 msgstr "bekannte Server"
 
-#: lib/abuuba_web/live/settings_live.ex:1851
+#: lib/abuuba_web/live/settings_live.ex:1858
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr "Eine Verwarnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr "Alles, was eine Moderatorin oder ein Moderator hier über dein Konto entschieden hat."
 
-#: lib/abuuba_web/live/settings_live.ex:1195
+#: lib/abuuba_web/live/settings_live.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr "Einspruch einlegen"
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr "Moderation"
 
-#: lib/abuuba_web/live/settings_live.ex:1225
+#: lib/abuuba_web/live/settings_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr "Hier ist nichts. Niemand aus der Moderation hat etwas gegen dein Konto unternommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1835
+#: lib/abuuba_web/live/settings_live.ex:1842
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr "Schreib bitte etwas dazu, warum du das für falsch hältst."
 
-#: lib/abuuba_web/live/settings_live.ex:1192
+#: lib/abuuba_web/live/settings_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr "Warum hältst du das für falsch?"
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1861
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr "Einige deiner Beiträge wurden gelöscht"
 
-#: lib/abuuba_web/live/settings_live.ex:1199
-#: lib/abuuba_web/live/settings_live.ex:1831
+#: lib/abuuba_web/live/settings_live.ex:1200
+#: lib/abuuba_web/live/settings_live.ex:1838
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr "Die Frist für einen Einspruch ist abgelaufen."
 
-#: lib/abuuba_web/live/settings_live.ex:1170
+#: lib/abuuba_web/live/settings_live.ex:1171
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr "Was die Moderation hier über dein Konto entschieden hat und was dir dazu gesagt wurde."
 
-#: lib/abuuba_web/live/settings_live.ex:1846
+#: lib/abuuba_web/live/settings_live.ex:1853
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr "Du hast Einspruch eingelegt, er wurde abgelehnt."
 
-#: lib/abuuba_web/live/settings_live.ex:1845
+#: lib/abuuba_web/live/settings_live.ex:1852
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr "Du hast Einspruch eingelegt, ihm wurde stattgegeben."
 
-#: lib/abuuba_web/live/settings_live.ex:1847
+#: lib/abuuba_web/live/settings_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr "Du hast Einspruch eingelegt. Entschieden ist noch nichts."
 
-#: lib/abuuba_web/live/settings_live.ex:1852
+#: lib/abuuba_web/live/settings_live.ex:1859
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr "Dein Konto wurde deaktiviert"
 
-#: lib/abuuba_web/live/settings_live.ex:1855
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr "Dein Konto wurde eingeschränkt"
 
-#: lib/abuuba_web/live/settings_live.ex:1856
+#: lib/abuuba_web/live/settings_live.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr "Dein Konto wurde gesperrt"
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr "Deine Beiträge wurden als sensibel markiert"
 
-#: lib/abuuba_web/live/settings_live.ex:1178
+#: lib/abuuba_web/live/settings_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr "inzwischen aufgehoben"
 
-#: lib/abuuba_web/live/settings_live.ex:1216
+#: lib/abuuba_web/live/settings_live.ex:1217
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] "%{count} Verbindung verloren"
 msgstr[1] "%{count} Verbindungen verloren"
 
-#: lib/abuuba_web/live/settings_live.ex:1205
+#: lib/abuuba_web/live/settings_live.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr "Verbindungen, die dich die Entscheidungen dieses Servers gekostet haben"
 
-#: lib/abuuba_web/live/settings_live.ex:1207
+#: lib/abuuba_web/live/settings_live.ex:1208
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr "Wenn dieser Server die Verbindung zu einem anderen abbricht, gehen die Folgebeziehungen zwischen dir und den Leuten dort verloren. Von hier aus lassen sie sich nicht wiederherstellen, weil die andere Seite nicht mehr erreichbar ist."
 
-#: lib/abuuba_web/live/admin_live.ex:2246
+#: lib/abuuba_web/live/admin_live.ex:2248
 #, elixir-autogen, elixir-format
 msgid "A new rule"
 msgstr "Eine neue Regel"
 
-#: lib/abuuba_web/live/admin_live.ex:2831
+#: lib/abuuba_web/live/admin_live.ex:2833
 #, elixir-autogen, elixir-format
 msgid "A rule needs some text."
 msgstr "Eine Regel braucht einen Text."
 
-#: lib/abuuba_web/live/admin_live.ex:3369
+#: lib/abuuba_web/live/admin_live.ex:3363
 #, elixir-autogen, elixir-format
 msgid "Accounts"
 msgstr "Konten"
 
-#: lib/abuuba_web/live/admin_live.ex:1601
-#: lib/abuuba_web/live/admin_live.ex:1819
-#: lib/abuuba_web/live/admin_live.ex:2249
+#: lib/abuuba_web/live/admin_live.ex:1603
+#: lib/abuuba_web/live/admin_live.ex:1821
+#: lib/abuuba_web/live/admin_live.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: lib/abuuba_web/live/admin_live.ex:1989
+#: lib/abuuba_web/live/admin_live.ex:1991
 #, elixir-autogen, elixir-format
 msgid "Address people can write to"
 msgstr "Adresse, an die man schreiben kann"
 
-#: lib/abuuba_web/live/admin_live.ex:220
-#: lib/abuuba_web/live/admin_live.ex:3387
+#: lib/abuuba_web/live/admin_live.ex:221
+#: lib/abuuba_web/live/admin_live.ex:3381
 #, elixir-autogen, elixir-format
 msgid "Administration"
 msgstr "Verwaltung"
 
-#: lib/abuuba_web/live/admin_live.ex:3731
+#: lib/abuuba_web/live/admin_live.ex:3718
 #, elixir-autogen, elixir-format
 msgid "An open server left unattended fills with spam registrations within days. Put sign-ups behind approval unless somebody is watching."
 msgstr "Ein offener Server ohne Aufsicht füllt sich innerhalb von Tagen mit Spam-Anmeldungen. Stell Anmeldungen auf Freigabe um, solange niemand mitliest."
 
-#: lib/abuuba_web/live/admin_live.ex:737
+#: lib/abuuba_web/live/admin_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Any state"
 msgstr "Beliebiger Zustand"
 
-#: lib/abuuba_web/live/admin_live.ex:3716
+#: lib/abuuba_web/live/admin_live.ex:3703
 #, elixir-autogen, elixir-format
 msgid "Anybody may sign up without being checked"
 msgstr "Jede und jeder kann sich ungeprüft anmelden"
 
-#: lib/abuuba_web/live/admin_live.ex:3418
+#: lib/abuuba_web/live/admin_live.ex:3412
 #, elixir-autogen, elixir-format
 msgid "Anybody, after somebody here says yes"
 msgstr "Alle, nachdem jemand hier zustimmt"
 
-#: lib/abuuba_web/live/admin_live.ex:3417
+#: lib/abuuba_web/live/admin_live.ex:3411
 #, elixir-autogen, elixir-format
 msgid "Anybody, straight away"
 msgstr "Alle, sofort"
 
-#: lib/abuuba_web/live/admin_live.ex:730
+#: lib/abuuba_web/live/admin_live.ex:732
 #, elixir-autogen, elixir-format
 msgid "Anywhere"
 msgstr "Überall"
 
-#: lib/abuuba_web/live/admin_live.ex:375
-#: lib/abuuba_web/live/admin_live.ex:379
+#: lib/abuuba_web/live/admin_live.ex:377
+#: lib/abuuba_web/live/admin_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Appeals waiting"
 msgstr "Offene Einsprüche"
 
-#: lib/abuuba_web/live/admin_live.ex:3386
+#: lib/abuuba_web/live/admin_live.ex:3380
 #, elixir-autogen, elixir-format
 msgid "Audit log"
 msgstr "Protokoll"
 
-#: lib/abuuba_web/live/admin_live.ex:1019
+#: lib/abuuba_web/live/admin_live.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Change an address only when somebody cannot reach their own."
 msgstr "Ändere eine Adresse nur, wenn jemand die eigene nicht mehr erreicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3368
+#: lib/abuuba_web/live/admin_live.ex:3362
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr "Übersicht"
 
-#: lib/abuuba_web/live/admin_live.ex:2865
+#: lib/abuuba_web/live/admin_live.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Deleting posts needs the posts named, which this page cannot do yet."
 msgstr "Beiträge zu löschen setzt voraus, dass die Beiträge benannt sind. Das kann diese Seite noch nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3428
+#: lib/abuuba_web/live/admin_live.ex:3422
 #, elixir-autogen, elixir-format
 msgid "Disable: they cannot sign in"
 msgstr "Deaktivieren: Anmeldung nicht mehr möglich"
 
-#: lib/abuuba_web/live/admin_live.ex:872
+#: lib/abuuba_web/live/admin_live.ex:874
 #, elixir-autogen, elixir-format
 msgid "Do it"
 msgstr "Ausführen"
 
-#: lib/abuuba_web/live/admin_live.ex:733
+#: lib/abuuba_web/live/admin_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Elsewhere"
 msgstr "Anderswo"
 
-#: lib/abuuba_web/live/admin_live.ex:1013
+#: lib/abuuba_web/live/admin_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
-#: lib/abuuba_web/live/admin_live.ex:3721
+#: lib/abuuba_web/live/admin_live.ex:3708
 #, elixir-autogen, elixir-format
 msgid "Everything else on this page is guesswork until that is fixed."
 msgstr "Alles andere auf dieser Seite ist geraten, solange das nicht behoben ist."
 
-#: lib/abuuba_web/live/admin_live.ex:746
-#: lib/abuuba_web/live/admin_live.ex:1470
+#: lib/abuuba_web/live/admin_live.ex:748
+#: lib/abuuba_web/live/admin_live.ex:1472
 #, elixir-autogen, elixir-format
 msgid "Find"
 msgstr "Suchen"
 
-#: lib/abuuba_web/live/admin_live.ex:731
+#: lib/abuuba_web/live/admin_live.ex:733
 #, elixir-autogen, elixir-format
 msgid "Here"
 msgstr "Hier"
 
-#: lib/abuuba_web/live/admin_live.ex:809
+#: lib/abuuba_web/live/admin_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "Let in"
 msgstr "Aufnehmen"
 
-#: lib/abuuba_web/live/admin_live.ex:893
-#: lib/abuuba_web/live/admin_live.ex:1191
-#: lib/abuuba_web/live/admin_live.ex:1218
-#: lib/abuuba_web/live/admin_live.ex:1246
-#: lib/abuuba_web/live/admin_live.ex:1270
+#: lib/abuuba_web/live/admin_live.ex:895
+#: lib/abuuba_web/live/admin_live.ex:1193
+#: lib/abuuba_web/live/admin_live.ex:1220
+#: lib/abuuba_web/live/admin_live.ex:1248
+#: lib/abuuba_web/live/admin_live.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Lift it"
 msgstr "Aufheben"
 
-#: lib/abuuba_web/live/admin_live.ex:3410
+#: lib/abuuba_web/live/admin_live.ex:3404
 #, elixir-autogen, elixir-format
 msgid "Limited"
 msgstr "Eingeschränkt"
 
-#: lib/abuuba_web/live/admin_live.ex:3429
+#: lib/abuuba_web/live/admin_live.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Mark everything they post sensitive"
 msgstr "Alle Beiträge als sensibel markieren"
 
-#: lib/abuuba_web/live/admin_live.ex:726
+#: lib/abuuba_web/live/admin_live.ex:728
 #, elixir-autogen, elixir-format
 msgid "Name or name@server"
 msgstr "Name oder name@server"
 
-#: lib/abuuba_web/live/admin_live.ex:3737
+#: lib/abuuba_web/live/admin_live.ex:3724
 #, elixir-autogen, elixir-format
 msgid "Nobody can grant roles or change settings that need it. Give somebody a role holding the administrator permission."
 msgstr "Niemand kann Rollen vergeben oder Einstellungen ändern, die das voraussetzen. Gib jemandem eine Rolle mit der Administrator-Berechtigung."
 
-#: lib/abuuba_web/live/admin_live.ex:3717
+#: lib/abuuba_web/live/admin_live.ex:3704
 #, elixir-autogen, elixir-format
 msgid "Nobody here is an administrator"
 msgstr "Niemand hier ist Administrator"
 
-#: lib/abuuba_web/live/admin_live.ex:827
+#: lib/abuuba_web/live/admin_live.ex:829
 #, elixir-autogen, elixir-format
 msgid "Nobody here matches that."
 msgstr "Dazu passt hier niemand."
 
-#: lib/abuuba_web/live/admin_live.ex:998
+#: lib/abuuba_web/live/admin_live.ex:1000
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr "Keine"
 
-#: lib/abuuba_web/live/admin_live.ex:2281
+#: lib/abuuba_web/live/admin_live.ex:2283
 #, elixir-autogen, elixir-format
 msgid "Nothing has been done yet."
 msgstr "Es ist noch nichts passiert."
 
-#: lib/abuuba_web/live/admin_live.ex:416
-#: lib/abuuba_web/live/admin_live.ex:441
-#: lib/abuuba_web/live/admin_live.ex:699
-#: lib/abuuba_web/live/admin_live.ex:898
+#: lib/abuuba_web/live/admin_live.ex:418
+#: lib/abuuba_web/live/admin_live.ex:443
+#: lib/abuuba_web/live/admin_live.ex:701
+#: lib/abuuba_web/live/admin_live.ex:900
 #, elixir-autogen, elixir-format
 msgid "Nothing yet."
 msgstr "Hier ist noch nichts."
 
-#: lib/abuuba_web/live/admin_live.ex:455
+#: lib/abuuba_web/live/admin_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "Nothing. Every check this server knows how to make came back fine."
 msgstr "Nichts. Jede Prüfung, die dieser Server kennt, war in Ordnung."
 
-#: lib/abuuba_web/live/admin_live.ex:383
+#: lib/abuuba_web/live/admin_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "People waiting to be let in"
 msgstr "Personen, die auf Aufnahme warten"
 
-#: lib/abuuba_web/live/admin_live.ex:367
+#: lib/abuuba_web/live/admin_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Reports waiting"
 msgstr "Offene Meldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:2239
+#: lib/abuuba_web/live/admin_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Retire it"
 msgstr "Zurückziehen"
 
-#: lib/abuuba_web/live/admin_live.ex:996
+#: lib/abuuba_web/live/admin_live.ex:998
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr "Rolle"
 
-#: lib/abuuba_web/live/admin_live.ex:2225
+#: lib/abuuba_web/live/admin_live.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Rules people agree to"
 msgstr "Regeln, denen man zustimmt"
 
-#: lib/abuuba_web/live/admin_live.ex:3425
+#: lib/abuuba_web/live/admin_live.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Send a warning and nothing else"
 msgstr "Nur verwarnen, sonst nichts"
 
-#: lib/abuuba_web/live/admin_live.ex:1467
-#: lib/abuuba_web/live/admin_live.ex:1907
+#: lib/abuuba_web/live/admin_live.ex:1469
+#: lib/abuuba_web/live/admin_live.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Server name"
 msgstr "Name des Servers"
 
-#: lib/abuuba_web/live/admin_live.ex:3385
+#: lib/abuuba_web/live/admin_live.ex:3379
 #, elixir-autogen, elixir-format
 msgid "Server settings"
 msgstr "Servereinstellungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3725
+#: lib/abuuba_web/live/admin_live.ex:3712
 #, elixir-autogen, elixir-format
 msgid "Servers running authorized fetch will refuse this one. It is created on first use, so this usually means something went wrong writing it."
 msgstr "Server mit Authorized Fetch weisen diesen hier ab. Er wird beim ersten Bedarf angelegt, das heißt hier ist beim Schreiben etwas schiefgegangen."
 
-#: lib/abuuba_web/live/admin_live.ex:2264
+#: lib/abuuba_web/live/admin_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr "Anzeigen"
 
-#: lib/abuuba_web/live/admin_live.ex:2227
+#: lib/abuuba_web/live/admin_live.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Shown when somebody signs up and when they file a report."
 msgstr "Wird bei der Anmeldung und beim Melden angezeigt."
 
-#: lib/abuuba_web/live/admin_live.ex:3426
+#: lib/abuuba_web/live/admin_live.ex:3420
 #, elixir-autogen, elixir-format
 msgid "Silence: out of everywhere nobody asked for them"
 msgstr "Einschränken: nicht mehr dort, wo niemand danach gefragt hat"
 
-#: lib/abuuba_web/live/admin_live.ex:3427
+#: lib/abuuba_web/live/admin_live.ex:3421
 #, elixir-autogen, elixir-format
 msgid "Suspend: hidden, and deleted after the grace window"
 msgstr "Sperren: verborgen, nach Ablauf der Frist gelöscht"
 
-#: lib/abuuba_web/live/admin_live.ex:3411
+#: lib/abuuba_web/live/admin_live.ex:3405
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr "Gesperrt"
 
-#: lib/abuuba_web/live/admin_live.ex:2057
+#: lib/abuuba_web/live/admin_live.ex:2059
 #, elixir-autogen, elixir-format
 msgid "Talk only to servers on the allowlist"
 msgstr "Nur mit Servern auf der Positivliste sprechen"
 
-#: lib/abuuba_web/live/admin_live.ex:3333
+#: lib/abuuba_web/live/admin_live.ex:3330
 #, elixir-autogen, elixir-format
 msgid "That account outranks yours, so there is nothing here you can do to it."
 msgstr "Dieses Konto steht über deinem, hier kannst du nichts damit machen."
 
-#: lib/abuuba_web/live/admin_live.ex:2869
-#: lib/abuuba_web/live/admin_live.ex:2881
+#: lib/abuuba_web/live/admin_live.ex:2871
+#: lib/abuuba_web/live/admin_live.ex:2883
 #, elixir-autogen, elixir-format
 msgid "That could not be done."
 msgstr "Das ließ sich nicht ausführen."
 
-#: lib/abuuba_web/live/admin_live.ex:2458
+#: lib/abuuba_web/live/admin_live.ex:2460
 #, elixir-autogen, elixir-format
 msgid "That is not a role you can hand out."
 msgstr "Diese Rolle kannst du nicht vergeben."
 
-#: lib/abuuba_web/live/admin_live.ex:2473
+#: lib/abuuba_web/live/admin_live.ex:2475
 #, elixir-autogen, elixir-format
 msgid "That is not an address."
 msgstr "Das ist keine Adresse."
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
-#: lib/abuuba_web/live/admin_live.ex:3328
-#: lib/abuuba_web/live/settings_live.ex:1627
+#: lib/abuuba_web/live/admin_live.ex:3325
+#: lib/abuuba_web/live/settings_live.ex:1628
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr "Das kann dein Konto nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3714
+#: lib/abuuba_web/live/admin_live.ex:3701
 #, elixir-autogen, elixir-format
 msgid "The database is not answering"
 msgstr "Die Datenbank antwortet nicht"
 
-#: lib/abuuba_web/live/admin_live.ex:846
+#: lib/abuuba_web/live/admin_live.ex:848
 #, elixir-autogen, elixir-format
 msgid "This account outranks yours, so there is nothing here you can do to it."
 msgstr "Dieses Konto steht über deinem, hier kannst du nichts damit machen."
 
-#: lib/abuuba_web/live/admin_live.ex:817
+#: lib/abuuba_web/live/admin_live.ex:819
 #, elixir-autogen, elixir-format
 msgid "This deletes the account as well. Go ahead?"
 msgstr "Damit wird auch das Konto gelöscht. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:3715
+#: lib/abuuba_web/live/admin_live.ex:3702
 #, elixir-autogen, elixir-format
 msgid "This server has no actor of its own"
 msgstr "Dieser Server hat keinen eigenen Actor"
 
-#: lib/abuuba_web/live/admin_live.ex:819
+#: lib/abuuba_web/live/admin_live.ex:821
 #, elixir-autogen, elixir-format
 msgid "Turn away"
 msgstr "Ablehnen"
 
-#: lib/abuuba_web/live/admin_live.ex:3409
+#: lib/abuuba_web/live/admin_live.ex:3403
 #, elixir-autogen, elixir-format
 msgid "Waiting to be let in"
 msgstr "Wartet auf Aufnahme"
 
-#: lib/abuuba_web/live/admin_live.ex:875
+#: lib/abuuba_web/live/admin_live.ex:877
 #, elixir-autogen, elixir-format
 msgid "What has been decided about them"
 msgstr "Was über sie entschieden wurde"
 
-#: lib/abuuba_web/live/admin_live.ex:444
+#: lib/abuuba_web/live/admin_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "What needs attention"
 msgstr "Was Aufmerksamkeit braucht"
 
-#: lib/abuuba_web/live/admin_live.ex:1912
+#: lib/abuuba_web/live/admin_live.ex:1914
 #, elixir-autogen, elixir-format
 msgid "What this server is for"
 msgstr "Wofür dieser Server da ist"
 
-#: lib/abuuba_web/live/admin_live.ex:861
+#: lib/abuuba_web/live/admin_live.ex:863
 #, elixir-autogen, elixir-format
 msgid "What to do"
 msgstr "Was passieren soll"
 
-#: lib/abuuba_web/live/admin_live.ex:2012
+#: lib/abuuba_web/live/admin_live.ex:2014
 #, elixir-autogen, elixir-format
 msgid "What to say when nobody may sign up"
 msgstr "Text, wenn niemand sich anmelden darf"
 
-#: lib/abuuba_web/live/admin_live.ex:868
+#: lib/abuuba_web/live/admin_live.ex:870
 #, elixir-autogen, elixir-format
 msgid "What to tell them"
 msgstr "Was ihnen gesagt wird"
 
-#: lib/abuuba_web/live/admin_live.ex:1999
+#: lib/abuuba_web/live/admin_live.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Who may sign up"
 msgstr "Wer sich anmelden darf"
 
-#: lib/abuuba_web/live/admin_live.ex:884
+#: lib/abuuba_web/live/admin_live.ex:886
 #, elixir-autogen, elixir-format
 msgid "lifted"
 msgstr "aufgehoben"
 
-#: lib/abuuba_web/live/admin_live.ex:799
+#: lib/abuuba_web/live/admin_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "limited"
 msgstr "eingeschränkt"
 
-#: lib/abuuba_web/live/admin_live.ex:798
+#: lib/abuuba_web/live/admin_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "suspended"
 msgstr "gesperrt"
 
-#: lib/abuuba_web/live/admin_live.ex:2270
+#: lib/abuuba_web/live/admin_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "the server"
 msgstr "der Server"
 
 #: lib/abuuba_web/components/status_component.ex:307
-#: lib/abuuba_web/live/admin_live.ex:1075
+#: lib/abuuba_web/live/admin_live.ex:1077
 #, elixir-autogen, elixir-format
 msgid "%{count} person"
 msgid_plural "%{count} people"
 msgstr[0] "%{count} Person"
 msgstr[1] "%{count} Personen"
 
-#: lib/abuuba_web/live/admin_live.ex:1031
+#: lib/abuuba_web/live/admin_live.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Nothing appears in the trending lists until somebody here has looked at it. This is what is waiting."
 msgstr "In den Trendlisten erscheint nichts, bevor jemand hier es angesehen hat. Das hier wartet darauf."
 
-#: lib/abuuba_web/live/admin_live.ex:1090
+#: lib/abuuba_web/live/admin_live.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Nothing is trending. That is what a quiet day looks like."
 msgstr "Nichts im Trend. So sieht ein ruhiger Tag aus."
 
-#: lib/abuuba_web/live/admin_live.ex:1065
+#: lib/abuuba_web/live/admin_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting to be looked at."
 msgstr "Es wartet nichts darauf, angesehen zu werden."
 
-#: lib/abuuba_web/live/admin_live.ex:1058
+#: lib/abuuba_web/live/admin_live.ex:1060
 #, elixir-autogen, elixir-format
 msgid "Refuse"
 msgstr "Ablehnen"
 
-#: lib/abuuba_web/live/admin_live.ex:1084
-#: lib/abuuba_web/live/admin_live.ex:1142
+#: lib/abuuba_web/live/admin_live.ex:1086
+#: lib/abuuba_web/live/admin_live.ex:1144
 #, elixir-autogen, elixir-format
 msgid "Take it down"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/admin_live.ex:3375
+#: lib/abuuba_web/live/admin_live.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Trends"
 msgstr "Trends"
 
-#: lib/abuuba_web/live/admin_live.ex:1068
+#: lib/abuuba_web/live/admin_live.ex:1070
 #, elixir-autogen, elixir-format
 msgid "What is trending now"
 msgstr "Was gerade im Trend liegt"
@@ -2836,32 +2833,32 @@ msgstr "Was gerade im Trend liegt"
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr "Worüber gerade mehr Leute als sonst schreiben, danach alles Übrige, das Neueste zuerst."
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr "%{uses} von %{max} genutzt"
 
-#: lib/abuuba_web/live/settings_live.ex:1241
+#: lib/abuuba_web/live/settings_live.ex:1242
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr "Ein Code, mit dem sich jemand anmelden kann, auch wenn Anmeldungen geschlossen sind. Lass die Anzahl leer für beliebig viele."
 
-#: lib/abuuba_web/live/admin_live.ex:2513
+#: lib/abuuba_web/live/admin_live.ex:2515
 #, elixir-autogen, elixir-format
 msgid "An announcement needs some text."
 msgstr "Eine Ankündigung braucht einen Text."
 
-#: lib/abuuba_web/live/admin_live.ex:3376
+#: lib/abuuba_web/live/admin_live.ex:3370
 #, elixir-autogen, elixir-format
 msgid "Announcements"
 msgstr "Ankündigungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2136
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr "Codes, mit denen sich Bekannte von dir anmelden können."
 
-#: lib/abuuba_web/live/admin_live.ex:2193
+#: lib/abuuba_web/live/admin_live.ex:2195
 #, elixir-autogen, elixir-format
 msgid "Each version is kept with the day it takes effect, so somebody can still read what they agreed to."
 msgstr "Jede Fassung wird mit dem Tag aufbewahrt, an dem sie gilt, damit man nachlesen kann, wozu man zugestimmt hat."
@@ -2871,22 +2868,22 @@ msgstr "Jede Fassung wird mit dem Tag aufbewahrt, an dem sie gilt, damit man nac
 msgid "Earlier versions"
 msgstr "Frühere Fassungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3794
+#: lib/abuuba_web/live/admin_live.ex:3781
 #, elixir-autogen, elixir-format
 msgid "Everybody has already been told about that one."
 msgstr "Darüber wurden bereits alle informiert."
 
-#: lib/abuuba_web/live/admin_live.ex:1130
+#: lib/abuuba_web/live/admin_live.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Goes up"
 msgstr "Erscheint"
 
-#: lib/abuuba_web/live/settings_live.ex:1252
+#: lib/abuuba_web/live/settings_live.ex:1253
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr "Wie viele Personen"
 
-#: lib/abuuba_web/live/admin_live.ex:2201
+#: lib/abuuba_web/live/admin_live.ex:2203
 #, elixir-autogen, elixir-format
 msgid "In effect from"
 msgstr "Gültig ab"
@@ -2896,83 +2893,83 @@ msgstr "Gültig ab"
 msgid "In effect from %{date}"
 msgstr "Gültig ab %{date}"
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr "Einladungen"
 
-#: lib/abuuba_web/live/settings_live.ex:1236
+#: lib/abuuba_web/live/settings_live.ex:1237
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
 
-#: lib/abuuba_web/live/admin_live.ex:1115
+#: lib/abuuba_web/live/admin_live.ex:1117
 #, elixir-autogen, elixir-format
 msgid "Leave this empty to publish it now."
 msgstr "Leer lassen, um sofort zu veröffentlichen."
 
-#: lib/abuuba_web/live/settings_live.ex:1259
+#: lib/abuuba_web/live/settings_live.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr "Erstellen"
 
-#: lib/abuuba_web/live/admin_live.ex:1133
+#: lib/abuuba_web/live/admin_live.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Not published"
 msgstr "Nicht veröffentlicht"
 
-#: lib/abuuba_web/live/admin_live.ex:1148
+#: lib/abuuba_web/live/admin_live.ex:1150
 #, elixir-autogen, elixir-format
 msgid "Nothing has been announced."
 msgstr "Es wurde noch nichts angekündigt."
 
-#: lib/abuuba_web/live/admin_live.ex:2204
+#: lib/abuuba_web/live/admin_live.ex:2206
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr "Neue Fassung veröffentlichen"
 
-#: lib/abuuba_web/live/admin_live.ex:1127
+#: lib/abuuba_web/live/admin_live.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Published"
 msgstr "Veröffentlicht"
 
-#: lib/abuuba_web/live/admin_live.ex:1100
+#: lib/abuuba_web/live/admin_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr "Etwas, das hier alle lesen sollten. Mit einer Uhrzeit veröffentlicht es sich selbst, sodass ein Hinweis auf Sonntag schon am Donnerstag geschrieben werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1273
+#: lib/abuuba_web/live/settings_live.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr "Zurücknehmen"
 
-#: lib/abuuba_web/live/admin_live.ex:2220
+#: lib/abuuba_web/live/admin_live.ex:2222
 #, elixir-autogen, elixir-format
 msgid "Tell everybody"
 msgstr "Alle informieren"
 
-#: lib/abuuba_web/live/admin_live.ex:2539
+#: lib/abuuba_web/live/admin_live.ex:2541
 #, elixir-autogen, elixir-format
 msgid "Terms need some text and a day they take effect."
 msgstr "Nutzungsbedingungen brauchen einen Text und einen Tag, ab dem sie gelten."
 
-#: lib/abuuba_web/live/settings_live.ex:1257
+#: lib/abuuba_web/live/settings_live.ex:1258
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr "Sie folgen dir"
 
-#: lib/abuuba_web/live/settings_live.ex:1248
+#: lib/abuuba_web/live/settings_live.ex:1249
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr "Wofür sie ist"
 
-#: lib/abuuba_web/live/admin_live.ex:1107
-#: lib/abuuba_web/live/admin_live.ex:2085
+#: lib/abuuba_web/live/admin_live.ex:1109
+#: lib/abuuba_web/live/admin_live.ex:2087
 #, elixir-autogen, elixir-format
 msgid "What to say"
 msgstr "Was gesagt werden soll"
 
-#: lib/abuuba_web/live/admin_live.ex:1112
+#: lib/abuuba_web/live/admin_live.ex:1114
 #, elixir-autogen, elixir-format
 msgid "When to publish it"
 msgstr "Wann es veröffentlicht wird"
@@ -2982,76 +2979,76 @@ msgstr "Wann es veröffentlicht wird"
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr "Du meldest dich auf eine Einladung hin an, eine Freigabe brauchst du deshalb nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:1279
+#: lib/abuuba_web/live/settings_live.ex:1280
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr "Du hast noch keine erstellt."
 
-#: lib/abuuba_web/live/admin_live.ex:2211
+#: lib/abuuba_web/live/admin_live.ex:2213
 #, elixir-autogen, elixir-format
 msgid "everybody was told"
 msgstr "alle wurden informiert"
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2088
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
 msgstr[0] "%{count}-mal genutzt"
 msgstr[1] "%{count}-mal genutzt"
 
-#: lib/abuuba_web/live/admin_live.ex:1198
+#: lib/abuuba_web/live/admin_live.ex:1200
 #, elixir-autogen, elixir-format
 msgid "Addresses"
 msgstr "Adressen"
 
-#: lib/abuuba_web/live/admin_live.ex:1230
+#: lib/abuuba_web/live/admin_live.ex:1232
 #, elixir-autogen, elixir-format
 msgid "Anywhere in a name"
 msgstr "Irgendwo im Namen"
 
-#: lib/abuuba_web/live/admin_live.ex:3776
+#: lib/abuuba_web/live/admin_live.ex:3763
 #, elixir-autogen, elixir-format
 msgid "Ask for approval"
 msgstr "Freigabe verlangen"
 
-#: lib/abuuba_web/live/admin_live.ex:1175
-#: lib/abuuba_web/live/admin_live.ex:1204
-#: lib/abuuba_web/live/admin_live.ex:1232
+#: lib/abuuba_web/live/admin_live.ex:1177
+#: lib/abuuba_web/live/admin_live.ex:1206
+#: lib/abuuba_web/live/admin_live.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Block it"
 msgstr "Sperren"
 
-#: lib/abuuba_web/live/admin_live.ex:1253
+#: lib/abuuba_web/live/admin_live.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Email addresses"
 msgstr "E-Mail-Adressen"
 
-#: lib/abuuba_web/live/admin_live.ex:1255
+#: lib/abuuba_web/live/admin_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "Kept as hashes rather than addresses. The list has to recognise somebody coming back, not be readable."
 msgstr "Als Hashes gespeichert, nicht als Adressen. Die Liste muss jemanden wiedererkennen, nicht lesbar sein."
 
-#: lib/abuuba_web/live/admin_live.ex:1164
+#: lib/abuuba_web/live/admin_live.ex:1166
 #, elixir-autogen, elixir-format
 msgid "Mail domains"
 msgstr "Mail-Domains"
 
-#: lib/abuuba_web/live/admin_live.ex:3778
+#: lib/abuuba_web/live/admin_live.ex:3765
 #, elixir-autogen, elixir-format
 msgid "No access at all"
 msgstr "Gar kein Zugriff"
 
-#: lib/abuuba_web/live/admin_live.ex:3777
+#: lib/abuuba_web/live/admin_live.ex:3764
 #, elixir-autogen, elixir-format
 msgid "No sign-ups"
 msgstr "Keine Anmeldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:1276
+#: lib/abuuba_web/live/admin_live.ex:1278
 #, elixir-autogen, elixir-format
 msgid "None. One is added when an account is suspended and you ask for it."
 msgstr "Keine. Ein Eintrag entsteht, wenn ein Konto gesperrt wird und du es verlangst."
 
-#: lib/abuuba_web/live/admin_live.ex:1173
+#: lib/abuuba_web/live/admin_live.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Only ask for approval"
 msgstr "Nur Freigabe verlangen"
@@ -3061,7 +3058,7 @@ msgstr "Nur Freigabe verlangen"
 msgid "Please complete the puzzle so we know you are a person."
 msgstr "Bitte löse das Rätsel, damit wir wissen, dass du ein Mensch bist."
 
-#: lib/abuuba_web/live/admin_live.ex:3377
+#: lib/abuuba_web/live/admin_live.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Sign-up blocks"
 msgstr "Anmeldesperren"
@@ -3081,22 +3078,22 @@ msgstr "Das Rätsel ließ sich gerade nicht prüfen. Bitte versuch es gleich noc
 msgid "This server asks new accounts to solve a puzzle first."
 msgstr "Dieser Server lässt neue Konten zuerst ein Rätsel lösen."
 
-#: lib/abuuba_web/live/admin_live.ex:1225
+#: lib/abuuba_web/live/admin_live.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Usernames"
 msgstr "Benutzernamen"
 
-#: lib/abuuba_web/live/admin_live.ex:1158
+#: lib/abuuba_web/live/admin_live.ex:1160
 #, elixir-autogen, elixir-format
 msgid "What this server refuses at the door. Most of these have a middle setting that asks somebody to look rather than shutting the door."
 msgstr "Was dieser Server an der Tür abweist. Das meiste davon hat eine mittlere Einstellung, die jemanden hinsehen lässt, statt die Tür zuzumachen."
 
-#: lib/abuuba_web/live/admin_live.ex:1238
+#: lib/abuuba_web/live/admin_live.ex:1240
 #, elixir-autogen, elixir-format
 msgid "anywhere"
 msgstr "irgendwo"
 
-#: lib/abuuba_web/live/admin_live.ex:1182
+#: lib/abuuba_web/live/admin_live.ex:1184
 #, elixir-autogen, elixir-format
 msgid "approval only"
 msgstr "nur mit Freigabe"
@@ -3106,11 +3103,11 @@ msgstr "nur mit Freigabe"
 msgid "by %{name}"
 msgstr "von %{name}"
 
-#: lib/abuuba_web/live/explore_live.ex:208
+#: lib/abuuba_web/live/explore_live.ex:204
 #: lib/abuuba_web/live/home_live.ex:337
-#: lib/abuuba_web/live/profile_live.ex:529
+#: lib/abuuba_web/live/profile_live.ex:518
 #: lib/abuuba_web/live/search_live.ex:195
-#: lib/abuuba_web/live/status_live.ex:184
+#: lib/abuuba_web/live/status_live.ex:185
 #: lib/abuuba_web/live/tag_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "That could not be translated just now."
@@ -3131,245 +3128,245 @@ msgstr "Übersetzt von %{provider}. Lade die Seite neu für das Original."
 msgid "This account has been disabled. Contact the moderators."
 msgstr "Dieses Konto wurde deaktiviert. Wende dich an die Moderation."
 
-#: lib/abuuba_web/live/settings_live.ex:1980
+#: lib/abuuba_web/live/settings_live.ex:1987
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr "%{count} konnten nicht übernommen werden"
 
-#: lib/abuuba_web/live/settings_live.ex:1971
+#: lib/abuuba_web/live/settings_live.ex:1978
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr "%{done} von %{total} gelesen, %{imported} übernommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1887
+#: lib/abuuba_web/live/settings_live.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr "Boosts und Umfragen. Ein Boost verweist auf den Beitrag einer anderen Person, den das Archiv nicht enthält, und die Stimmen einer Umfrage wären hier nicht mehr richtig."
 
-#: lib/abuuba_web/live/settings_live.ex:2044
+#: lib/abuuba_web/live/settings_live.ex:2051
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr "Wähle zuerst ein Archiv aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1868
+#: lib/abuuba_web/live/settings_live.ex:1875
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr "Jeder Fediverse-Server gibt dir ein ZIP mit allem, was du geschrieben hast. Lade es hier hoch, und deine Beiträge kommen zurück, mit ihren Bildern und ihrem ursprünglichen Datum."
 
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr "Fertig."
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2109
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
 
-#: lib/abuuba_web/live/settings_live.ex:1893
+#: lib/abuuba_web/live/settings_live.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr "Importierte Beiträge tauchen in keiner Timeline auf und gehen nicht ins Netzwerk. Sie stehen in deinem Profil, in der Reihenfolge, in der du sie geschrieben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2066
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr "Ein Archiv auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:2132
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr "Ein Archiv deiner Beiträge von einem anderen Server wieder einlesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr "Dein Archiv wird gelesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2068
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr "Das Archiv konnte nicht gelesen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2040
+#: lib/abuuba_web/live/settings_live.ex:2047
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr "Das konnte nicht gelesen werden. Lade das Archiv hoch, das dir dein alter Server gegeben hat."
 
-#: lib/abuuba_web/live/settings_live.ex:2055
-#: lib/abuuba_web/live/settings_live.ex:2060
+#: lib/abuuba_web/live/settings_live.ex:2062
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr "Das konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2057
+#: lib/abuuba_web/live/settings_live.ex:2064
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/settings_live.ex:2058
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr "Das ist keine Archivdatei."
 
-#: lib/abuuba_web/live/settings_live.ex:1877
+#: lib/abuuba_web/live/settings_live.ex:1884
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr "Die alten Adressen. Deine Beiträge lagen auf einer anderen Domain und können dort nicht wieder liegen, also bleibt jeder Link darauf tot."
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2072
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr "Wartet auf den Start."
 
-#: lib/abuuba_web/live/settings_live.ex:1874
+#: lib/abuuba_web/live/settings_live.ex:1881
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr "Was nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:1882
+#: lib/abuuba_web/live/settings_live.ex:1889
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr "Deine Follower. Ein Follow ist eine Abmachung zwischen zwei Servern, und einer davon ist weg; sie müssen diesem Konto neu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:2071
+#: lib/abuuba_web/live/settings_live.ex:2078
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr "ein Boost, der nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2080
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr "eine Umfrage, die nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr "kein Datum, also kein Platz dafür"
 
-#: lib/abuuba_web/live/settings_live.ex:2077
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr "die Datei ist kein Archiv"
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2082
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr "der Beitrag wurde nicht gefunden"
 
-#: lib/abuuba_web/live/settings_live.ex:2076
+#: lib/abuuba_web/live/settings_live.ex:2083
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr "dieser Server hat ihn nicht angenommen"
 
-#: lib/abuuba_web/live/settings_live.ex:1044
+#: lib/abuuba_web/live/settings_live.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr "Alle annehmen"
 
-#: lib/abuuba_web/live/settings_live.ex:1926
+#: lib/abuuba_web/live/settings_live.ex:1933
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr "Dazu hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:1039
+#: lib/abuuba_web/live/settings_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr "Nach einem Umzug kommen alle, die dir gefolgt sind, auf einmal an. Das nimmt sie alle an, was dieselbe Antwort ist, die du ihnen schon gegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1944
+#: lib/abuuba_web/live/settings_live.ex:1951
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr "Ein Archiv deiner Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:1049
+#: lib/abuuba_web/live/settings_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr "Für den Export deiner Daten und das Löschen des Kontos steht die Arbeit noch aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1037
+#: lib/abuuba_web/live/settings_live.ex:1038
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr "Wartende Folgeanfragen"
 
-#: lib/abuuba_web/live/settings_live.ex:1006
+#: lib/abuuba_web/live/settings_live.ex:1007
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr "Ich bin zurück"
 
-#: lib/abuuba_web/live/settings_live.ex:1957
+#: lib/abuuba_web/live/settings_live.ex:1964
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr "Archiv importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1934
+#: lib/abuuba_web/live/settings_live.ex:1941
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr "Liste importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1063
-#: lib/abuuba_web/live/settings_live.ex:1906
-#: lib/abuuba_web/live/settings_live.ex:2231
+#: lib/abuuba_web/live/settings_live.ex:1064
+#: lib/abuuba_web/live/settings_live.ex:1913
+#: lib/abuuba_web/live/settings_live.ex:2232
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr "Listen"
 
-#: lib/abuuba_web/live/settings_live.ex:1033
+#: lib/abuuba_web/live/settings_live.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr "Umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:1017
+#: lib/abuuba_web/live/settings_live.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr "Zu einem anderen Konto umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2030
+#: lib/abuuba_web/live/settings_live.ex:2037
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr "Unter dieser Adresse war niemand zu finden."
 
-#: lib/abuuba_web/live/settings_live.ex:1001
+#: lib/abuuba_web/live/settings_live.ex:1002
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr "Anderen Servern wird gesagt, dass sie stattdessen dem neuen Konto folgen sollen. Wer dir von diesem Server aus folgt, ist bereits umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1930
+#: lib/abuuba_web/live/settings_live.ex:1937
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr "Durch die Datei ersetzen"
 
-#: lib/abuuba_web/live/settings_live.ex:2020
+#: lib/abuuba_web/live/settings_live.ex:2027
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr "Dieses Konto nennt dieses hier nicht als eines von deinen. Trage die Adresse dieses Kontos zuerst dort bei den Aliassen ein."
 
-#: lib/abuuba_web/live/settings_live.ex:2031
+#: lib/abuuba_web/live/settings_live.ex:2038
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr "Das ist dieses Konto."
 
-#: lib/abuuba_web/live/settings_live.ex:1908
+#: lib/abuuba_web/live/settings_live.ex:1915
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr "Die CSV-Dateien, die dir dein alter Server gibt: Follows, Blocks, Stummschaltungen, Domain-Blocks, Listen, Lesezeichen, Filter. Lade sie einzeln hoch, unter dem Namen, unter dem sie kamen."
 
-#: lib/abuuba_web/live/settings_live.ex:1027
+#: lib/abuuba_web/live/settings_live.ex:1028
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr "Das andere Konto muss dieses hier zuerst in seinen eigenen Aliassen nennen. Deine Follower hier ziehen mit um, und alle anderen Server werden benachrichtigt; ein Konto kann nur alle %{days} Tage umziehen."
 
-#: lib/abuuba_web/live/settings_live.ex:999
+#: lib/abuuba_web/live/settings_live.ex:1000
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1923
+#: lib/abuuba_web/live/settings_live.ex:1930
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr "Was mit dem passieren soll, was schon da ist"
 
-#: lib/abuuba_web/live/settings_live.ex:2026
+#: lib/abuuba_web/live/settings_live.ex:2033
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr "Du bist vor Kurzem umgezogen. Ein Konto kann nur alle %{days} Tage umziehen."
@@ -3379,109 +3376,109 @@ msgstr "Du bist vor Kurzem umgezogen. Ein Konto kann nur alle %{days} Tage umzie
 msgid "No such post here."
 msgstr "So einen Beitrag gibt es hier nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:243
+#: lib/abuuba_web/live/settings_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr "Ein Link bekommt einen Haken, sobald die Seite, auf die er zeigt, mit rel=\"me\" auf dein Profil zurückverweist. Wir schauen etwa einmal pro Woche wieder nach."
 
-#: lib/abuuba_web/live/settings_live.ex:781
+#: lib/abuuba_web/live/settings_live.ex:782
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr "Ein Wort pro Zeile. Ein Beitrag passt, wenn eines davon darin vorkommt."
 
-#: lib/abuuba_web/live/settings_live.ex:794
+#: lib/abuuba_web/live/settings_live.ex:795
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr "Nur ganze Wörter, damit „Katze“ nicht auf „Katzenklo“ passt"
 
-#: lib/abuuba_web/live/settings_live.ex:778
+#: lib/abuuba_web/live/settings_live.ex:779
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr "Wonach gesucht wird"
 
-#: lib/abuuba_web/live/settings_live.ex:1513
+#: lib/abuuba_web/live/settings_live.ex:1514
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr "Ein Filter braucht mindestens ein Wort, nach dem er suchen soll."
 
-#: lib/abuuba_web/live/admin_live.ex:796
+#: lib/abuuba_web/live/admin_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "Why they want to join:"
 msgstr "Warum die Person mitmachen möchte:"
 
-#: lib/abuuba_web/live/settings_live.ex:306
+#: lib/abuuba_web/live/settings_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] "%{count} Beitrag"
 msgstr[1] "%{count} Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:323
+#: lib/abuuba_web/live/settings_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr "Ein Hashtag, ohne das #"
 
-#: lib/abuuba_web/live/settings_live.ex:326
+#: lib/abuuba_web/live/settings_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "Feature it"
 msgstr "Hervorheben"
 
-#: lib/abuuba_web/live/settings_live.ex:297
+#: lib/abuuba_web/live/settings_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr "Hervorgehobene Hashtags"
 
-#: lib/abuuba_web/live/settings_live.ex:299
+#: lib/abuuba_web/live/settings_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr "Stehen auf deinem Profil als Abkürzung zu dem, worüber du schreibst."
 
-#: lib/abuuba_web/live/settings_live.ex:1496
+#: lib/abuuba_web/live/settings_live.ex:1497
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr "Das ist kein Hashtag, den man benutzen kann."
 
-#: lib/abuuba_web/live/settings_live.ex:330
+#: lib/abuuba_web/live/settings_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr "Du schreibst oft über:"
 
-#: lib/abuuba_web/live/settings_live.ex:1490
+#: lib/abuuba_web/live/settings_live.ex:1491
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr "Ein Profil kann %{count} Hashtags tragen. Nimm zuerst einen weg."
 
-#: lib/abuuba_web/live/settings_live.ex:481
+#: lib/abuuba_web/live/settings_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr "Sagen, aus welcher App du schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:483
+#: lib/abuuba_web/live/settings_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr "Steht für alle anderen unter deinen Beiträgen. An deinen eigenen siehst du es immer."
 
-#: lib/abuuba_web/live/admin_live.ex:915
+#: lib/abuuba_web/live/admin_live.ex:917
 #, elixir-autogen, elixir-format
 msgid "Mark as a memorial"
 msgstr "Als Gedenkseite markieren"
 
-#: lib/abuuba_web/live/admin_live.ex:902
+#: lib/abuuba_web/live/admin_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "Marking an account as a memorial stops it being signed in to and marks the profile as one. Nothing is hidden and nothing is deleted."
 msgstr "Ein Konto als Gedenkseite zu markieren beendet die Anmeldung und kennzeichnet das Profil als solche. Nichts wird versteckt und nichts gelöscht."
 
-#: lib/abuuba_web/live/admin_live.ex:2304
+#: lib/abuuba_web/live/admin_live.ex:2306
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr "Das ließ sich nicht speichern."
 
-#: lib/abuuba_web/live/admin_live.ex:910
+#: lib/abuuba_web/live/admin_live.ex:912
 #, elixir-autogen, elixir-format
 msgid "This also disables their login. Go ahead?"
 msgstr "Damit endet auch die Anmeldung dieser Person. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:914
+#: lib/abuuba_web/live/admin_live.ex:916
 #, elixir-autogen, elixir-format
 msgid "This is not a memorial"
 msgstr "Das ist keine Gedenkseite"
@@ -3493,7 +3490,7 @@ msgid_plural "%{count} accounts"
 msgstr[0] "%{count} Konto"
 msgstr[1] "%{count} Konten"
 
-#: lib/abuuba_web/live/collection_live.ex:115
+#: lib/abuuba_web/live/collection_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "A collection by %{name}"
 msgstr "Eine Sammlung von %{name}"
@@ -3513,7 +3510,7 @@ msgstr "Sammlung"
 msgid "Nobody is on this list yet."
 msgstr "Auf dieser Liste steht noch niemand."
 
-#: lib/abuuba_web/live/annual_report_live.ex:117
+#: lib/abuuba_web/live/annual_report_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "%{count} posts in %{year}"
 msgstr "%{count} Beiträge in %{year}"
@@ -3523,7 +3520,7 @@ msgstr "%{count} Beiträge in %{year}"
 msgid "%{name}'s year"
 msgstr "Das Jahr von %{name}"
 
-#: lib/abuuba_web/live/annual_report_live.ex:109
+#: lib/abuuba_web/live/annual_report_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "Asked a lot of questions."
 msgstr "Hat viele Fragen gestellt."
@@ -3533,7 +3530,7 @@ msgstr "Hat viele Fragen gestellt."
 msgid "Counted from public posts only."
 msgstr "Gezählt wurden nur öffentliche Beiträge."
 
-#: lib/abuuba_web/live/annual_report_live.ex:108
+#: lib/abuuba_web/live/annual_report_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Mostly here to pass on what other people said."
 msgstr "Vor allem hier, um weiterzugeben, was andere gesagt haben."
@@ -3548,12 +3545,12 @@ msgstr "Neue Follower"
 msgid "Posts this year"
 msgstr "Beiträge in diesem Jahr"
 
-#: lib/abuuba_web/live/annual_report_live.ex:107
+#: lib/abuuba_web/live/annual_report_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Read a lot more than they wrote."
 msgstr "Hat sehr viel mehr gelesen als geschrieben."
 
-#: lib/abuuba_web/live/annual_report_live.ex:110
+#: lib/abuuba_web/live/annual_report_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Spent the year in other people's threads."
 msgstr "Hat das Jahr in den Threads anderer verbracht."
@@ -3563,22 +3560,22 @@ msgstr "Hat das Jahr in den Threads anderer verbracht."
 msgid "Written about most"
 msgstr "Worüber am meisten geschrieben wurde"
 
-#: lib/abuuba_web/live/annual_report_live.ex:111
+#: lib/abuuba_web/live/annual_report_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Wrote things other people replied to."
 msgstr "Hat Dinge geschrieben, auf die andere geantwortet haben."
 
-#: lib/abuuba_web/live/admin_live.ex:2098
+#: lib/abuuba_web/live/admin_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "An http or https address. Anything else is refused and nothing is shown."
 msgstr "Eine http- oder https-Adresse. Alles andere wird abgelehnt und es wird nichts angezeigt."
 
-#: lib/abuuba_web/live/admin_live.ex:2077
+#: lib/abuuba_web/live/admin_live.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Asking for money"
 msgstr "Um Geld bitten"
 
-#: lib/abuuba_web/live/admin_live.ex:2079
+#: lib/abuuba_web/live/admin_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Clients show this to people signed in here. Leave the message empty to show nothing."
 msgstr "Apps zeigen das den hier angemeldeten Leuten. Lass den Text leer, damit nichts angezeigt wird."
@@ -3598,13 +3595,13 @@ msgstr "Bestätige, dass du Neuigkeiten von %{name} bekommen möchtest"
 msgid "Donate"
 msgstr "Spenden"
 
-#: lib/abuuba_web/live/admin_live.ex:2072
+#: lib/abuuba_web/live/admin_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "Each person still has to turn it on for themselves, and every address has to confirm before anything is sent to it."
 msgstr "Jede Person muss es zusätzlich für sich selbst einschalten, und jede Adresse muss bestätigen, bevor irgendetwas dorthin geht."
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:644
+#: lib/abuuba_web/live/settings_live.ex:645
 #, elixir-autogen, elixir-format
 msgid "Email updates"
 msgstr "Neuigkeiten per E-Mail"
@@ -3619,7 +3616,7 @@ msgstr "Neuigkeiten per E-Mail von %{name}"
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr "Wenn du das nicht warst, kannst du diese Nachricht ignorieren. An diese Adresse geht dann nichts weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:662
+#: lib/abuuba_web/live/settings_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr "Leute dürfen meine Neuigkeiten per E-Mail abonnieren"
@@ -3629,7 +3626,7 @@ msgstr "Leute dürfen meine Neuigkeiten per E-Mail abonnieren"
 msgid "No, remove my address"
 msgstr "Nein, meine Adresse löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:664
+#: lib/abuuba_web/live/settings_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3657,12 +3654,12 @@ msgstr "Dieser Link ist nicht mehr gültig."
 msgid "This address is getting updates. You can stop them at any time."
 msgstr "Diese Adresse bekommt Neuigkeiten. Du kannst das jederzeit beenden."
 
-#: lib/abuuba_web/live/admin_live.ex:2103
+#: lib/abuuba_web/live/admin_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "What the button says"
 msgstr "Was auf dem Knopf steht"
 
-#: lib/abuuba_web/live/admin_live.ex:2090
+#: lib/abuuba_web/live/admin_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Where the button goes"
 msgstr "Wohin der Knopf führt"
@@ -3677,12 +3674,12 @@ msgstr "Ja, bitte schicken"
 msgid "somebody gave this address to receive updates from %{name} on %{site}. If that was you, confirm it here:"
 msgstr "jemand hat diese Adresse angegeben, um Neuigkeiten von %{name} auf %{site} zu bekommen. Wenn du das warst, bestätige es hier:"
 
-#: lib/abuuba_web/live/admin_live.ex:2069
+#: lib/abuuba_web/live/admin_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "Let people collect email addresses for updates"
 msgstr "Erlaube es, E-Mail-Adressen für Neuigkeiten zu sammeln"
 
-#: lib/abuuba_web/live/settings_live.ex:646
+#: lib/abuuba_web/live/settings_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr "Wer hier kein Konto möchte, kann stattdessen eine E-Mail-Adresse angeben. Die Adresse bestätigt selbst und kann die Neuigkeiten aus jeder Nachricht heraus wieder abbestellen. Verschickt wird noch nichts; das hier sammelt die Liste."
@@ -3830,75 +3827,75 @@ msgstr "jemand hat für dein Konto auf %{site} ein neues Passwort angefordert. W
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr "das Passwort deines Kontos auf %{site} wurde gerade geändert, und überall, wo du angemeldet warst, wurdest du abgemeldet."
 
-#: lib/abuuba_web/live/settings_live.ex:1076
+#: lib/abuuba_web/live/settings_live.ex:1077
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr "Eine Kopie von allem"
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2239
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr "Wird gebaut"
 
-#: lib/abuuba_web/live/settings_live.ex:809
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:810
+#: lib/abuuba_web/live/settings_live.ex:2233
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr "Blockierte Server"
 
-#: lib/abuuba_web/live/admin_live.ex:1301
-#: lib/abuuba_web/live/admin_live.ex:1316
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/admin_live.ex:1303
+#: lib/abuuba_web/live/admin_live.ex:1318
+#: lib/abuuba_web/live/settings_live.ex:2230
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr "Blockierte"
 
-#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2234
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/abuuba_web/live/settings_live.ex:1118
+#: lib/abuuba_web/live/settings_live.ex:1119
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr "Bau mir eine Kopie"
 
-#: lib/abuuba_web/live/settings_live.ex:2240
+#: lib/abuuba_web/live/settings_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr "Hat nicht geklappt"
 
-#: lib/abuuba_web/live/settings_live.ex:1101
+#: lib/abuuba_web/live/settings_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr "Herunterladen"
 
-#: lib/abuuba_web/live/settings_live.ex:2103
+#: lib/abuuba_web/live/settings_live.ex:2110
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr "Exportieren"
 
-#: lib/abuuba_web/live/settings_live.ex:2230
+#: lib/abuuba_web/live/settings_live.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr "Stummgeschaltete"
 
-#: lib/abuuba_web/live/settings_live.ex:1065
+#: lib/abuuba_web/live/settings_live.ex:1066
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr "Je eine Datei, im Format, das der Import dieses Servers liest. Ein Export von hier ist ein Import anderswo."
 
-#: lib/abuuba_web/live/settings_live.ex:1386
+#: lib/abuuba_web/live/settings_live.ex:1387
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr "Eine wird gerade schon gebaut."
 
-#: lib/abuuba_web/live/settings_live.ex:1083
+#: lib/abuuba_web/live/settings_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr "Bilder und Videos sind nicht in der Datei. Sie enthält ihre Adressen, die funktionieren, solange dieser Server läuft."
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr "Fertig"
@@ -3918,13 +3915,13 @@ msgstr "Die Datei wird nach %{days} Tagen gelöscht, weil sie dein ganzes Konto 
 msgid "There is nothing of that kind to export."
 msgstr "So etwas gibt es hier nicht zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:2237
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr "Wartet auf den Start"
 
-#: lib/abuuba_web/live/settings_live.ex:1107
-#: lib/abuuba_web/live/settings_live.ex:1392
+#: lib/abuuba_web/live/settings_live.ex:1108
+#: lib/abuuba_web/live/settings_live.ex:1393
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr "Ab %{date} kannst du eine neue anfordern."
@@ -3934,7 +3931,7 @@ msgstr "Ab %{date} kannst du eine neue anfordern."
 msgid "Your archive is ready"
 msgstr "Deine Kopie ist fertig"
 
-#: lib/abuuba_web/live/settings_live.ex:1078
+#: lib/abuuba_web/live/settings_live.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wird im Hintergrund gebaut; wir schicken dir eine E-Mail, wenn sie fertig ist."
@@ -3944,87 +3941,87 @@ msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wi
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr "die Kopie deines Kontos auf %{site}, die du angefordert hast, ist fertig. Hier herunterladen:"
 
-#: lib/abuuba_web/live/settings_live.ex:1157
+#: lib/abuuba_web/live/settings_live.ex:1158
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr "Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1155
+#: lib/abuuba_web/live/settings_live.ex:1156
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr "Das Konto endgültig schließen? Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1121
+#: lib/abuuba_web/live/settings_live.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr "Dieses Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1060
+#: lib/abuuba_web/live/settings_live.ex:1061
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr "Alles hier gehört dir, und das Konto zu schließen ist deine Entscheidung."
 
-#: lib/abuuba_web/live/settings_live.ex:2135
+#: lib/abuuba_web/live/settings_live.ex:2142
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr "Eine Kopie von allem mitnehmen, oder das Konto endgültig schließen."
 
-#: lib/abuuba_web/live/settings_live.ex:1138
+#: lib/abuuba_web/live/settings_live.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr "Hol dir vorher deine Kopie. Danach gibt es nichts mehr zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:1419
+#: lib/abuuba_web/live/settings_live.ex:1420
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr "Das hat nicht geklappt. Es wurde nichts gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:1416
+#: lib/abuuba_web/live/settings_live.ex:1417
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr "Das ist nicht dein Passwort."
 
-#: lib/abuuba_web/live/settings_live.ex:1128
+#: lib/abuuba_web/live/settings_live.ex:1129
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr "Das Konto verschwindet sofort. Die Datensätze werden kurz danach gelöscht, damit die Nachricht an die anderen Server noch signiert und verschickt werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1412
+#: lib/abuuba_web/live/settings_live.ex:1413
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr "Das Konto ist geschlossen. Danke, dass du hier warst."
 
-#: lib/abuuba_web/live/settings_live.ex:1143
+#: lib/abuuba_web/live/settings_live.ex:1144
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr "Dein Passwort, damit sicher ist, dass du es bist"
 
-#: lib/abuuba_web/live/settings_live.ex:1123
+#: lib/abuuba_web/live/settings_live.ex:1124
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr "Deine Beiträge, Folge-Beziehungen, Listen, Filter, Lesezeichen und Einstellungen werden gelöscht, und andere Server werden aufgefordert, ihre Kopien zu löschen. Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1133
+#: lib/abuuba_web/live/settings_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr "Dein Benutzername bleibt und niemand kann ihn je bekommen, damit alte Links und Erwähnungen von dir nie auf jemand anderen zeigen."
 
-#: lib/abuuba_web/controllers/feed_controller.ex:131
+#: lib/abuuba_web/controllers/feed_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "A post"
 msgstr "Ein Beitrag"
 
-#: lib/abuuba_web/live/profile_live.ex:399
+#: lib/abuuba_web/live/profile_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Nobody yet."
 msgstr "Noch niemand."
 
-#: lib/abuuba_web/controllers/feed_controller.ex:76
+#: lib/abuuba_web/controllers/feed_controller.ex:77
 #, elixir-autogen, elixir-format
 msgid "Public posts tagged #%{tag}"
 msgstr "Öffentliche Beiträge mit #%{tag}"
 
-#: lib/abuuba_web/live/profile_live.ex:376
+#: lib/abuuba_web/live/profile_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr "Dieses Konto behält für sich, wem es folgt und wer ihm folgt."
@@ -4050,99 +4047,99 @@ msgstr "Diese Einladung kennen wir nicht."
 msgid "You can still sign up without one."
 msgstr "Du kannst dich trotzdem ohne eine anmelden."
 
-#: lib/abuuba_web/live/settings_live.ex:1448
+#: lib/abuuba_web/live/settings_live.ex:1449
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr "Ein Alter muss mindestens 7 Tage betragen, und die Anzahlen dürfen nicht negativ sein."
 
-#: lib/abuuba_web/live/settings_live.ex:913
+#: lib/abuuba_web/live/settings_live.ex:914
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr "Gescheiterte Versuche stehen hier ebenfalls. Dass jemand anderes dein Passwort probiert, sollte man früh mitbekommen, und nichts sonst würde es dir sagen."
 
-#: lib/abuuba_web/live/settings_live.ex:522
+#: lib/abuuba_web/live/settings_live.ex:523
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr "Meine alten Beiträge löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:531
+#: lib/abuuba_web/live/settings_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr "Beiträge löschen, die älter sind als, in Tagen"
 
-#: lib/abuuba_web/live/settings_live.ex:550
+#: lib/abuuba_web/live/settings_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr "Angeheftete Beiträge behalten"
 
-#: lib/abuuba_web/live/settings_live.ex:577
+#: lib/abuuba_web/live/settings_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr "Beiträge behalten, die mindestens so oft geboostet wurden"
 
-#: lib/abuuba_web/live/settings_live.ex:566
+#: lib/abuuba_web/live/settings_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr "Beiträge behalten, die mindestens so oft favorisiert wurden"
 
-#: lib/abuuba_web/live/settings_live.ex:562
+#: lib/abuuba_web/live/settings_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr "Beiträge mit Bildern oder Video behalten"
 
-#: lib/abuuba_web/live/settings_live.ex:936
+#: lib/abuuba_web/live/settings_live.ex:937
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr "Wird %{days} Tage aufgehoben und dann gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:519
+#: lib/abuuba_web/live/settings_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "Nothing pinned."
 msgstr "Nichts angeheftet."
 
-#: lib/abuuba_web/live/settings_live.ex:932
+#: lib/abuuba_web/live/settings_live.ex:933
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr "Noch nichts aufgezeichnet."
 
-#: lib/abuuba_web/live/settings_live.ex:524
+#: lib/abuuba_web/live/settings_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr "Aus, solange du es nicht einschaltest. Lass das Alter leer, um es wieder auszuschalten; bis du eines setzt, wird nichts gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:588
+#: lib/abuuba_web/live/settings_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] "Ein Beitrag passt gerade auf diese Einstellungen."
 msgstr[1] "%{count} Beiträge passen gerade auf diese Einstellungen."
 
-#: lib/abuuba_web/live/settings_live.ex:499
+#: lib/abuuba_web/live/settings_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Pinned posts"
 msgstr "Angeheftete Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:911
+#: lib/abuuba_web/live/settings_live.ex:912
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr "Letzte Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:921
+#: lib/abuuba_web/live/settings_live.ex:922
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr "Abgelehnt"
 
-#: lib/abuuba_web/live/settings_live.ex:921
+#: lib/abuuba_web/live/settings_live.ex:922
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr "Angemeldet"
 
-#: lib/abuuba_web/live/settings_live.ex:513
+#: lib/abuuba_web/live/settings_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr "Lösen"
 
-#: lib/abuuba_web/live/settings_live.ex:501
+#: lib/abuuba_web/live/settings_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr "Was oben auf deinem Profil steht. Angeheftet wird vom Beitrag aus."
@@ -4152,7 +4149,7 @@ msgstr "Was oben auf deinem Profil steht. Angeheftet wird vom Beitrag aus."
 msgid "Mail about your own account — password resets and the like — still comes."
 msgstr "Post zu deinem eigenen Konto, etwa zum Zurücksetzen des Passworts, kommt weiterhin."
 
-#: lib/abuuba_web/live/admin_live.ex:2141
+#: lib/abuuba_web/live/admin_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Served from this server and linked from every page. It goes out exactly as typed."
 msgstr "Wird von diesem Server ausgeliefert und auf jeder Seite eingebunden. Es geht genau so raus, wie es hier steht."
@@ -4178,7 +4175,7 @@ msgstr "Abstellen"
 msgid "You will not get that kind of email from us again."
 msgstr "Diese Art E-Mail bekommst du von uns nicht mehr."
 
-#: lib/abuuba_web/live/admin_live.ex:2139
+#: lib/abuuba_web/live/admin_live.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Your own CSS"
 msgstr "Eigenes CSS"
@@ -4198,649 +4195,649 @@ msgstr "alle E-Mails außer denen zu deinem Konto"
 msgid "the occasional summary of what you missed"
 msgstr "die gelegentliche Zusammenfassung dessen, was du verpasst hast"
 
-#: lib/abuuba_web/live/admin_live.ex:1588
+#: lib/abuuba_web/live/admin_live.ex:1590
 #, elixir-autogen, elixir-format
 msgid "A relay forwards every public post it is sent on to everybody subscribed to it. On a young server it is the quickest way to have a federated timeline with anything in it."
 msgstr "Ein Relay leitet jeden öffentlichen Beitrag, den es bekommt, an alle weiter, die es abonniert haben. Auf einem jungen Server ist das der schnellste Weg zu einer föderierten Timeline, in der überhaupt etwas steht."
 
-#: lib/abuuba_web/live/admin_live.ex:1511
-#: lib/abuuba_web/live/admin_live.ex:1623
+#: lib/abuuba_web/live/admin_live.ex:1513
+#: lib/abuuba_web/live/admin_live.ex:1625
 #, elixir-autogen, elixir-format
 msgid "Last error:"
 msgstr "Letzter Fehler:"
 
-#: lib/abuuba_web/live/admin_live.ex:1660
+#: lib/abuuba_web/live/admin_live.ex:1662
 #, elixir-autogen, elixir-format
 msgid "No relays yet."
 msgstr "Noch keine Relays."
 
-#: lib/abuuba_web/live/admin_live.ex:3679
+#: lib/abuuba_web/live/admin_live.ex:3666
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Aus"
 
-#: lib/abuuba_web/live/admin_live.ex:3681
+#: lib/abuuba_web/live/admin_live.ex:3668
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "An"
 
-#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/admin_live.ex:3372
 #, elixir-autogen, elixir-format
 msgid "Relays"
 msgstr "Relays"
 
-#: lib/abuuba_web/live/admin_live.ex:1652
+#: lib/abuuba_web/live/admin_live.ex:1654
 #, elixir-autogen, elixir-format
 msgid "Remove this relay?"
 msgstr "Dieses Relay entfernen?"
 
-#: lib/abuuba_web/live/admin_live.ex:2811
+#: lib/abuuba_web/live/admin_live.ex:2813
 #, elixir-autogen, elixir-format
 msgid "That is not an https inbox address, or it is already here."
 msgstr "Das ist keine https-Inbox-Adresse, oder sie ist schon da."
 
-#: lib/abuuba_web/live/admin_live.ex:3682
+#: lib/abuuba_web/live/admin_live.ex:3669
 #, elixir-autogen, elixir-format
 msgid "The relay refused"
 msgstr "Das Relay hat abgelehnt"
 
-#: lib/abuuba_web/live/admin_live.ex:1605
+#: lib/abuuba_web/live/admin_live.ex:1607
 #, elixir-autogen, elixir-format
 msgid "The relay's inbox address, which its operator publishes. Adding and turning on are separate steps, so a mistyped address can be corrected before anything is sent to it."
 msgstr "Die Inbox-Adresse des Relays, die dessen Betrieb veröffentlicht. Hinzufügen und Einschalten sind getrennte Schritte, damit eine vertippte Adresse korrigiert werden kann, bevor irgendetwas dorthin geht."
 
-#: lib/abuuba_web/live/admin_live.ex:1644
-#: lib/abuuba_web/live/admin_live.ex:1842
+#: lib/abuuba_web/live/admin_live.ex:1646
+#: lib/abuuba_web/live/admin_live.ex:1844
 #, elixir-autogen, elixir-format
 msgid "Turn off"
 msgstr "Ausschalten"
 
-#: lib/abuuba_web/live/admin_live.ex:1634
-#: lib/abuuba_web/live/admin_live.ex:1842
+#: lib/abuuba_web/live/admin_live.ex:1636
+#: lib/abuuba_web/live/admin_live.ex:1844
 #, elixir-autogen, elixir-format
 msgid "Turn on"
 msgstr "Einschalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3680
+#: lib/abuuba_web/live/admin_live.ex:3667
 #, elixir-autogen, elixir-format
 msgid "Waiting for the relay to answer"
 msgstr "Wartet auf die Antwort des Relays"
 
-#: lib/abuuba_web/live/admin_live.ex:1617
+#: lib/abuuba_web/live/admin_live.ex:1619
 #, elixir-autogen, elixir-format
 msgid "last sent %{when}"
 msgstr "zuletzt gesendet %{when}"
 
-#: lib/abuuba_web/live/admin_live.ex:1823
+#: lib/abuuba_web/live/admin_live.ex:1825
 #, elixir-autogen, elixir-format
 msgid "Added turned off, so a URL typed wrong can be corrected before anything goes to it."
 msgstr "Wird ausgeschaltet angelegt, damit eine vertippte Adresse korrigiert werden kann, bevor irgendetwas dorthin geht."
 
-#: lib/abuuba_web/live/admin_live.ex:1798
+#: lib/abuuba_web/live/admin_live.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Copy it now. It is not shown again."
 msgstr "Kopiere es jetzt. Es wird nicht noch einmal angezeigt."
 
-#: lib/abuuba_web/live/admin_live.ex:1852
+#: lib/abuuba_web/live/admin_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "New secret"
 msgstr "Neues Geheimnis"
 
-#: lib/abuuba_web/live/admin_live.ex:1894
+#: lib/abuuba_web/live/admin_live.ex:1896
 #, elixir-autogen, elixir-format
 msgid "No webhooks yet."
 msgstr "Noch keine Webhooks."
 
-#: lib/abuuba_web/live/admin_live.ex:1889
+#: lib/abuuba_web/live/admin_live.ex:1891
 #, elixir-autogen, elixir-format
 msgid "Nothing sent yet."
 msgstr "Noch nichts verschickt."
 
-#: lib/abuuba_web/live/admin_live.ex:1860
+#: lib/abuuba_web/live/admin_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Remove this webhook?"
 msgstr "Diesen Webhook entfernen?"
 
-#: lib/abuuba_web/live/admin_live.ex:3097
-#: lib/abuuba_web/live/admin_live.ex:3675
+#: lib/abuuba_web/live/admin_live.ex:3094
+#: lib/abuuba_web/live/admin_live.ex:3662
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr "Das hat nicht geklappt."
 
-#: lib/abuuba_web/live/admin_live.ex:3672
+#: lib/abuuba_web/live/admin_live.ex:3659
 #, elixir-autogen, elixir-format
 msgid "That is not an event this server sends."
 msgstr "So ein Ereignis verschickt dieser Server nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3669
+#: lib/abuuba_web/live/admin_live.ex:3656
 #, elixir-autogen, elixir-format
 msgid "That is not an https address, or it is already here."
 msgstr "Das ist keine https-Adresse, oder sie ist schon da."
 
-#: lib/abuuba_web/live/admin_live.ex:1850
+#: lib/abuuba_web/live/admin_live.ex:1852
 #, elixir-autogen, elixir-format
 msgid "The old secret stops working immediately. Continue?"
 msgstr "Das alte Geheimnis funktioniert sofort nicht mehr. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:1796
+#: lib/abuuba_web/live/admin_live.ex:1798
 #, elixir-autogen, elixir-format
 msgid "The signing secret"
 msgstr "Das Signatur-Geheimnis"
 
-#: lib/abuuba_web/live/admin_live.ex:1790
+#: lib/abuuba_web/live/admin_live.ex:1792
 #, elixir-autogen, elixir-format
 msgid "This server posts to a webhook when something happens that a moderator would want to know about."
 msgstr "Dieser Server schickt etwas an einen Webhook, wenn etwas passiert, das die Moderation wissen möchte."
 
-#: lib/abuuba_web/live/admin_live.ex:3384
+#: lib/abuuba_web/live/admin_live.ex:3378
 #, elixir-autogen, elixir-format
 msgid "Webhooks"
 msgstr "Webhooks"
 
-#: lib/abuuba_web/live/admin_live.ex:1875
+#: lib/abuuba_web/live/admin_live.ex:1877
 #, elixir-autogen, elixir-format
 msgid "no answer"
 msgstr "keine Antwort"
 
-#: lib/abuuba_web/live/admin_live.ex:1672
+#: lib/abuuba_web/live/admin_live.ex:1674
 #, elixir-autogen, elixir-format
 msgid "A role is a set of permissions and a position. Position is what decides who may act on whom: nobody may edit a role at or above their own, and nobody may grant a permission they do not hold themselves."
 msgstr "Eine Rolle ist ein Satz Berechtigungen und eine Position. Die Position entscheidet, wer auf wen einwirken darf: niemand darf eine Rolle auf oder über der eigenen bearbeiten, und niemand darf eine Berechtigung vergeben, die er selbst nicht hat."
 
-#: lib/abuuba_web/live/admin_live.ex:1774
+#: lib/abuuba_web/live/admin_live.ex:1776
 #, elixir-autogen, elixir-format
 msgid "Above yours"
 msgstr "Über deiner"
 
-#: lib/abuuba_web/live/admin_live.ex:3588
+#: lib/abuuba_web/live/admin_live.ex:3575
 #, elixir-autogen, elixir-format
 msgid "Act on accounts"
 msgstr "Auf Konten einwirken"
 
-#: lib/abuuba_web/live/admin_live.ex:3592
+#: lib/abuuba_web/live/admin_live.ex:3579
 #, elixir-autogen, elixir-format
 msgid "Answer appeals"
 msgstr "Einsprüche beantworten"
 
-#: lib/abuuba_web/live/admin_live.ex:3618
+#: lib/abuuba_web/live/admin_live.ex:3605
 #, elixir-autogen, elixir-format
 msgid "Approve registrations, and turn two-factor off for somebody locked out."
 msgstr "Anmeldungen freigeben und die Zwei-Faktor-Anmeldung für Ausgesperrte abschalten."
 
-#: lib/abuuba_web/live/admin_live.ex:3596
+#: lib/abuuba_web/live/admin_live.ex:3583
 #, elixir-autogen, elixir-format
 msgid "Approve what trends"
 msgstr "Freigeben, was in den Trends erscheint"
 
-#: lib/abuuba_web/live/admin_live.ex:3626
+#: lib/abuuba_web/live/admin_live.ex:3613
 #, elixir-autogen, elixir-format
 msgid "Block and unblock other servers, and set up relays."
 msgstr "Andere Server blockieren und freigeben, und Relays einrichten."
 
-#: lib/abuuba_web/live/admin_live.ex:3594
+#: lib/abuuba_web/live/admin_live.ex:3581
 #, elixir-autogen, elixir-format
 msgid "Block sign-ups"
 msgstr "Anmeldungen blockieren"
 
-#: lib/abuuba_web/live/admin_live.ex:3595
+#: lib/abuuba_web/live/admin_live.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Change the server's settings"
 msgstr "Die Einstellungen des Servers ändern"
 
-#: lib/abuuba_web/live/admin_live.ex:1697
+#: lib/abuuba_web/live/admin_live.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Colour"
 msgstr "Farbe"
 
-#: lib/abuuba_web/live/admin_live.ex:1736
+#: lib/abuuba_web/live/admin_live.ex:1738
 #, elixir-autogen, elixir-format
 msgid "Create the role"
 msgstr "Rolle anlegen"
 
-#: lib/abuuba_web/live/admin_live.ex:3593
+#: lib/abuuba_web/live/admin_live.ex:3580
 #, elixir-autogen, elixir-format
 msgid "Decide about other servers"
 msgstr "Über andere Server entscheiden"
 
-#: lib/abuuba_web/live/admin_live.ex:3632
+#: lib/abuuba_web/live/admin_live.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Decide which hashtags, links and posts may appear in what is trending."
 msgstr "Entscheiden, welche Hashtags, Links und Beiträge in den Trends erscheinen dürfen."
 
-#: lib/abuuba_web/live/admin_live.ex:3590
+#: lib/abuuba_web/live/admin_live.ex:3577
 #, elixir-autogen, elixir-format
 msgid "Delete an account's data"
 msgstr "Die Daten eines Kontos löschen"
 
-#: lib/abuuba_web/live/admin_live.ex:3621
+#: lib/abuuba_web/live/admin_live.ex:3608
 #, elixir-autogen, elixir-format
 msgid "Delete somebody's posts and files. This cannot be undone."
 msgstr "Beiträge und Dateien einer Person löschen. Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/admin_live.ex:3607
+#: lib/abuuba_web/live/admin_live.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Every permission below, including ones added later. Give it to very few people."
 msgstr "Alle Berechtigungen unten, auch später hinzugekommene. Gib sie nur ganz wenigen Leuten."
 
-#: lib/abuuba_web/live/admin_live.ex:3591
+#: lib/abuuba_web/live/admin_live.ex:3578
 #, elixir-autogen, elixir-format
 msgid "Handle reports"
 msgstr "Meldungen bearbeiten"
 
-#: lib/abuuba_web/live/admin_live.ex:3589
+#: lib/abuuba_web/live/admin_live.ex:3576
 #, elixir-autogen, elixir-format
 msgid "Let people in and out"
 msgstr "Leute hereinlassen und hinauslassen"
 
-#: lib/abuuba_web/live/admin_live.ex:3636
+#: lib/abuuba_web/live/admin_live.ex:3623
 #, elixir-autogen, elixir-format
 msgid "Make and change roles, never above their own and never granting more than they hold."
 msgstr "Rollen anlegen und ändern, nie über der eigenen und nie mit mehr, als man selbst hat."
 
-#: lib/abuuba_web/live/admin_live.ex:3601
+#: lib/abuuba_web/live/admin_live.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Manage custom emoji"
 msgstr "Eigene Emojis verwalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3597
+#: lib/abuuba_web/live/admin_live.ex:3584
 #, elixir-autogen, elixir-format
 msgid "Manage everybody's invites"
 msgstr "Die Einladungen aller verwalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3603
+#: lib/abuuba_web/live/admin_live.ex:3590
 #, elixir-autogen, elixir-format
 msgid "Manage roles"
 msgstr "Rollen verwalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3602
+#: lib/abuuba_web/live/admin_live.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Manage webhooks"
 msgstr "Webhooks verwalten"
 
-#: lib/abuuba_web/live/admin_live.ex:1682
+#: lib/abuuba_web/live/admin_live.ex:1684
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Name"
 
-#: lib/abuuba_web/live/admin_live.ex:1779
+#: lib/abuuba_web/live/admin_live.ex:1781
 #, elixir-autogen, elixir-format
 msgid "No roles yet."
 msgstr "Noch keine Rollen."
 
-#: lib/abuuba_web/live/admin_live.ex:1687
+#: lib/abuuba_web/live/admin_live.ex:1689
 #, elixir-autogen, elixir-format
 msgid "Position"
 msgstr "Position"
 
-#: lib/abuuba_web/live/admin_live.ex:1750
+#: lib/abuuba_web/live/admin_live.ex:1752
 #, elixir-autogen, elixir-format
 msgid "Position %{position}"
 msgstr "Position %{position}"
 
-#: lib/abuuba_web/live/admin_live.ex:3587
+#: lib/abuuba_web/live/admin_live.ex:3574
 #, elixir-autogen, elixir-format
 msgid "Read the audit log"
 msgstr "Das Protokoll lesen"
 
-#: lib/abuuba_web/live/admin_live.ex:3623
+#: lib/abuuba_web/live/admin_live.ex:3610
 #, elixir-autogen, elixir-format
 msgid "Read the queue, resolve and reopen."
 msgstr "Die Warteschlange lesen, erledigen und wieder öffnen."
 
-#: lib/abuuba_web/live/admin_live.ex:1768
+#: lib/abuuba_web/live/admin_live.ex:1770
 #, elixir-autogen, elixir-format
 msgid "Remove this role? Anybody holding it keeps their account."
 msgstr "Diese Rolle entfernen? Wer sie hat, behält sein Konto."
 
-#: lib/abuuba_web/live/admin_live.ex:3383
+#: lib/abuuba_web/live/admin_live.ex:3377
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr "Rollen"
 
-#: lib/abuuba_web/live/admin_live.ex:1736
+#: lib/abuuba_web/live/admin_live.ex:1738
 #, elixir-autogen, elixir-format
 msgid "Save the role"
 msgstr "Rolle speichern"
 
-#: lib/abuuba_web/live/admin_live.ex:3586
+#: lib/abuuba_web/live/admin_live.ex:3573
 #, elixir-autogen, elixir-format
 msgid "See the admin area"
 msgstr "Den Administrationsbereich sehen"
 
-#: lib/abuuba_web/live/admin_live.ex:3615
+#: lib/abuuba_web/live/admin_live.ex:3602
 #, elixir-autogen, elixir-format
 msgid "Silence, suspend, approve and reject accounts on this server."
 msgstr "Konten auf diesem Server einschränken, sperren, freigeben und ablehnen."
 
-#: lib/abuuba_web/live/admin_live.ex:3500
-#: lib/abuuba_web/live/admin_live.ex:3526
+#: lib/abuuba_web/live/admin_live.ex:3487
+#: lib/abuuba_web/live/admin_live.ex:3513
 #, elixir-autogen, elixir-format
 msgid "That role could not be saved."
 msgstr "Diese Rolle konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3612
+#: lib/abuuba_web/live/admin_live.ex:3599
 #, elixir-autogen, elixir-format
 msgid "What every moderator has done, including this person's own actions."
 msgstr "Was jede moderierende Person getan hat, auch die eigenen Aktionen."
 
-#: lib/abuuba_web/live/admin_live.ex:1709
+#: lib/abuuba_web/live/admin_live.ex:1711
 #, elixir-autogen, elixir-format
 msgid "What this role may do"
 msgstr "Was diese Rolle darf"
 
-#: lib/abuuba_web/live/admin_live.ex:3629
+#: lib/abuuba_web/live/admin_live.ex:3616
 #, elixir-autogen, elixir-format
 msgid "Who may sign up, the server's name and description, and the rest."
 msgstr "Wer sich anmelden darf, Name und Beschreibung des Servers, und der Rest."
 
-#: lib/abuuba_web/live/admin_live.ex:3609
+#: lib/abuuba_web/live/admin_live.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Without this the admin area is closed."
 msgstr "Ohne das ist der Administrationsbereich zu."
 
-#: lib/abuuba_web/live/admin_live.ex:3600
+#: lib/abuuba_web/live/admin_live.ex:3587
 #, elixir-autogen, elixir-format
 msgid "Write announcements"
 msgstr "Ankündigungen schreiben"
 
-#: lib/abuuba_web/live/admin_live.ex:3598
+#: lib/abuuba_web/live/admin_live.ex:3585
 #, elixir-autogen, elixir-format
 msgid "Write invites"
 msgstr "Einladungen schreiben"
 
-#: lib/abuuba_web/live/admin_live.ex:3599
+#: lib/abuuba_web/live/admin_live.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Write the server rules"
 msgstr "Die Serverregeln schreiben"
 
-#: lib/abuuba_web/live/admin_live.ex:3579
+#: lib/abuuba_web/live/admin_live.ex:3566
 #, elixir-autogen, elixir-format
 msgid "You cannot make a role at or above your own position, or grant a permission you do not hold."
 msgstr "Du kannst keine Rolle auf oder über deiner eigenen Position anlegen und keine Berechtigung vergeben, die du selbst nicht hast."
 
-#: lib/abuuba_web/live/admin_live.ex:1729
+#: lib/abuuba_web/live/admin_live.ex:1731
 #, elixir-autogen, elixir-format
 msgid "You do not hold this yourself, so you cannot grant it."
 msgstr "Das hast du selbst nicht, also kannst du es nicht vergeben."
 
-#: lib/abuuba_web/live/admin_live.ex:3649
+#: lib/abuuba_web/live/admin_live.ex:3636
 #, elixir-autogen, elixir-format
 msgid "nothing in particular"
 msgstr "nichts Bestimmtes"
 
-#: lib/abuuba_web/live/admin_live.ex:920
-#: lib/abuuba_web/live/admin_live.ex:1569
+#: lib/abuuba_web/live/admin_live.ex:922
+#: lib/abuuba_web/live/admin_live.ex:1571
 #, elixir-autogen, elixir-format
 msgid "A note for the other moderators"
 msgstr "Eine Notiz für die anderen Moderierenden"
 
-#: lib/abuuba_web/live/admin_live.ex:1546
+#: lib/abuuba_web/live/admin_live.ex:1548
 #, elixir-autogen, elixir-format
 msgid "Blocked: %{severity}"
 msgstr "Blockiert: %{severity}"
 
-#: lib/abuuba_web/live/admin_live.ex:1504
+#: lib/abuuba_web/live/admin_live.ex:1506
 #, elixir-autogen, elixir-format
 msgid "Delivering"
 msgstr "Zustellung läuft"
 
-#: lib/abuuba_web/live/admin_live.ex:1490
+#: lib/abuuba_web/live/admin_live.ex:1492
 #, elixir-autogen, elixir-format
 msgid "Delivery stopped by a moderator"
 msgstr "Zustellung von der Moderation gestoppt"
 
-#: lib/abuuba_web/live/admin_live.ex:1457
+#: lib/abuuba_web/live/admin_live.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Every server this one has heard from, busiest first. A peer that has quietly stopped accepting deliveries looks exactly like a peer whose people have gone quiet, and this is where the two are told apart."
 msgstr "Jeder Server, von dem dieser hier gehört hat, der geschäftigste zuerst. Ein Gegenüber, das stillschweigend nichts mehr annimmt, sieht genauso aus wie eines, dessen Leute einfach ruhig geworden sind — hier lassen sich die beiden auseinanderhalten."
 
-#: lib/abuuba_web/live/admin_live.ex:1542
+#: lib/abuuba_web/live/admin_live.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Forget the failures"
 msgstr "Fehlschläge vergessen"
 
-#: lib/abuuba_web/live/admin_live.ex:1578
+#: lib/abuuba_web/live/admin_live.ex:1580
 #, elixir-autogen, elixir-format
 msgid "No other servers yet."
 msgstr "Noch keine anderen Server."
 
-#: lib/abuuba_web/live/admin_live.ex:1482
+#: lib/abuuba_web/live/admin_live.ex:1484
 #, elixir-autogen, elixir-format
 msgid "One account"
 msgid_plural "%{count} accounts"
 msgstr[0] "Ein Konto"
 msgstr[1] "%{count} Konten"
 
-#: lib/abuuba_web/live/admin_live.ex:3382
+#: lib/abuuba_web/live/admin_live.ex:3376
 #, elixir-autogen, elixir-format
 msgid "Other servers"
 msgstr "Andere Server"
 
-#: lib/abuuba_web/live/admin_live.ex:1559
+#: lib/abuuba_web/live/admin_live.ex:1561
 #, elixir-autogen, elixir-format
 msgid "Silence this server"
 msgstr "Diesen Server stummschalten"
 
-#: lib/abuuba_web/live/admin_live.ex:1556
+#: lib/abuuba_web/live/admin_live.ex:1558
 #, elixir-autogen, elixir-format
 msgid "Silence this server? Its posts stop appearing in public timelines."
 msgstr "Diesen Server stummschalten? Seine Beiträge erscheinen dann nicht mehr in öffentlichen Timelines."
 
-#: lib/abuuba_web/live/admin_live.ex:1532
+#: lib/abuuba_web/live/admin_live.ex:1534
 #, elixir-autogen, elixir-format
 msgid "Start again"
 msgstr "Wieder starten"
 
-#: lib/abuuba_web/live/admin_live.ex:1522
+#: lib/abuuba_web/live/admin_live.ex:1524
 #, elixir-autogen, elixir-format
 msgid "Stop delivering"
 msgstr "Zustellung stoppen"
 
-#: lib/abuuba_web/live/admin_live.ex:2668
+#: lib/abuuba_web/live/admin_live.ex:2670
 #, elixir-autogen, elixir-format
 msgid "That server could not be blocked."
 msgstr "Dieser Server konnte nicht blockiert werden."
 
-#: lib/abuuba_web/live/admin_live.ex:1496
+#: lib/abuuba_web/live/admin_live.ex:1498
 #, elixir-autogen, elixir-format
 msgid "Treated as down since %{when}"
 msgstr "Gilt seit %{when} als nicht erreichbar"
 
-#: lib/abuuba_web/live/admin_live.ex:1507
+#: lib/abuuba_web/live/admin_live.ex:1509
 #, elixir-autogen, elixir-format
 msgid "one bad day"
 msgid_plural "%{count} bad days"
 msgstr[0] "ein schlechter Tag"
 msgstr[1] "%{count} schlechte Tage"
 
-#: lib/abuuba_web/live/admin_live.ex:1482
+#: lib/abuuba_web/live/admin_live.ex:1484
 #, elixir-autogen, elixir-format
 msgid "one post"
 msgid_plural "%{count} posts"
 msgstr[0] "ein Beitrag"
 msgstr[1] "%{count} Beiträge"
 
-#: lib/abuuba_web/live/admin_live.ex:953
+#: lib/abuuba_web/live/admin_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Ask their server for it again. Worth doing when the name or picture here is out of date and waiting for their next post is waiting for something that may not come."
 msgstr "Frag ihren Server noch einmal danach. Sinnvoll, wenn Name oder Bild hier veraltet sind und das Warten auf den nächsten Beitrag ein Warten auf etwas ist, das vielleicht nie kommt."
 
-#: lib/abuuba_web/live/admin_live.ex:980
+#: lib/abuuba_web/live/admin_live.ex:982
 #, elixir-autogen, elixir-format
 msgid "Delete this post? Other servers are told to delete it too."
 msgstr "Diesen Beitrag löschen? Andere Server werden aufgefordert, ihre Kopie ebenfalls zu löschen."
 
-#: lib/abuuba_web/live/admin_live.ex:965
+#: lib/abuuba_web/live/admin_live.ex:967
 #, elixir-autogen, elixir-format
 msgid "Deleting one from here is the same delete they would do themselves."
 msgstr "Von hier aus zu löschen ist dasselbe Löschen, das die Person selbst machen würde."
 
-#: lib/abuuba_web/live/admin_live.ex:958
+#: lib/abuuba_web/live/admin_live.ex:960
 #, elixir-autogen, elixir-format
 msgid "Fetch it again"
 msgstr "Noch einmal holen"
 
-#: lib/abuuba_web/live/admin_live.ex:946
+#: lib/abuuba_web/live/admin_live.ex:948
 #, elixir-autogen, elixir-format
 msgid "Force a password reset"
 msgstr "Passwort-Zurücksetzen erzwingen"
 
-#: lib/abuuba_web/live/admin_live.ex:934
+#: lib/abuuba_web/live/admin_live.ex:936
 #, elixir-autogen, elixir-format
 msgid "Locked out, or somebody else is in"
 msgstr "Ausgesperrt, oder jemand anderes ist drin"
 
-#: lib/abuuba_web/live/admin_live.ex:922
+#: lib/abuuba_web/live/admin_live.ex:924
 #, elixir-autogen, elixir-format
 msgid "Nobody is told and nothing is applied. This is for the context that otherwise lives in one person's head: that this is the third report about the same joke, or that somebody spoke to them and they understood."
 msgstr "Niemand wird benachrichtigt und nichts wird angewendet. Das hier ist für den Zusammenhang, der sonst nur in einem Kopf steckt: dass dies die dritte Meldung zum selben Witz ist, oder dass jemand mit ihnen gesprochen hat und sie es verstanden haben."
 
-#: lib/abuuba_web/live/admin_live.ex:989
+#: lib/abuuba_web/live/admin_live.ex:991
 #, elixir-autogen, elixir-format
 msgid "Nothing posted."
 msgstr "Nichts geschrieben."
 
-#: lib/abuuba_web/live/admin_live.ex:943
+#: lib/abuuba_web/live/admin_live.ex:945
 #, elixir-autogen, elixir-format
 msgid "Sign them out everywhere and send a reset link?"
 msgstr "Überall abmelden und einen Link zum Zurücksetzen schicken?"
 
-#: lib/abuuba_web/live/admin_live.ex:2686
+#: lib/abuuba_web/live/admin_live.ex:2688
 #, elixir-autogen, elixir-format
 msgid "That account has nobody to sign in as."
 msgstr "Zu diesem Konto gibt es niemanden, der sich anmelden könnte."
 
-#: lib/abuuba_web/live/admin_live.ex:963
+#: lib/abuuba_web/live/admin_live.ex:965
 #, elixir-autogen, elixir-format
 msgid "Their most recent posts"
 msgstr "Ihre letzten Beiträge"
 
-#: lib/abuuba_web/live/admin_live.ex:951
+#: lib/abuuba_web/live/admin_live.ex:953
 #, elixir-autogen, elixir-format
 msgid "Their profile here is a copy"
 msgstr "Ihr Profil ist hier nur eine Kopie"
 
-#: lib/abuuba_web/live/admin_live.ex:2699
+#: lib/abuuba_web/live/admin_live.ex:2701
 #, elixir-autogen, elixir-format
 msgid "Their server did not answer."
 msgstr "Ihr Server hat nicht geantwortet."
 
-#: lib/abuuba_web/live/admin_live.ex:936
+#: lib/abuuba_web/live/admin_live.ex:938
 #, elixir-autogen, elixir-format
 msgid "This ends every session and every app, and emails them a link to set a new password. It does not choose one for them: a password a moderator picked is a password a moderator knows."
 msgstr "Das beendet jede Sitzung und jede App und schickt ihnen per E-Mail einen Link, um ein neues Passwort zu setzen. Es wählt keines für sie aus: ein Passwort, das die Moderation vergeben hat, ist ein Passwort, das die Moderation kennt."
 
-#: lib/abuuba_web/live/admin_live.ex:2135
+#: lib/abuuba_web/live/admin_live.ex:2137
 #, elixir-autogen, elixir-format
 msgid "%{latest} is out."
 msgstr "%{latest} ist draußen."
 
-#: lib/abuuba_web/live/admin_live.ex:1287
+#: lib/abuuba_web/live/admin_live.ex:1289
 #, elixir-autogen, elixir-format
 msgid "A server that has decided about four hundred domains has made four hundred decisions, and the way those get shared is a list somebody publishes. This reads and writes those lists."
 msgstr "Ein Server, der über vierhundert Domains entschieden hat, hat vierhundert Entscheidungen getroffen, und weitergegeben werden die als Liste, die jemand veröffentlicht. Hier werden solche Listen gelesen und geschrieben."
 
-#: lib/abuuba_web/live/admin_live.ex:2755
+#: lib/abuuba_web/live/admin_live.ex:2757
 #, elixir-autogen, elixir-format
 msgid "Added %{added}. %{skipped} were already decided about."
 msgstr "%{added} hinzugefügt. Über %{skipped} war schon entschieden."
 
-#: lib/abuuba_web/live/admin_live.ex:1429
+#: lib/abuuba_web/live/admin_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Addresses that asked one account here to write to them. Only the confirmed ones are counted: an unconfirmed address is a claim somebody typed, not a subscriber."
 msgstr "Adressen, die ein Konto hier gebeten haben, ihnen zu schreiben. Gezählt werden nur die bestätigten: eine unbestätigte Adresse ist eine Behauptung, die jemand eingetippt hat, kein Abonnement."
 
-#: lib/abuuba_web/live/admin_live.ex:1302
-#: lib/abuuba_web/live/admin_live.ex:1317
+#: lib/abuuba_web/live/admin_live.ex:1304
+#: lib/abuuba_web/live/admin_live.ex:1319
 #, elixir-autogen, elixir-format
 msgid "Allows"
 msgstr "Erlaubte"
 
-#: lib/abuuba_web/live/admin_live.ex:2112
+#: lib/abuuba_web/live/admin_live.ex:2114
 #, elixir-autogen, elixir-format
 msgid "Checking for updates"
 msgstr "Nach Aktualisierungen sehen"
 
-#: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/admin_live.ex:3375
 #, elixir-autogen, elixir-format
 msgid "Domain lists"
 msgstr "Domain-Listen"
 
-#: lib/abuuba_web/live/admin_live.ex:1307
+#: lib/abuuba_web/live/admin_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Domains this server has already decided about are left exactly as they are. An import adds and never removes: one paste should not be able to undo every decision made here, silently and unrecoverably."
 msgstr "Domains, über die dieser Server schon entschieden hat, bleiben genau so, wie sie sind. Ein Import fügt hinzu und entfernt nie: ein einziges Einfügen soll nicht jede hier getroffene Entscheidung stillschweigend und unwiederbringlich rückgängig machen können."
 
-#: lib/abuuba_web/live/admin_live.ex:3379
+#: lib/abuuba_web/live/admin_live.ex:3373
 #, elixir-autogen, elixir-format
 msgid "Email subscriptions"
 msgstr "E-Mail-Abos"
 
-#: lib/abuuba_web/live/admin_live.ex:1446
+#: lib/abuuba_web/live/admin_live.ex:1448
 #, elixir-autogen, elixir-format
 msgid "Nobody here has any subscribers."
 msgstr "Niemand hier hat Abonnenten."
 
-#: lib/abuuba_web/live/admin_live.ex:1419
+#: lib/abuuba_web/live/admin_live.ex:1421
 #, elixir-autogen, elixir-format
 msgid "Nobody is being suggested yet. It needs a few follows to work from."
 msgstr "Es wird noch niemand vorgeschlagen. Dafür braucht es erst ein paar Folge-Beziehungen."
 
-#: lib/abuuba_web/live/admin_live.ex:1401
+#: lib/abuuba_web/live/admin_live.ex:1403
 #, elixir-autogen, elixir-format
 msgid "Not suggested"
 msgstr "Wird nicht vorgeschlagen"
 
-#: lib/abuuba_web/live/admin_live.ex:2114
+#: lib/abuuba_web/live/admin_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. It asks %{url} whether there is a newer abuuba. What that tells them is what any web request tells anybody: this server's address, a user agent, and that somebody asked. Nothing about the accounts here, their number or their posts is sent, and there is nowhere in the request for it to go."
 msgstr "Aus, solange du es nicht einschaltest. Es fragt %{url}, ob es ein neueres abuuba gibt. Was das dort verrät, ist das, was jede Web-Anfrage verrät: die Adresse dieses Servers, einen User-Agent und dass jemand gefragt hat. Nichts über die Konten hier, ihre Zahl oder ihre Beiträge wird gesendet, und in der Anfrage ist auch kein Platz dafür."
 
-#: lib/abuuba_web/live/admin_live.ex:1440
+#: lib/abuuba_web/live/admin_live.ex:1442
 #, elixir-autogen, elixir-format
 msgid "One address"
 msgid_plural "%{count} addresses"
 msgstr[0] "Eine Adresse"
 msgstr[1] "%{count} Adressen"
 
-#: lib/abuuba_web/live/admin_live.ex:1294
+#: lib/abuuba_web/live/admin_live.ex:1296
 #, elixir-autogen, elixir-format
 msgid "One blocked domain"
 msgid_plural "%{count} blocked domains"
 msgstr[0] "Eine blockierte Domain"
 msgstr[1] "%{count} blockierte Domains"
 
-#: lib/abuuba_web/live/admin_live.ex:1328
+#: lib/abuuba_web/live/admin_live.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Read it in"
 msgstr "Einlesen"
 
-#: lib/abuuba_web/live/admin_live.ex:1305
+#: lib/abuuba_web/live/admin_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Read one in"
 msgstr "Eine einlesen"
 
-#: lib/abuuba_web/live/admin_live.ex:2133
+#: lib/abuuba_web/live/admin_live.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Running %{version}."
 msgstr "Läuft mit %{version}."
 
-#: lib/abuuba_web/live/admin_live.ex:1413
+#: lib/abuuba_web/live/admin_live.ex:1415
 #, elixir-autogen, elixir-format
 msgid "Stop suggesting"
 msgstr "Nicht mehr vorschlagen"
 
-#: lib/abuuba_web/live/admin_live.ex:1412
+#: lib/abuuba_web/live/admin_live.ex:1414
 #, elixir-autogen, elixir-format
 msgid "Suggest again"
 msgstr "Wieder vorschlagen"
 
-#: lib/abuuba_web/live/admin_live.ex:1292
+#: lib/abuuba_web/live/admin_live.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Take a copy"
 msgstr "Eine Kopie mitnehmen"
 
-#: lib/abuuba_web/live/admin_live.ex:2129
+#: lib/abuuba_web/live/admin_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Tell me when there is a newer version"
 msgstr "Sag mir Bescheid, wenn es eine neuere Version gibt"
@@ -4850,228 +4847,228 @@ msgstr "Sag mir Bescheid, wenn es eine neuere Version gibt"
 msgid "There is no list of that kind."
 msgstr "So eine Liste gibt es nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:1314
+#: lib/abuuba_web/live/admin_live.ex:1316
 #, elixir-autogen, elixir-format
 msgid "Which list"
 msgstr "Welche Liste"
 
-#: lib/abuuba_web/live/admin_live.ex:1389
+#: lib/abuuba_web/live/admin_live.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Who this server puts in front of a newcomer. Taking somebody out is not a block and not a silence: their account carries on exactly as before and nobody is told."
 msgstr "Wen dieser Server Neuankömmlingen zeigt. Jemanden herauszunehmen ist keine Blockade und keine Stummschaltung: das Konto läuft genau wie vorher weiter, und niemand wird benachrichtigt."
 
-#: lib/abuuba_web/live/admin_live.ex:1294
+#: lib/abuuba_web/live/admin_live.ex:1296
 #, elixir-autogen, elixir-format
 msgid "one allowed domain"
 msgid_plural "%{count} allowed domains"
 msgstr[0] "eine erlaubte Domain"
 msgstr[1] "%{count} erlaubte Domains"
 
-#: lib/abuuba_web/live/admin_live.ex:342
+#: lib/abuuba_web/live/admin_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "%{label}, highest %{top}"
 msgstr "%{label}, höchster Wert %{top}"
 
-#: lib/abuuba_web/live/admin_live.ex:3703
+#: lib/abuuba_web/live/admin_live.ex:3690
 #, elixir-autogen, elixir-format
 msgid "Favourites, boosts and replies"
 msgstr "Favoriten, Boosts und Antworten"
 
-#: lib/abuuba_web/live/admin_live.ex:3708
+#: lib/abuuba_web/live/admin_live.ex:3695
 #, elixir-autogen, elixir-format
 msgid "Languages people write in"
 msgstr "Sprachen, in denen geschrieben wird"
 
-#: lib/abuuba_web/live/admin_live.ex:3701
+#: lib/abuuba_web/live/admin_live.ex:3688
 #, elixir-autogen, elixir-format
 msgid "New accounts"
 msgstr "Neue Konten"
 
-#: lib/abuuba_web/live/admin_live.ex:423
+#: lib/abuuba_web/live/admin_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Of the people who signed up in a given week, how many were still posting in the weeks after. A number that only means something once the server has been running a while."
 msgstr "Von den Leuten, die sich in einer bestimmten Woche angemeldet haben: wie viele in den Wochen danach noch geschrieben haben. Eine Zahl, die erst etwas bedeutet, wenn der Server eine Weile läuft."
 
-#: lib/abuuba_web/live/admin_live.ex:3700
+#: lib/abuuba_web/live/admin_live.ex:3687
 #, elixir-autogen, elixir-format
 msgid "People who posted"
 msgstr "Leute, die geschrieben haben"
 
-#: lib/abuuba_web/live/admin_live.ex:3702
+#: lib/abuuba_web/live/admin_live.ex:3689
 #, elixir-autogen, elixir-format
 msgid "Posts written here"
 msgstr "Hier geschriebene Beiträge"
 
-#: lib/abuuba_web/live/admin_live.ex:3704
+#: lib/abuuba_web/live/admin_live.ex:3691
 #, elixir-autogen, elixir-format
 msgid "Reports opened"
 msgstr "Eröffnete Meldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3705
+#: lib/abuuba_web/live/admin_live.ex:3692
 #, elixir-autogen, elixir-format
 msgid "Reports resolved"
 msgstr "Erledigte Meldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3710
+#: lib/abuuba_web/live/admin_live.ex:3697
 #, elixir-autogen, elixir-format
 msgid "Servers we hear most from"
 msgstr "Server, von denen wir am meisten hören"
 
-#: lib/abuuba_web/live/admin_live.ex:387
+#: lib/abuuba_web/live/admin_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "The last thirty days"
 msgstr "Die letzten dreißig Tage"
 
-#: lib/abuuba_web/live/admin_live.ex:389
+#: lib/abuuba_web/live/admin_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "The same numbers a moderation client draws from the API, so what you see here and what it shows are the same figures rather than two answers to one question."
 msgstr "Dieselben Zahlen, die sich ein Moderations-Client über die API holt — was du hier siehst und was der anzeigt, sind also dieselben Werte und nicht zwei Antworten auf eine Frage."
 
-#: lib/abuuba_web/live/admin_live.ex:3711
+#: lib/abuuba_web/live/admin_live.ex:3698
 #, elixir-autogen, elixir-format
 msgid "What those servers run"
 msgstr "Was auf diesen Servern läuft"
 
-#: lib/abuuba_web/live/admin_live.ex:3709
+#: lib/abuuba_web/live/admin_live.ex:3696
 #, elixir-autogen, elixir-format
 msgid "Where accounts signed up from"
 msgstr "Woher sich Konten angemeldet haben"
 
-#: lib/abuuba_web/live/admin_live.ex:402
+#: lib/abuuba_web/live/admin_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "Where things come from"
 msgstr "Woher die Dinge kommen"
 
-#: lib/abuuba_web/live/admin_live.ex:421
+#: lib/abuuba_web/live/admin_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "Who stayed"
 msgstr "Wer geblieben ist"
 
-#: lib/abuuba_web/live/admin_live.ex:432
+#: lib/abuuba_web/live/admin_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "one signed up"
 msgid_plural "%{count} signed up"
 msgstr[0] "eine Anmeldung"
 msgstr[1] "%{count} Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2219
+#: lib/abuuba_web/live/settings_live.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr "Profilbild"
 
-#: lib/abuuba_web/live/settings_live.ex:2220
+#: lib/abuuba_web/live/settings_live.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr "Titelbild"
 
-#: lib/abuuba_web/live/settings_live.ex:345
+#: lib/abuuba_web/live/settings_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr "JPEG, PNG, GIF oder WebP, bis %{size}. Größere werden schon vor dem Hochladen abgelehnt und nicht erst danach, und was du schickst, wird hier verkleinert, damit niemand ein ganzes Foto lädt, um es bei vierzig Pixeln zu sehen."
 
-#: lib/abuuba_web/live/admin_live.ex:550
-#: lib/abuuba_web/live/settings_live.ex:363
+#: lib/abuuba_web/live/admin_live.ex:552
+#: lib/abuuba_web/live/settings_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "None yet."
 msgstr "Noch keins."
 
-#: lib/abuuba_web/live/settings_live.ex:2054
+#: lib/abuuba_web/live/settings_live.ex:2061
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr "Ein Bild auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:343
+#: lib/abuuba_web/live/settings_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr "Bilder"
 
-#: lib/abuuba_web/live/settings_live.ex:395
+#: lib/abuuba_web/live/settings_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "Take it off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2052
-#: lib/abuuba_web/live/settings_live.ex:2213
+#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2214
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr "Damit kann dieser Server nichts anfangen. Versuch es mit JPEG, PNG, GIF oder WebP."
 
-#: lib/abuuba_web/live/settings_live.ex:2208
-#: lib/abuuba_web/live/settings_live.ex:2215
+#: lib/abuuba_web/live/settings_live.ex:2209
+#: lib/abuuba_web/live/settings_live.ex:2216
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr "Dieses Bild konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2049
+#: lib/abuuba_web/live/settings_live.ex:2056
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr "Dieses Bild ist zu groß. Die Grenze steht eine Zeile weiter oben."
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr "Auf meinem Profil hervorheben"
 
-#: lib/abuuba_web/live/profile_live.ex:322
-#: lib/abuuba_web/live/profile_live.ex:326
+#: lib/abuuba_web/live/profile_live.ex:313
+#: lib/abuuba_web/live/profile_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Featured accounts"
 msgstr "Hervorgehobene Konten"
 
-#: lib/abuuba_web/live/profile_live.ex:182
+#: lib/abuuba_web/live/profile_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr "Nicht mehr hervorheben"
 
-#: lib/abuuba_web/live/profile_live.ex:555
+#: lib/abuuba_web/live/profile_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr "Schau in dieses Postfach: Dort liegt eine Nachricht mit der Bitte um Bestätigung."
 
-#: lib/abuuba_web/live/profile_live.ex:276
+#: lib/abuuba_web/live/profile_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr "Neuigkeiten von %{name} per E-Mail"
 
-#: lib/abuuba_web/live/settings_live.ex:679
+#: lib/abuuba_web/live/settings_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr "Geht an jede bestätigte Adresse, mit einem Link, der die Neuigkeiten beendet. Bis zu %{count} Nachrichten am Tag."
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr "Kein Konto nötig. Wir schreiben einmal an die Adresse, um zu prüfen, ob sie dir gehört, und in jeder Nachricht steht ein Link, der die Neuigkeiten beendet."
 
-#: lib/abuuba_web/live/settings_live.ex:704
+#: lib/abuuba_web/live/settings_live.ex:705
 #, elixir-autogen, elixir-format
 msgid "Send it"
 msgstr "Abschicken"
 
-#: lib/abuuba_web/live/profile_live.ex:295
+#: lib/abuuba_web/live/profile_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr "Neuigkeiten schicken"
 
-#: lib/abuuba_web/live/settings_live.ex:713
+#: lib/abuuba_web/live/settings_live.ex:714
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] "Am %{date} an eine Adresse geschickt."
 msgstr[1] "Am %{date} an %{count} Adressen geschickt."
 
-#: lib/abuuba_web/live/settings_live.ex:690
-#: lib/abuuba_web/live/settings_live.ex:1781
+#: lib/abuuba_web/live/settings_live.ex:691
+#: lib/abuuba_web/live/settings_live.ex:1788
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Betreff"
 
-#: lib/abuuba_web/live/profile_live.ex:558
+#: lib/abuuba_web/live/profile_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr "Das sieht nicht nach einer gültigen E-Mail-Adresse aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1367
+#: lib/abuuba_web/live/settings_live.ex:1368
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr "Diese Liste ist nicht offen."
@@ -5081,17 +5078,17 @@ msgstr "Diese Liste ist nicht offen."
 msgid "To stop them, open this link:"
 msgstr "Zum Beenden diesen Link öffnen:"
 
-#: lib/abuuba_web/live/profile_live.ex:545
+#: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr "Gerade zu viele Versuche von hier. Bitte später noch einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:697
+#: lib/abuuba_web/live/settings_live.ex:698
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr "Was du ihnen sagen möchtest"
 
-#: lib/abuuba_web/live/settings_live.ex:677
+#: lib/abuuba_web/live/settings_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr "An sie schreiben"
@@ -5101,253 +5098,253 @@ msgstr "An sie schreiben"
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr "Du bekommst das, weil du auf %{site} um Neuigkeiten von %{name} gebeten hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1372
+#: lib/abuuba_web/live/settings_live.ex:1373
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr "Du hast heute schon so viele Nachrichten geschickt, wie du kannst."
 
-#: lib/abuuba_web/live/profile_live.ex:288
+#: lib/abuuba_web/live/profile_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr "du@example.com"
 
-#: lib/abuuba_web/live/settings_live.ex:1782
+#: lib/abuuba_web/live/settings_live.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
 
-#: lib/abuuba_web/live/settings_live.ex:720
+#: lib/abuuba_web/live/settings_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr "Unterwegs."
 
-#: lib/abuuba_web/live/admin_live.ex:2421
+#: lib/abuuba_web/live/admin_live.ex:2423
 #, elixir-autogen, elixir-format
 msgid "A preset needs both."
 msgstr "Ein Baustein braucht beides."
 
-#: lib/abuuba_web/live/admin_live.ex:492
-#: lib/abuuba_web/live/admin_live.ex:708
+#: lib/abuuba_web/live/admin_live.ex:494
+#: lib/abuuba_web/live/admin_live.ex:710
 #, elixir-autogen, elixir-format
 msgid "Add it"
 msgstr "Hinzufügen"
 
-#: lib/abuuba_web/live/admin_live.ex:568
+#: lib/abuuba_web/live/admin_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "All of them"
 msgstr "Alle"
 
-#: lib/abuuba_web/live/admin_live.ex:566
+#: lib/abuuba_web/live/admin_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Dealt with"
 msgstr "Erledigt"
 
-#: lib/abuuba_web/live/admin_live.ex:775
+#: lib/abuuba_web/live/admin_live.ex:777
 #, elixir-autogen, elixir-format
 msgid "Do it to all of them"
 msgstr "Auf alle anwenden"
 
-#: lib/abuuba_web/live/admin_live.ex:627
+#: lib/abuuba_web/live/admin_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Filed as %{category} on %{date}."
 msgstr "Am %{date} unter %{category} gemeldet."
 
-#: lib/abuuba_web/live/admin_live.ex:685
+#: lib/abuuba_web/live/admin_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "For whoever picks this up next. The person reported never sees any of it, and neither does whoever filed it."
 msgstr "Für die Person, die das als Nächstes übernimmt. Weder die gemeldete Person noch die meldende sieht davon etwas."
 
-#: lib/abuuba_web/live/admin_live.ex:661
+#: lib/abuuba_web/live/admin_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "I am on this"
 msgstr "Ich kümmere mich"
 
-#: lib/abuuba_web/live/admin_live.ex:2171
+#: lib/abuuba_web/live/admin_live.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr "Speichern"
 
-#: lib/abuuba_web/live/admin_live.ex:3298
+#: lib/abuuba_web/live/admin_live.ex:3295
 #, elixir-autogen, elixir-format
 msgid "Limit them"
 msgstr "Einschränken"
 
-#: lib/abuuba_web/live/admin_live.ex:670
+#: lib/abuuba_web/live/admin_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "Mark it dealt with"
 msgstr "Als erledigt markieren"
 
-#: lib/abuuba_web/live/admin_live.ex:599
+#: lib/abuuba_web/live/admin_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Nothing waiting."
 msgstr "Nichts offen."
 
-#: lib/abuuba_web/live/admin_live.ex:853
+#: lib/abuuba_web/live/admin_live.ex:855
 #, elixir-autogen, elixir-format
 msgid "Nothing, I will write it"
 msgstr "Nichts, ich schreibe selbst"
 
-#: lib/abuuba_web/live/admin_live.ex:755
+#: lib/abuuba_web/live/admin_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "One account ticked."
 msgid_plural "%{count} accounts ticked."
 msgstr[0] "Ein Konto ausgewählt."
 msgstr[1] "%{count} Konten ausgewählt."
 
-#: lib/abuuba_web/live/admin_live.ex:679
+#: lib/abuuba_web/live/admin_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Put it back in the queue"
 msgstr "Zurück in die Warteschlange"
 
-#: lib/abuuba_web/live/admin_live.ex:2153
+#: lib/abuuba_web/live/admin_live.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Ready-made texts a moderator picks instead of retyping. Kept for the server rather than for one moderator, so two people writing about the same thing say the same thing."
 msgstr "Fertige Texte, die man auswählt, statt sie neu zu tippen. Sie gehören zum Server und nicht zu einer einzelnen moderierenden Person, damit zwei Leute zur selben Sache dasselbe schreiben."
 
-#: lib/abuuba_web/live/admin_live.ex:3373
+#: lib/abuuba_web/live/admin_live.ex:3367
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr "Meldung"
 
-#: lib/abuuba_web/live/admin_live.ex:576
+#: lib/abuuba_web/live/admin_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Report %{id}"
 msgstr "Meldung %{id}"
 
-#: lib/abuuba_web/live/admin_live.ex:3371
+#: lib/abuuba_web/live/admin_live.ex:3365
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr "Meldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:851
+#: lib/abuuba_web/live/admin_live.ex:853
 #, elixir-autogen, elixir-format
 msgid "Start from"
 msgstr "Ausgehen von"
 
-#: lib/abuuba_web/live/admin_live.ex:564
+#: lib/abuuba_web/live/admin_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "Still open"
 msgstr "Noch offen"
 
-#: lib/abuuba_web/live/admin_live.ex:3300
+#: lib/abuuba_web/live/admin_live.ex:3297
 #, elixir-autogen, elixir-format
 msgid "Stop them signing in"
 msgstr "Anmeldung sperren"
 
-#: lib/abuuba_web/live/admin_live.ex:3299
+#: lib/abuuba_web/live/admin_live.ex:3296
 #, elixir-autogen, elixir-format
 msgid "Suspend them"
 msgstr "Sperren"
 
-#: lib/abuuba_web/live/admin_live.ex:637
+#: lib/abuuba_web/live/admin_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "The posts it names"
 msgstr "Die genannten Beiträge"
 
-#: lib/abuuba_web/live/admin_live.ex:768
+#: lib/abuuba_web/live/admin_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "This does the same thing to one account and tells them. Go ahead?"
 msgid_plural "This does the same thing to all %{count} accounts and tells each of them. Go ahead?"
 msgstr[0] "Das tut dasselbe mit einem Konto und teilt es ihm mit. Fortfahren?"
 msgstr[1] "Das tut dasselbe mit allen %{count} Konten und teilt es jedem einzeln mit. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:786
+#: lib/abuuba_web/live/admin_live.ex:788
 #, elixir-autogen, elixir-format
 msgid "Tick %{name}"
 msgstr "%{name} auswählen"
 
-#: lib/abuuba_web/live/admin_live.ex:753
+#: lib/abuuba_web/live/admin_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Tick some accounts to do one thing to all of them."
 msgstr "Konten auswählen, um dasselbe mit allen zu tun."
 
-#: lib/abuuba_web/live/admin_live.ex:2151
+#: lib/abuuba_web/live/admin_live.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Warning presets"
 msgstr "Verwarnungs-Bausteine"
 
-#: lib/abuuba_web/live/admin_live.ex:2168
+#: lib/abuuba_web/live/admin_live.ex:2170
 #, elixir-autogen, elixir-format
 msgid "What it says"
 msgstr "Was darin steht"
 
-#: lib/abuuba_web/live/admin_live.ex:683
+#: lib/abuuba_web/live/admin_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "What moderators have written here"
 msgstr "Was die Moderation hier notiert hat"
 
-#: lib/abuuba_web/live/admin_live.ex:705
+#: lib/abuuba_web/live/admin_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "What you found"
 msgstr "Was du herausgefunden hast"
 
-#: lib/abuuba_web/live/admin_live.ex:562
+#: lib/abuuba_web/live/admin_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Which ones"
 msgstr "Welche"
 
-#: lib/abuuba_web/live/admin_live.ex:580
+#: lib/abuuba_web/live/admin_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "about"
 msgstr "über"
 
-#: lib/abuuba_web/live/admin_live.ex:587
+#: lib/abuuba_web/live/admin_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "dealt with"
 msgstr "erledigt"
 
-#: lib/abuuba_web/live/admin_live.ex:580
-#: lib/abuuba_web/live/admin_live.ex:622
+#: lib/abuuba_web/live/admin_live.ex:582
+#: lib/abuuba_web/live/admin_live.ex:624
 #, elixir-autogen, elixir-format
 msgid "from"
 msgstr "von"
 
-#: lib/abuuba_web/live/admin_live.ex:3316
+#: lib/abuuba_web/live/admin_live.ex:3313
 #, elixir-autogen, elixir-format
 msgid "somebody who is gone"
 msgstr "jemand, den es nicht mehr gibt"
 
-#: lib/abuuba_web/live/admin_live.ex:589
+#: lib/abuuba_web/live/admin_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "taken"
 msgstr "übernommen"
 
-#: lib/abuuba_web/live/admin_live.ex:3275
+#: lib/abuuba_web/live/admin_live.ex:3272
 #, elixir-autogen, elixir-format
 msgid "One account could not be changed."
 msgid_plural "%{count} accounts could not be changed."
 msgstr[0] "Ein Konto konnte nicht geändert werden."
 msgstr[1] "%{count} Konten konnten nicht geändert werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3268
+#: lib/abuuba_web/live/admin_live.ex:3265
 #, elixir-autogen, elixir-format
 msgid "One account was left alone because it outranks yours."
 msgid_plural "%{count} accounts were left alone because they outrank yours."
 msgstr[0] "Ein Konto blieb unangetastet, weil es über deinem steht."
 msgstr[1] "%{count} Konten blieben unangetastet, weil sie über deinem stehen."
 
-#: lib/abuuba_web/live/admin_live.ex:603
+#: lib/abuuba_web/live/admin_live.ex:605
 #, elixir-autogen, elixir-format
 msgid "Showing the newest %{count}. Deal with some to see the ones that have waited longest."
 msgstr "Es werden die neuesten %{count} gezeigt. Arbeite welche ab, um die am längsten wartenden zu sehen."
 
-#: lib/abuuba_web/live/admin_live.ex:3233
+#: lib/abuuba_web/live/admin_live.ex:3230
 #, elixir-autogen, elixir-format
 msgid "That is not something this list can do."
 msgstr "Das kann diese Liste nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:642
+#: lib/abuuba_web/live/admin_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Warning:"
 msgstr "Warnung:"
 
-#: lib/abuuba_web/live/admin_live.ex:182
-#: lib/abuuba_web/live/admin_live.ex:186
+#: lib/abuuba_web/live/admin_live.ex:183
+#: lib/abuuba_web/live/admin_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Your account may not do that."
 msgstr "Dein Konto darf das nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:648
+#: lib/abuuba_web/live/admin_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "has pictures or video"
 msgstr "mit Bild oder Video"
@@ -5402,7 +5399,7 @@ msgstr "Deine Unterhaltungen als gelesen markieren"
 msgid "Mute and unmute people for you"
 msgstr "Leute für dich stummschalten und wieder lautstellen"
 
-#: lib/abuuba_web/live/settings_live.ex:959
+#: lib/abuuba_web/live/settings_live.ex:960
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr "Nichts. Sie sieht nur, dass du angemeldet bist, sonst nichts."
@@ -5457,115 +5454,115 @@ msgstr "Gefiltert: %{title}"
 msgid "Show anyway"
 msgstr "Trotzdem anzeigen"
 
-#: lib/abuuba_web/live/admin_live.ex:488
+#: lib/abuuba_web/live/admin_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "A PNG or a GIF, at most %{size}."
 msgstr "Ein PNG oder ein GIF, höchstens %{size}."
 
-#: lib/abuuba_web/live/admin_live.ex:3200
+#: lib/abuuba_web/live/admin_live.ex:3197
 #, elixir-autogen, elixir-format
 msgid "A shortcode is letters, numbers and underscores, and nothing else."
 msgstr "Ein Kurzname besteht aus Buchstaben, Ziffern und Unterstrichen, sonst nichts."
 
-#: lib/abuuba_web/live/admin_live.ex:3136
-#: lib/abuuba_web/live/admin_live.ex:3182
+#: lib/abuuba_web/live/admin_live.ex:3133
+#: lib/abuuba_web/live/admin_live.ex:3179
 #, elixir-autogen, elixir-format
 msgid "An emoji has to be a PNG or a GIF."
 msgstr "Ein Emoji muss ein PNG oder ein GIF sein."
 
-#: lib/abuuba_web/live/admin_live.ex:3126
-#: lib/abuuba_web/live/admin_live.ex:3160
+#: lib/abuuba_web/live/admin_live.ex:3123
+#: lib/abuuba_web/live/admin_live.ex:3157
 #, elixir-autogen, elixir-format
 msgid "Choose a picture for it."
 msgstr "Wähle ein Bild dafür aus."
 
-#: lib/abuuba_web/live/admin_live.ex:3372
+#: lib/abuuba_web/live/admin_live.ex:3366
 #, elixir-autogen, elixir-format
 msgid "Custom emoji"
 msgstr "Eigene Emojis"
 
-#: lib/abuuba_web/live/admin_live.ex:541
+#: lib/abuuba_web/live/admin_live.ex:543
 #, elixir-autogen, elixir-format
 msgid "Every post that used it loses its picture. Go ahead?"
 msgstr "Jeder Beitrag, der es benutzt hat, verliert sein Bild. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:479
+#: lib/abuuba_web/live/admin_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Group it under"
 msgstr "Einordnen unter"
 
-#: lib/abuuba_web/live/admin_live.ex:516
+#: lib/abuuba_web/live/admin_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "Offer it"
 msgstr "Anbieten"
 
-#: lib/abuuba_web/live/admin_live.ex:466
+#: lib/abuuba_web/live/admin_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Pictures people here can type into a post by name. One uploaded here is held on this server, so it outlives whoever made it."
 msgstr "Bilder, die man hier über ihren Namen in einen Beitrag schreiben kann. Ein hier hochgeladenes liegt auf diesem Server und überlebt damit den, von dem es stammt."
 
-#: lib/abuuba_web/live/admin_live.ex:474
+#: lib/abuuba_web/live/admin_live.ex:476
 #, elixir-autogen, elixir-format
 msgid "Shortcode"
 msgstr "Kurzname"
 
-#: lib/abuuba_web/live/admin_live.ex:515
+#: lib/abuuba_web/live/admin_live.ex:517
 #, elixir-autogen, elixir-format
 msgid "Stop offering it"
 msgstr "Nicht mehr anbieten"
 
-#: lib/abuuba_web/live/admin_live.ex:3202
+#: lib/abuuba_web/live/admin_live.ex:3199
 #, elixir-autogen, elixir-format
 msgid "That emoji could not be saved."
 msgstr "Dieses Emoji konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3188
+#: lib/abuuba_web/live/admin_live.ex:3185
 #, elixir-autogen, elixir-format
 msgid "That picture could not be stored."
 msgstr "Dieses Bild konnte nicht abgelegt werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3142
+#: lib/abuuba_web/live/admin_live.ex:3139
 #, elixir-autogen, elixir-format
 msgid "That picture could not be used."
 msgstr "Dieses Bild konnte nicht verwendet werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3139
-#: lib/abuuba_web/live/admin_live.ex:3185
+#: lib/abuuba_web/live/admin_live.ex:3136
+#: lib/abuuba_web/live/admin_live.ex:3182
 #, elixir-autogen, elixir-format
 msgid "That picture is too large for an emoji."
 msgstr "Dieses Bild ist zu groß für ein Emoji."
 
-#: lib/abuuba_web/live/admin_live.ex:485
+#: lib/abuuba_web/live/admin_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "The picture"
 msgstr "Das Bild"
 
-#: lib/abuuba_web/live/admin_live.ex:3123
+#: lib/abuuba_web/live/admin_live.ex:3120
 #, elixir-autogen, elixir-format
 msgid "The picture is still uploading. Try again in a moment."
 msgstr "Das Bild wird noch hochgeladen. Gleich noch einmal versuchen."
 
-#: lib/abuuba_web/live/admin_live.ex:503
+#: lib/abuuba_web/live/admin_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "not offered"
 msgstr "nicht angeboten"
 
-#: lib/abuuba_web/live/profile_live.ex:245
+#: lib/abuuba_web/live/profile_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr "Keine auszuwählen heißt: alles, was sie schreiben."
 
-#: lib/abuuba_web/live/profile_live.ex:243
+#: lib/abuuba_web/live/profile_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr "Nur diese Sprachen"
 
-#: lib/abuuba_web/live/profile_live.ex:222
+#: lib/abuuba_web/live/profile_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr "Ihre Weitergaben anderer Leute"
 
-#: lib/abuuba_web/live/profile_live.ex:207
+#: lib/abuuba_web/live/profile_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr "Was du von ihnen siehst"
@@ -5590,12 +5587,12 @@ msgstr "Beendet die Benachrichtigungen und nimmt sie aus deiner Timeline. Nieman
 msgid "Unmute this conversation"
 msgstr "Stummschaltung dieser Unterhaltung aufheben"
 
-#: lib/abuuba_web/live/notifications_live.ex:453
+#: lib/abuuba_web/live/notifications_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr "Beiträge von Leuten, die du beobachtest"
 
-#: lib/abuuba_web/live/profile_live.ex:237
+#: lib/abuuba_web/live/profile_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr "Sag mir Bescheid, wenn sie etwas posten"
@@ -5630,146 +5627,146 @@ msgstr "Dein Konto hat eine Verwarnung der Moderation erhalten"
 msgid "Your year on this server is ready to read"
 msgstr "Dein Jahr auf diesem Server ist fertig zum Lesen"
 
-#: lib/abuuba_web/live/notifications_live.ex:448
+#: lib/abuuba_web/live/notifications_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Quotes"
 msgstr "Zitate"
 
-#: lib/abuuba_web/live/admin_live.ex:2017
+#: lib/abuuba_web/live/admin_live.ex:2019
 #, elixir-autogen, elixir-format
 msgid "Days to keep other servers' files"
 msgstr "Tage, die Dateien anderer Server bleiben"
 
-#: lib/abuuba_web/live/admin_live.ex:2026
+#: lib/abuuba_web/live/admin_live.ex:2028
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them indefinitely. Anything older goes off this server's disk each night. The posts stay, and a file is fetched again if somebody opens it."
 msgstr "Null behält sie unbegrenzt. Alles Ältere verschwindet jede Nacht von der Platte dieses Servers. Die Beiträge bleiben, und eine Datei wird neu geholt, wenn jemand sie öffnet."
 
-#: lib/abuuba_web/live/admin_live.ex:528
+#: lib/abuuba_web/live/admin_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Every post that used it loses its picture until you turn it back on. Go ahead?"
 msgstr "Jeder Beitrag, der es benutzt hat, verliert sein Bild, bis du es wieder einschaltest. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:501
+#: lib/abuuba_web/live/admin_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "turned off"
 msgstr "ausgeschaltet"
 
-#: lib/abuuba_web/live/conversations_live.ex:97
+#: lib/abuuba_web/live/conversations_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Mark unread"
 msgstr "Als ungelesen markieren"
 
 #: lib/abuuba_web/components/layouts.ex:239
-#: lib/abuuba_web/live/conversations_live.ex:44
-#: lib/abuuba_web/live/conversations_live.ex:60
+#: lib/abuuba_web/live/conversations_live.ex:45
+#: lib/abuuba_web/live/conversations_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/abuuba_web/live/conversations_live.ex:63
+#: lib/abuuba_web/live/conversations_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. A post addressed to only the people you name arrives as a message, and its replies stay with it."
 msgstr "Hier ist noch nichts. Ein Beitrag an „nur die Erwähnten“ kommt als Nachricht an, und seine Antworten bleiben bei ihm."
 
-#: lib/abuuba_web/live/conversations_live.ex:82
+#: lib/abuuba_web/live/conversations_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Open the conversation with %{people}"
 msgstr "Das Gespräch mit %{people} öffnen"
 
-#: lib/abuuba_web/live/conversations_live.ex:224
+#: lib/abuuba_web/live/conversations_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "The last message has been deleted."
 msgstr "Die letzte Nachricht wurde gelöscht."
 
-#: lib/abuuba_web/live/conversations_live.ex:105
+#: lib/abuuba_web/live/conversations_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "This takes it out of your inbox only. Nobody else loses anything, and a later message brings it back. Go ahead?"
 msgstr "Das nimmt es nur aus deinem Posteingang. Niemand sonst verliert etwas, und eine spätere Nachricht holt es zurück. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:2033
+#: lib/abuuba_web/live/admin_live.ex:2035
 #, elixir-autogen, elixir-format
 msgid "Days to keep other servers' posts"
 msgstr "Tage, die Beiträge anderer Server bleiben"
 
-#: lib/abuuba_web/live/admin_live.ex:2042
+#: lib/abuuba_web/live/admin_live.ex:2044
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them for ever. Anything older is deleted each night, except a post somebody here favourited, bookmarked, pinned, boosted, quoted, replied to or was mentioned in."
 msgstr "Null behält sie für immer. Alles Ältere wird jede Nacht gelöscht, außer einem Beitrag, den hier jemand favorisiert, als Lesezeichen gesetzt, angeheftet, geteilt, zitiert oder beantwortet hat oder in dem jemand von hier erwähnt wird."
 
-#: lib/abuuba_web/live/admin_live.ex:1917
+#: lib/abuuba_web/live/admin_live.ex:1919
 #, elixir-autogen, elixir-format
 msgid "The longer version, for the about page"
 msgstr "Die längere Fassung, für die Über-Seite"
 
-#: lib/abuuba_web/live/admin_live.ex:1968
-#: lib/abuuba_web/live/admin_live.ex:1977
+#: lib/abuuba_web/live/admin_live.ex:1970
+#: lib/abuuba_web/live/admin_live.ex:1979
 #, elixir-autogen, elixir-format
 msgid "Anybody, including people with no account"
 msgstr "Alle, auch ohne Konto"
 
-#: lib/abuuba_web/live/admin_live.ex:1983
+#: lib/abuuba_web/live/admin_live.ex:1985
 #, elixir-autogen, elixir-format
 msgid "Nobody: turn them off"
 msgstr "Niemand: ganz abschalten"
 
-#: lib/abuuba_web/live/admin_live.ex:1965
-#: lib/abuuba_web/live/admin_live.ex:1980
+#: lib/abuuba_web/live/admin_live.ex:1967
+#: lib/abuuba_web/live/admin_live.ex:1982
 #, elixir-autogen, elixir-format
 msgid "Only people signed in here"
 msgstr "Nur hier angemeldete Personen"
 
-#: lib/abuuba_web/live/admin_live.ex:1974
+#: lib/abuuba_web/live/admin_live.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Who may read the public timelines"
 msgstr "Wer die öffentlichen Timelines lesen darf"
 
-#: lib/abuuba_web/live/admin_live.ex:1949
+#: lib/abuuba_web/live/admin_live.ex:1951
 #, elixir-autogen, elixir-format
 msgid "The privacy policy takes effect on"
 msgstr "Die Datenschutzerklärung gilt ab"
 
-#: lib/abuuba_web/live/admin_live.ex:1933
+#: lib/abuuba_web/live/admin_live.ex:1935
 #, elixir-autogen, elixir-format
 msgid "The account to write to"
 msgstr "Das Konto, an das man schreiben kann"
 
-#: lib/abuuba_web/live/admin_live.ex:1938
+#: lib/abuuba_web/live/admin_live.ex:1940
 #, elixir-autogen, elixir-format
 msgid "a username on this server"
 msgstr "ein Benutzername auf diesem Server"
 
-#: lib/abuuba_web/live/admin_live.ex:1922
+#: lib/abuuba_web/live/admin_live.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Status page"
 msgstr "Statusseite"
 
-#: lib/abuuba_web/live/admin_live.ex:1962
+#: lib/abuuba_web/live/admin_live.ex:1964
 #, elixir-autogen, elixir-format
 msgid "Nobody: the server does not say"
 msgstr "Niemand: der Server sagt es nicht"
 
-#: lib/abuuba_web/live/admin_live.ex:1959
+#: lib/abuuba_web/live/admin_live.ex:1961
 #, elixir-autogen, elixir-format
 msgid "Who may read the blocklist"
 msgstr "Wer die Sperrliste lesen darf"
 
-#: lib/abuuba_web/live/settings_live.ex:634
+#: lib/abuuba_web/live/settings_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr "Eine Domain pro Zeile. Wird hier ein Link auf eine dieser Seiten geteilt, weist die Vorschau dich als Urheberin oder Urheber aus. Eine Seite, die du nicht eingetragen hast, kann dich nicht für sich beanspruchen, egal was in ihrer Seitenquelle steht."
 
-#: lib/abuuba_web/live/settings_live.ex:626
+#: lib/abuuba_web/live/settings_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr "Seiten, die mich als Autorin oder Autor nennen dürfen"
 
-#: lib/abuuba_web/live/settings_live.ex:838
+#: lib/abuuba_web/live/settings_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "Block a server"
 msgstr "Server blockieren"
 
-#: lib/abuuba_web/live/settings_live.ex:811
+#: lib/abuuba_web/live/settings_live.ex:812
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht deine Timelines, deine Suche, deine Threads oder deine Benachrichtigungen. Folge-Beziehungen in beide Richtungen werden aufgelöst, genau wie beim Blockieren einer einzelnen Person."
@@ -5779,83 +5776,68 @@ msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht d
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr "Zu viele Anmeldungen von hier im Moment. Bitte versuche es später noch einmal."
 
-#: lib/abuuba_web/live/explore_live.ex:148
-#: lib/abuuba_web/live/profile_live.ex:596
+#: lib/abuuba_web/live/explore_live.ex:144
+#: lib/abuuba_web/live/profile_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr "Zu viele Follows für heute. Versuche es morgen noch einmal."
 
-#: lib/abuuba_web/live/admin_live.ex:3361
+#: lib/abuuba_web/live/admin_live.ex:3355
 #, elixir-autogen, elixir-format
 msgid "Account disabled"
 msgstr "Konto deaktiviert"
 
-#: lib/abuuba_web/live/admin_live.ex:3364
+#: lib/abuuba_web/live/admin_live.ex:3358
 #, elixir-autogen, elixir-format
 msgid "Account limited"
 msgstr "Konto eingeschränkt"
 
-#: lib/abuuba_web/live/admin_live.ex:3365
+#: lib/abuuba_web/live/admin_live.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Account suspended"
 msgstr "Konto gesperrt"
 
-#: lib/abuuba_web/live/admin_live.ex:3374
+#: lib/abuuba_web/live/admin_live.ex:3368
 #, elixir-autogen, elixir-format
 msgid "Appeals"
 msgstr "Einsprüche"
 
-#: lib/abuuba_web/live/admin_live.ex:1379
+#: lib/abuuba_web/live/admin_live.ex:1381
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting. Appeals against a strike show up here."
 msgstr "Es wartet nichts. Einsprüche gegen eine Maßnahme erscheinen hier."
 
-#: lib/abuuba_web/live/admin_live.ex:3363
+#: lib/abuuba_web/live/admin_live.ex:3357
 #, elixir-autogen, elixir-format
 msgid "Posts deleted"
 msgstr "Beiträge gelöscht"
 
-#: lib/abuuba_web/live/admin_live.ex:3362
+#: lib/abuuba_web/live/admin_live.ex:3356
 #, elixir-autogen, elixir-format
 msgid "Posts marked sensitive"
 msgstr "Beiträge als sensibel markiert"
 
-#: lib/abuuba_web/live/admin_live.ex:1338
+#: lib/abuuba_web/live/admin_live.ex:1340
 #, elixir-autogen, elixir-format
 msgid "Somebody who was warned, silenced or suspended saying it was a mistake. Upholding an appeal undoes the action where it can be undone; where it cannot, the appeal is still recorded as upheld. Either way the account's owner is told."
 msgstr "Jemand, der verwarnt, eingeschränkt oder gesperrt wurde und sagt, dass das ein Fehler war. Wird einem Einspruch stattgegeben, wird die Maßnahme rückgängig gemacht, soweit das geht; wo nicht, gilt der Einspruch trotzdem als angenommen. In beiden Fällen wird die Person benachrichtigt."
 
-#: lib/abuuba_web/live/admin_live.ex:3073
+#: lib/abuuba_web/live/admin_live.ex:3070
 #, elixir-autogen, elixir-format
 msgid "That appeal is no longer waiting."
 msgstr "Dieser Einspruch wartet nicht mehr."
 
-#: lib/abuuba_web/live/admin_live.ex:1372
+#: lib/abuuba_web/live/admin_live.ex:1374
 #, elixir-autogen, elixir-format
 msgid "Turn down"
 msgstr "Ablehnen"
 
-#: lib/abuuba_web/live/admin_live.ex:1364
+#: lib/abuuba_web/live/admin_live.ex:1366
 #, elixir-autogen, elixir-format
 msgid "Uphold and undo"
 msgstr "Stattgeben und rückgängig machen"
 
-#: lib/abuuba_web/live/admin_live.ex:3360
+#: lib/abuuba_web/live/admin_live.ex:3354
 #, elixir-autogen, elixir-format
 msgid "Warned"
 msgstr "Verwarnt"
-
-#: lib/abuuba_web/live/profile_live.ex:155
-#, elixir-autogen, elixir-format
-msgid "Cancel follow request"
-msgstr "Folgeanfrage zurückziehen"
-
-#: lib/abuuba_web/live/explore_live.ex:117
-#, elixir-autogen, elixir-format
-msgid "Requested"
-msgstr "Angefragt"
-
-#: lib/abuuba_web/live/profile_live.ex:606
-#, elixir-autogen, elixir-format
-msgid "This account approves its followers. Your request is waiting for an answer."
-msgstr "Dieses Konto bestätigt seine Follower selbst. Deine Anfrage wartet auf eine Antwort."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -656,7 +656,7 @@ msgstr "Diese Anfrage muss signiert sein."
 
 #: lib/abuuba_web/components/layouts.ex:243
 #: lib/abuuba_web/components/layouts.ex:252
-#: lib/abuuba_web/live/explore_live.ex:50
+#: lib/abuuba_web/live/explore_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr "Entdecken"
@@ -690,7 +690,7 @@ msgstr "Hauptnavigation"
 
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
-#: lib/abuuba_web/live/notifications_live.ex:57
+#: lib/abuuba_web/live/notifications_live.ex:59
 #: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -904,7 +904,7 @@ msgid "Ends after"
 msgstr "Endet nach"
 
 #: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/profile_live.ex:866
+#: lib/abuuba_web/live/profile_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr "Follower"
@@ -1206,24 +1206,24 @@ msgstr "oder zieh eine ins Feld oder füg sie ein"
 msgid "%{name} on %{server}"
 msgstr "%{name} auf %{server}"
 
-#: lib/abuuba_web/live/profile_live.ex:301
+#: lib/abuuba_web/live/profile_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr "Eine Notiz, die nur du liest"
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr "Blockieren"
 
-#: lib/abuuba_web/live/explore_live.ex:113
-#: lib/abuuba_web/live/profile_live.ex:146
-#: lib/abuuba_web/live/tag_live.ex:64
+#: lib/abuuba_web/live/explore_live.ex:112
+#: lib/abuuba_web/live/profile_live.ex:144
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
 
-#: lib/abuuba_web/live/profile_live.ex:95
+#: lib/abuuba_web/live/profile_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "Go to the new account"
 msgstr "Zum neuen Konto"
@@ -1233,43 +1233,43 @@ msgstr "Zum neuen Konto"
 msgid "Look for more replies on the other server"
 msgstr "Auf dem anderen Server nach weiteren Antworten suchen"
 
-#: lib/abuuba_web/live/profile_live.ex:865
+#: lib/abuuba_web/live/profile_live.ex:803
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr "Medien"
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr "Stummschalten"
 
-#: lib/abuuba_web/live/profile_live.ex:372
+#: lib/abuuba_web/live/profile_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr "Hier ist noch nichts."
 
-#: lib/abuuba_web/live/profile_live.ex:347
-#: lib/abuuba_web/live/profile_live.ex:348
+#: lib/abuuba_web/live/profile_live.ex:345
+#: lib/abuuba_web/live/profile_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr "Angeheftet"
 
-#: lib/abuuba_web/live/explore_live.ex:304
-#: lib/abuuba_web/live/profile_live.ex:863
+#: lib/abuuba_web/live/explore_live.ex:248
+#: lib/abuuba_web/live/profile_live.ex:801
+#: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
-#: lib/abuuba_web/live/search_live.ex:122
-#: lib/abuuba_web/live/search_live.ex:264
+#: lib/abuuba_web/live/search_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/abuuba_web/live/profile_live.ex:864
+#: lib/abuuba_web/live/profile_live.ex:802
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr "Beiträge und Antworten"
 
 #: lib/abuuba_web/live/admin_live.ex:944
-#: lib/abuuba_web/live/profile_live.ex:305
+#: lib/abuuba_web/live/profile_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr "Notiz speichern"
@@ -1279,24 +1279,24 @@ msgstr "Notiz speichern"
 msgid "That server could not be reached, so this is all there is."
 msgstr "Der Server war nicht erreichbar, mehr gibt es also nicht."
 
-#: lib/abuuba_web/live/profile_live.ex:92
+#: lib/abuuba_web/live/profile_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "This account has moved to %{handle}."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:196
 #: lib/abuuba_web/live/settings_live.ex:827
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr "Blockierung aufheben"
 
-#: lib/abuuba_web/live/profile_live.ex:164
-#: lib/abuuba_web/live/tag_live.ex:64
+#: lib/abuuba_web/live/profile_live.ex:162
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Entfolgen"
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr "Stummschaltung aufheben"
@@ -1306,109 +1306,109 @@ msgstr "Stummschaltung aufheben"
 msgid "Verified"
 msgstr "Bestätigt"
 
-#: lib/abuuba_web/live/profile_live.ex:309
-#: lib/abuuba_web/live/search_live.ex:90
+#: lib/abuuba_web/live/profile_live.ex:307
+#: lib/abuuba_web/live/search_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "What to show"
 msgstr "Was gezeigt wird"
 
-#: lib/abuuba_web/live/notifications_live.ex:84
+#: lib/abuuba_web/live/notifications_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] "%{count} neu"
 msgstr[1] "%{count} neu"
 
-#: lib/abuuba_web/live/notifications_live.ex:134
+#: lib/abuuba_web/live/notifications_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] "%{count} Mitteilung"
 msgstr[1] "%{count} Mitteilungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:381
+#: lib/abuuba_web/live/notifications_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] "%{count} Person hat deinen Beitrag geteilt"
 msgstr[1] "%{count} Leute haben deinen Beitrag geteilt"
 
-#: lib/abuuba_web/live/notifications_live.ex:385
+#: lib/abuuba_web/live/notifications_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] "%{count} Person hat deinen Beitrag favorisiert"
 msgstr[1] "%{count} Leute haben deinen Beitrag favorisiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:392
+#: lib/abuuba_web/live/notifications_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] "%{count} Person folgt dir jetzt"
 msgstr[1] "%{count} Leute folgen dir jetzt"
 
-#: lib/abuuba_web/live/notifications_live.ex:395
+#: lib/abuuba_web/live/notifications_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] "%{count} Person hat dich erwähnt"
 msgstr[1] "%{count} Leute haben dich erwähnt"
 
-#: lib/abuuba_web/live/notifications_live.ex:119
+#: lib/abuuba_web/live/notifications_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] "%{count} Person wartet darauf, dich zu erreichen"
 msgstr[1] "%{count} Leute warten darauf, dich zu erreichen"
 
-#: lib/abuuba_web/live/notifications_live.ex:399
+#: lib/abuuba_web/live/notifications_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] "%{name} und %{count} weitere Person"
 msgstr[1] "%{name} und %{count} weitere Leute"
 
-#: lib/abuuba_web/live/notifications_live.ex:348
+#: lib/abuuba_web/live/notifications_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr "%{name} möchte dir folgen"
 
-#: lib/abuuba_web/live/notifications_live.ex:346
+#: lib/abuuba_web/live/notifications_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "%{name} boosted your post"
 msgstr "%{name} hat deinen Beitrag geteilt"
 
-#: lib/abuuba_web/live/notifications_live.ex:351
+#: lib/abuuba_web/live/notifications_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr "%{name} hat einen Beitrag bearbeitet, den du geteilt hast"
 
-#: lib/abuuba_web/live/notifications_live.ex:349
+#: lib/abuuba_web/live/notifications_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr "%{name} hat deinen Beitrag favorisiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:347
+#: lib/abuuba_web/live/notifications_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr "%{name} folgt dir jetzt"
 
-#: lib/abuuba_web/live/notifications_live.ex:345
+#: lib/abuuba_web/live/notifications_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr "%{name} hat dich erwähnt"
 
-#: lib/abuuba_web/live/notifications_live.ex:352
+#: lib/abuuba_web/live/notifications_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "%{name} posted"
 msgstr "%{name} hat etwas veröffentlicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:353
+#: lib/abuuba_web/live/notifications_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr "%{name} hat deinen Beitrag zitiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:350
+#: lib/abuuba_web/live/notifications_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr "Eine Umfrage von %{name} ist beendet"
@@ -1433,7 +1433,7 @@ msgstr "Konten, die eine Moderation eingeschränkt hat"
 msgid "Accounts made very recently"
 msgstr "Ganz neu angelegte Konten"
 
-#: lib/abuuba_web/live/notifications_live.ex:431
+#: lib/abuuba_web/live/notifications_live.ex:448
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr "Alle"
@@ -1463,17 +1463,17 @@ msgstr "Alle, denen du nicht folgst."
 msgid "Automated accounts"
 msgstr "Automatische Konten"
 
-#: lib/abuuba_web/live/notifications_live.ex:440
+#: lib/abuuba_web/live/notifications_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "Boosts"
 msgstr "Geteilte Beiträge"
 
-#: lib/abuuba_web/live/notifications_live.ex:112
+#: lib/abuuba_web/live/notifications_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr "Alle löschen"
 
-#: lib/abuuba_web/live/notifications_live.ex:179
+#: lib/abuuba_web/live/notifications_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr "Ausblenden"
@@ -1483,12 +1483,12 @@ msgstr "Ausblenden"
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr "Jede Zeile beschreibt eine Art von Absender. Annehmen lässt sie durch, Filtern legt sie in die Warteliste auf deiner Mitteilungsseite, und Ignorieren verwirft sie."
 
-#: lib/abuuba_web/live/notifications_live.ex:445
+#: lib/abuuba_web/live/notifications_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Edits"
 msgstr "Bearbeitungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:443
+#: lib/abuuba_web/live/notifications_live.ex:460
 #, elixir-autogen, elixir-format
 msgid "Favourites"
 msgstr "Favoriten"
@@ -1498,13 +1498,13 @@ msgstr "Favoriten"
 msgid "Filter"
 msgstr "Filtern"
 
-#: lib/abuuba_web/live/notifications_live.ex:442
+#: lib/abuuba_web/live/notifications_live.ex:459
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr "Folgeanfragen"
 
-#: lib/abuuba_web/live/notifications_live.ex:441
-#: lib/abuuba_web/live/profile_live.ex:867
+#: lib/abuuba_web/live/notifications_live.ex:458
+#: lib/abuuba_web/live/profile_live.ex:805
 #: lib/abuuba_web/live/settings_live.ex:2104
 #: lib/abuuba_web/live/settings_live.ex:2242
 #, elixir-autogen, elixir-format
@@ -1521,28 +1521,28 @@ msgstr "Ignorieren"
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr "Bei Ignorieren ist Vorsicht geboten: nichts wird irgendwo abgelegt und es lässt sich nicht wiederherstellen. Filtern ist die umkehrbare Wahl."
 
-#: lib/abuuba_web/live/notifications_live.ex:148
+#: lib/abuuba_web/live/notifications_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr "Durchlassen"
 
-#: lib/abuuba_web/live/notifications_live.ex:108
+#: lib/abuuba_web/live/notifications_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
-#: lib/abuuba_web/live/notifications_live.ex:431
-#: lib/abuuba_web/live/notifications_live.ex:439
+#: lib/abuuba_web/live/notifications_live.ex:448
+#: lib/abuuba_web/live/notifications_live.ex:456
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr "Erwähnungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:157
+#: lib/abuuba_web/live/notifications_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:193
+#: lib/abuuba_web/live/notifications_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr "Es ist noch nichts passiert."
@@ -1557,7 +1557,7 @@ msgstr "Leute, die dir nicht folgen"
 msgid "People you do not follow"
 msgstr "Leute, denen du nicht folgst"
 
-#: lib/abuuba_web/live/notifications_live.ex:444
+#: lib/abuuba_web/live/notifications_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Polls"
 msgstr "Umfragen"
@@ -1573,7 +1573,7 @@ msgstr "Private Erwähnungen aus dem Nichts"
 #: lib/abuuba_web/live/admin_live.ex:1587
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:264
+#: lib/abuuba_web/live/profile_live.ex:262
 #: lib/abuuba_web/live/settings_live.ex:295
 #: lib/abuuba_web/live/settings_live.ex:389
 #: lib/abuuba_web/live/settings_live.ex:426
@@ -1593,8 +1593,8 @@ msgstr "Speichern"
 msgid "Saved."
 msgstr "Gespeichert."
 
-#: lib/abuuba_web/live/notifications_live.ex:343
-#: lib/abuuba_web/live/notifications_live.ex:408
+#: lib/abuuba_web/live/notifications_live.ex:360
+#: lib/abuuba_web/live/notifications_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr "Jemand"
@@ -1604,7 +1604,7 @@ msgstr "Jemand"
 msgid "Somebody a moderator here has already restricted."
 msgstr "Jemand, den eine Moderation hier bereits eingeschränkt hat."
 
-#: lib/abuuba_web/live/notifications_live.ex:378
+#: lib/abuuba_web/live/notifications_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr "Etwas ist passiert, das %{name} betrifft"
@@ -1614,7 +1614,7 @@ msgstr "Etwas ist passiert, das %{name} betrifft"
 msgid "That could not be saved. Try again."
 msgstr "Das konnte nicht gespeichert werden. Versuch es noch einmal."
 
-#: lib/abuuba_web/live/notifications_live.ex:73
+#: lib/abuuba_web/live/notifications_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr "Welche Mitteilungen"
@@ -1624,7 +1624,7 @@ msgstr "Welche Mitteilungen"
 msgid "Who can reach you"
 msgstr "Wer dich erreichen kann"
 
-#: lib/abuuba_web/live/notifications_live.ex:126
+#: lib/abuuba_web/live/notifications_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr "Deine Einstellungen haben diese abgelegt, statt sie zu zeigen."
@@ -1635,22 +1635,22 @@ msgstr "Deine Einstellungen haben diese abgelegt, statt sie zu zeigen."
 msgid "unread"
 msgstr "ungelesen"
 
-#: lib/abuuba_web/live/search_live.ex:67
+#: lib/abuuba_web/live/search_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "A name, a #tag, or some words"
 msgstr "Ein Name, ein #Tag oder ein paar Wörter"
 
 #: lib/abuuba_web/live/admin_live.ex:2277
 #: lib/abuuba_web/live/admin_live.ex:3587
-#: lib/abuuba_web/live/search_live.ex:261
+#: lib/abuuba_web/live/search_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr "Alles"
 
-#: lib/abuuba_web/live/explore_live.ex:305
+#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
-#: lib/abuuba_web/live/search_live.ex:113
-#: lib/abuuba_web/live/search_live.ex:263
+#: lib/abuuba_web/live/search_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Hashtags"
 msgstr "Hashtags"
@@ -1665,7 +1665,7 @@ msgstr "Er läuft mit %{software}, freier Software, die jeder betreiben darf."
 msgid "Look around first"
 msgstr "Erst mal umsehen"
 
-#: lib/abuuba_web/live/search_live.ex:76
+#: lib/abuuba_web/live/search_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Narrowing a search"
 msgstr "Eine Suche eingrenzen"
@@ -1675,25 +1675,25 @@ msgstr "Eine Suche eingrenzen"
 msgid "Nobody has posted publicly here yet."
 msgstr "Hier hat noch niemand öffentlich etwas veröffentlicht."
 
-#: lib/abuuba_web/live/tag_live.ex:79
+#: lib/abuuba_web/live/tag_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted under this tag yet."
 msgstr "Unter diesem Tag hat noch niemand etwas veröffentlicht."
 
-#: lib/abuuba_web/live/explore_live.ex:123
+#: lib/abuuba_web/live/explore_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht haben."
 
-#: lib/abuuba_web/live/search_live.ex:133
+#: lib/abuuba_web/live/search_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Nothing matched that."
 msgstr "Dazu gab es keine Treffer."
 
-#: lib/abuuba_web/live/explore_live.ex:306
+#: lib/abuuba_web/live/explore_live.ex:250
+#: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
-#: lib/abuuba_web/live/search_live.ex:103
-#: lib/abuuba_web/live/search_live.ex:262
+#: lib/abuuba_web/live/search_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr "Leute"
@@ -1720,9 +1720,9 @@ msgstr "Die Registrierung braucht eine Freigabe: du meldest dich an und eine Adm
 
 #: lib/abuuba_web/components/layouts.ex:244
 #: lib/abuuba_web/components/layouts.ex:253
-#: lib/abuuba_web/live/search_live.ex:40
-#: lib/abuuba_web/live/search_live.ex:62
-#: lib/abuuba_web/live/search_live.ex:71
+#: lib/abuuba_web/live/search_live.ex:38
+#: lib/abuuba_web/live/search_live.ex:61
+#: lib/abuuba_web/live/search_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr "Suche"
@@ -1732,27 +1732,27 @@ msgstr "Suche"
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr "Dies ist ein Server im Fediverse: ein Netzwerk unabhängiger Server, deren Leute einander folgen und miteinander reden können, egal auf welchem sie sind. Ein Konto hier kann allen überall darin folgen."
 
-#: lib/abuuba_web/live/explore_live.ex:65
+#: lib/abuuba_web/live/explore_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "What to explore"
 msgstr "Was erkundet wird"
 
-#: lib/abuuba_web/live/search_live.ex:271
+#: lib/abuuba_web/live/search_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "posts by one person"
 msgstr "Beiträge von einer Person"
 
-#: lib/abuuba_web/live/search_live.ex:272
+#: lib/abuuba_web/live/search_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "posts carrying a picture or a poll"
 msgstr "Beiträge mit Bild oder Umfrage"
 
-#: lib/abuuba_web/live/search_live.ex:274
+#: lib/abuuba_web/live/search_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "posts newer than a date"
 msgstr "Beiträge nach einem Datum"
 
-#: lib/abuuba_web/live/search_live.ex:273
+#: lib/abuuba_web/live/search_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "posts older than a date"
 msgstr "Beiträge vor einem Datum"
@@ -2828,7 +2828,7 @@ msgstr "Trends"
 msgid "What is trending now"
 msgstr "Was gerade im Trend liegt"
 
-#: lib/abuuba_web/live/explore_live.ex:77
+#: lib/abuuba_web/live/explore_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr "Worüber gerade mehr Leute als sonst schreiben, danach alles Übrige, das Neueste zuerst."
@@ -3103,12 +3103,9 @@ msgstr "nur mit Freigabe"
 msgid "by %{name}"
 msgstr "von %{name}"
 
-#: lib/abuuba_web/live/explore_live.ex:208
 #: lib/abuuba_web/live/home_live.ex:338
-#: lib/abuuba_web/live/profile_live.ex:529
-#: lib/abuuba_web/live/search_live.ex:195
+#: lib/abuuba_web/live/post_actions.ex:297
 #: lib/abuuba_web/live/status_live.ex:185
-#: lib/abuuba_web/live/tag_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "That could not be translated just now."
 msgstr "Das ließ sich gerade nicht übersetzen."
@@ -4011,7 +4008,7 @@ msgstr "Dein Benutzername bleibt und niemand kann ihn je bekommen, damit alte Li
 msgid "A post"
 msgstr "Ein Beitrag"
 
-#: lib/abuuba_web/live/profile_live.ex:399
+#: lib/abuuba_web/live/profile_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Nobody yet."
 msgstr "Noch niemand."
@@ -4021,7 +4018,7 @@ msgstr "Noch niemand."
 msgid "Public posts tagged #%{tag}"
 msgstr "Öffentliche Beiträge mit #%{tag}"
 
-#: lib/abuuba_web/live/profile_live.ex:376
+#: lib/abuuba_web/live/profile_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr "Dieses Konto behält für sich, wem es folgt und wer ihm folgt."
@@ -5004,28 +5001,28 @@ msgstr "Dieses Bild konnte nicht gespeichert werden."
 msgid "That picture is too large. The limit is on the line above."
 msgstr "Dieses Bild ist zu groß. Die Grenze steht eine Zeile weiter oben."
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr "Auf meinem Profil hervorheben"
 
-#: lib/abuuba_web/live/profile_live.ex:322
-#: lib/abuuba_web/live/profile_live.ex:326
+#: lib/abuuba_web/live/profile_live.ex:320
+#: lib/abuuba_web/live/profile_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "Featured accounts"
 msgstr "Hervorgehobene Konten"
 
-#: lib/abuuba_web/live/profile_live.ex:182
+#: lib/abuuba_web/live/profile_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr "Nicht mehr hervorheben"
 
-#: lib/abuuba_web/live/profile_live.ex:555
+#: lib/abuuba_web/live/profile_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr "Schau in dieses Postfach: Dort liegt eine Nachricht mit der Bitte um Bestätigung."
 
-#: lib/abuuba_web/live/profile_live.ex:276
+#: lib/abuuba_web/live/profile_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr "Neuigkeiten von %{name} per E-Mail"
@@ -5035,7 +5032,7 @@ msgstr "Neuigkeiten von %{name} per E-Mail"
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr "Geht an jede bestätigte Adresse, mit einem Link, der die Neuigkeiten beendet. Bis zu %{count} Nachrichten am Tag."
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr "Kein Konto nötig. Wir schreiben einmal an die Adresse, um zu prüfen, ob sie dir gehört, und in jeder Nachricht steht ein Link, der die Neuigkeiten beendet."
@@ -5045,7 +5042,7 @@ msgstr "Kein Konto nötig. Wir schreiben einmal an die Adresse, um zu prüfen, o
 msgid "Send it"
 msgstr "Abschicken"
 
-#: lib/abuuba_web/live/profile_live.ex:295
+#: lib/abuuba_web/live/profile_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr "Neuigkeiten schicken"
@@ -5063,7 +5060,7 @@ msgstr[1] "Am %{date} an %{count} Adressen geschickt."
 msgid "Subject"
 msgstr "Betreff"
 
-#: lib/abuuba_web/live/profile_live.ex:558
+#: lib/abuuba_web/live/profile_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr "Das sieht nicht nach einer gültigen E-Mail-Adresse aus."
@@ -5078,7 +5075,7 @@ msgstr "Diese Liste ist nicht offen."
 msgid "To stop them, open this link:"
 msgstr "Zum Beenden diesen Link öffnen:"
 
-#: lib/abuuba_web/live/profile_live.ex:545
+#: lib/abuuba_web/live/profile_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr "Gerade zu viele Versuche von hier. Bitte später noch einmal."
@@ -5103,7 +5100,7 @@ msgstr "Du bekommst das, weil du auf %{site} um Neuigkeiten von %{name} gebeten 
 msgid "You have sent as many messages as you can today."
 msgstr "Du hast heute schon so viele Nachrichten geschickt, wie du kannst."
 
-#: lib/abuuba_web/live/profile_live.ex:288
+#: lib/abuuba_web/live/profile_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr "du@example.com"
@@ -5547,22 +5544,22 @@ msgstr "Das Bild wird noch hochgeladen. Gleich noch einmal versuchen."
 msgid "not offered"
 msgstr "nicht angeboten"
 
-#: lib/abuuba_web/live/profile_live.ex:245
+#: lib/abuuba_web/live/profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr "Keine auszuwählen heißt: alles, was sie schreiben."
 
-#: lib/abuuba_web/live/profile_live.ex:243
+#: lib/abuuba_web/live/profile_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr "Nur diese Sprachen"
 
-#: lib/abuuba_web/live/profile_live.ex:222
+#: lib/abuuba_web/live/profile_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr "Ihre Weitergaben anderer Leute"
 
-#: lib/abuuba_web/live/profile_live.ex:207
+#: lib/abuuba_web/live/profile_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr "Was du von ihnen siehst"
@@ -5587,47 +5584,47 @@ msgstr "Beendet die Benachrichtigungen und nimmt sie aus deiner Timeline. Nieman
 msgid "Unmute this conversation"
 msgstr "Stummschaltung dieser Unterhaltung aufheben"
 
-#: lib/abuuba_web/live/notifications_live.ex:451
+#: lib/abuuba_web/live/notifications_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr "Beiträge von Leuten, die du beobachtest"
 
-#: lib/abuuba_web/live/profile_live.ex:237
+#: lib/abuuba_web/live/profile_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr "Sag mir Bescheid, wenn sie etwas posten"
 
-#: lib/abuuba_web/live/notifications_live.ex:370
+#: lib/abuuba_web/live/notifications_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr "%{name} hat deinen Beitrag zu einer Sammlung hinzugefügt"
 
-#: lib/abuuba_web/live/notifications_live.ex:374
+#: lib/abuuba_web/live/notifications_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr "%{name} hat eine Meldung eingereicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:372
+#: lib/abuuba_web/live/notifications_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "%{name} signed up"
 msgstr "%{name} hat sich registriert"
 
-#: lib/abuuba_web/live/notifications_live.ex:363
+#: lib/abuuba_web/live/notifications_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr "Einige deiner Follows wurden entfernt, als dieser Server die Föderation mit einem anderen beendet hat"
 
-#: lib/abuuba_web/live/notifications_live.ex:359
+#: lib/abuuba_web/live/notifications_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr "Dein Konto hat eine Verwarnung der Moderation erhalten"
 
-#: lib/abuuba_web/live/notifications_live.ex:367
+#: lib/abuuba_web/live/notifications_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr "Dein Jahr auf diesem Server ist fertig zum Lesen"
 
-#: lib/abuuba_web/live/notifications_live.ex:446
+#: lib/abuuba_web/live/notifications_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "Quotes"
 msgstr "Zitate"
@@ -5776,8 +5773,8 @@ msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht d
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr "Zu viele Anmeldungen von hier im Moment. Bitte versuche es später noch einmal."
 
-#: lib/abuuba_web/live/explore_live.ex:148
-#: lib/abuuba_web/live/profile_live.ex:596
+#: lib/abuuba_web/live/explore_live.ex:147
+#: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr "Zu viele Follows für heute. Versuche es morgen noch einmal."
@@ -5848,17 +5845,17 @@ msgstr "Verwarnt"
 msgid "%{size} MB"
 msgstr "%{size} MB"
 
-#: lib/abuuba_web/live/profile_live.ex:155
+#: lib/abuuba_web/live/profile_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Cancel follow request"
 msgstr "Folgeanfrage zurückziehen"
 
-#: lib/abuuba_web/live/explore_live.ex:117
+#: lib/abuuba_web/live/explore_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr "Angefragt"
 
-#: lib/abuuba_web/live/profile_live.ex:606
+#: lib/abuuba_web/live/profile_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr "Dieses Konto bestätigt seine Follower selbst. Deine Anfrage wartet auf eine Antwort."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -654,7 +654,7 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:243
 #: lib/abuuba_web/components/layouts.ex:252
-#: lib/abuuba_web/live/explore_live.ex:50
+#: lib/abuuba_web/live/explore_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr ""
@@ -688,7 +688,7 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
-#: lib/abuuba_web/live/notifications_live.ex:57
+#: lib/abuuba_web/live/notifications_live.ex:59
 #: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -902,7 +902,7 @@ msgid "Ends after"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/profile_live.ex:866
+#: lib/abuuba_web/live/profile_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
@@ -1204,24 +1204,24 @@ msgstr ""
 msgid "%{name} on %{server}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:301
+#: lib/abuuba_web/live/profile_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:113
-#: lib/abuuba_web/live/profile_live.ex:146
-#: lib/abuuba_web/live/tag_live.ex:64
+#: lib/abuuba_web/live/explore_live.ex:112
+#: lib/abuuba_web/live/profile_live.ex:144
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:95
+#: lib/abuuba_web/live/profile_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "Go to the new account"
 msgstr ""
@@ -1231,43 +1231,43 @@ msgstr ""
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:865
+#: lib/abuuba_web/live/profile_live.ex:803
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:372
+#: lib/abuuba_web/live/profile_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:347
-#: lib/abuuba_web/live/profile_live.ex:348
+#: lib/abuuba_web/live/profile_live.ex:345
+#: lib/abuuba_web/live/profile_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:304
-#: lib/abuuba_web/live/profile_live.ex:863
+#: lib/abuuba_web/live/explore_live.ex:248
+#: lib/abuuba_web/live/profile_live.ex:801
+#: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
-#: lib/abuuba_web/live/search_live.ex:122
-#: lib/abuuba_web/live/search_live.ex:264
+#: lib/abuuba_web/live/search_live.ex:208
 #, elixir-autogen, elixir-format
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:864
+#: lib/abuuba_web/live/profile_live.ex:802
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:944
-#: lib/abuuba_web/live/profile_live.ex:305
+#: lib/abuuba_web/live/profile_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr ""
@@ -1277,24 +1277,24 @@ msgstr ""
 msgid "That server could not be reached, so this is all there is."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:92
+#: lib/abuuba_web/live/profile_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "This account has moved to %{handle}."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:196
 #: lib/abuuba_web/live/settings_live.ex:827
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:164
-#: lib/abuuba_web/live/tag_live.ex:64
+#: lib/abuuba_web/live/profile_live.ex:162
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
@@ -1304,109 +1304,109 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:309
-#: lib/abuuba_web/live/search_live.ex:90
+#: lib/abuuba_web/live/profile_live.ex:307
+#: lib/abuuba_web/live/search_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "What to show"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:84
+#: lib/abuuba_web/live/notifications_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:134
+#: lib/abuuba_web/live/notifications_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:381
+#: lib/abuuba_web/live/notifications_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:385
+#: lib/abuuba_web/live/notifications_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:392
+#: lib/abuuba_web/live/notifications_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:395
+#: lib/abuuba_web/live/notifications_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:119
+#: lib/abuuba_web/live/notifications_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:399
+#: lib/abuuba_web/live/notifications_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:348
+#: lib/abuuba_web/live/notifications_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:346
+#: lib/abuuba_web/live/notifications_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "%{name} boosted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:351
+#: lib/abuuba_web/live/notifications_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:349
+#: lib/abuuba_web/live/notifications_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:347
+#: lib/abuuba_web/live/notifications_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:345
+#: lib/abuuba_web/live/notifications_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:352
+#: lib/abuuba_web/live/notifications_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "%{name} posted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:353
+#: lib/abuuba_web/live/notifications_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:350
+#: lib/abuuba_web/live/notifications_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr ""
@@ -1431,7 +1431,7 @@ msgstr ""
 msgid "Accounts made very recently"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:431
+#: lib/abuuba_web/live/notifications_live.ex:448
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
@@ -1461,17 +1461,17 @@ msgstr ""
 msgid "Automated accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:440
+#: lib/abuuba_web/live/notifications_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "Boosts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:112
+#: lib/abuuba_web/live/notifications_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:179
+#: lib/abuuba_web/live/notifications_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -1481,12 +1481,12 @@ msgstr ""
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:445
+#: lib/abuuba_web/live/notifications_live.ex:462
 #, elixir-autogen, elixir-format
 msgid "Edits"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:443
+#: lib/abuuba_web/live/notifications_live.ex:460
 #, elixir-autogen, elixir-format
 msgid "Favourites"
 msgstr ""
@@ -1496,13 +1496,13 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:442
+#: lib/abuuba_web/live/notifications_live.ex:459
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:441
-#: lib/abuuba_web/live/profile_live.ex:867
+#: lib/abuuba_web/live/notifications_live.ex:458
+#: lib/abuuba_web/live/profile_live.ex:805
 #: lib/abuuba_web/live/settings_live.ex:2104
 #: lib/abuuba_web/live/settings_live.ex:2242
 #, elixir-autogen, elixir-format
@@ -1519,28 +1519,28 @@ msgstr ""
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:148
+#: lib/abuuba_web/live/notifications_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:108
+#: lib/abuuba_web/live/notifications_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:431
-#: lib/abuuba_web/live/notifications_live.ex:439
+#: lib/abuuba_web/live/notifications_live.ex:448
+#: lib/abuuba_web/live/notifications_live.ex:456
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:157
+#: lib/abuuba_web/live/notifications_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:193
+#: lib/abuuba_web/live/notifications_live.ex:210
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr ""
@@ -1555,7 +1555,7 @@ msgstr ""
 msgid "People you do not follow"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:444
+#: lib/abuuba_web/live/notifications_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Polls"
 msgstr ""
@@ -1571,7 +1571,7 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1587
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:264
+#: lib/abuuba_web/live/profile_live.ex:262
 #: lib/abuuba_web/live/settings_live.ex:295
 #: lib/abuuba_web/live/settings_live.ex:389
 #: lib/abuuba_web/live/settings_live.ex:426
@@ -1591,8 +1591,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:343
-#: lib/abuuba_web/live/notifications_live.ex:408
+#: lib/abuuba_web/live/notifications_live.ex:360
+#: lib/abuuba_web/live/notifications_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr ""
@@ -1602,7 +1602,7 @@ msgstr ""
 msgid "Somebody a moderator here has already restricted."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:378
+#: lib/abuuba_web/live/notifications_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr ""
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "That could not be saved. Try again."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:73
+#: lib/abuuba_web/live/notifications_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr ""
@@ -1622,7 +1622,7 @@ msgstr ""
 msgid "Who can reach you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:126
+#: lib/abuuba_web/live/notifications_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr ""
@@ -1633,22 +1633,22 @@ msgstr ""
 msgid "unread"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:67
+#: lib/abuuba_web/live/search_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "A name, a #tag, or some words"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2277
 #: lib/abuuba_web/live/admin_live.ex:3587
-#: lib/abuuba_web/live/search_live.ex:261
+#: lib/abuuba_web/live/search_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:305
+#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
-#: lib/abuuba_web/live/search_live.ex:113
-#: lib/abuuba_web/live/search_live.ex:263
+#: lib/abuuba_web/live/search_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Hashtags"
 msgstr ""
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Look around first"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:76
+#: lib/abuuba_web/live/search_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Narrowing a search"
 msgstr ""
@@ -1673,25 +1673,25 @@ msgstr ""
 msgid "Nobody has posted publicly here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/tag_live.ex:79
+#: lib/abuuba_web/live/tag_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:123
+#: lib/abuuba_web/live/explore_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:133
+#: lib/abuuba_web/live/search_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:306
+#: lib/abuuba_web/live/explore_live.ex:250
+#: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
-#: lib/abuuba_web/live/search_live.ex:103
-#: lib/abuuba_web/live/search_live.ex:262
+#: lib/abuuba_web/live/search_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
@@ -1718,9 +1718,9 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:244
 #: lib/abuuba_web/components/layouts.ex:253
-#: lib/abuuba_web/live/search_live.ex:40
-#: lib/abuuba_web/live/search_live.ex:62
-#: lib/abuuba_web/live/search_live.ex:71
+#: lib/abuuba_web/live/search_live.ex:38
+#: lib/abuuba_web/live/search_live.ex:61
+#: lib/abuuba_web/live/search_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
@@ -1730,27 +1730,27 @@ msgstr ""
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:65
+#: lib/abuuba_web/live/explore_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "What to explore"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:271
+#: lib/abuuba_web/live/search_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "posts by one person"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:272
+#: lib/abuuba_web/live/search_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "posts carrying a picture or a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:274
+#: lib/abuuba_web/live/search_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "posts newer than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:273
+#: lib/abuuba_web/live/search_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "posts older than a date"
 msgstr ""
@@ -2826,7 +2826,7 @@ msgstr ""
 msgid "What is trending now"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:77
+#: lib/abuuba_web/live/explore_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
@@ -3101,12 +3101,9 @@ msgstr ""
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:208
 #: lib/abuuba_web/live/home_live.ex:338
-#: lib/abuuba_web/live/profile_live.ex:529
-#: lib/abuuba_web/live/search_live.ex:195
+#: lib/abuuba_web/live/post_actions.ex:297
 #: lib/abuuba_web/live/status_live.ex:185
-#: lib/abuuba_web/live/tag_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "That could not be translated just now."
 msgstr ""
@@ -4009,7 +4006,7 @@ msgstr ""
 msgid "A post"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:399
+#: lib/abuuba_web/live/profile_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Nobody yet."
 msgstr ""
@@ -4019,7 +4016,7 @@ msgstr ""
 msgid "Public posts tagged #%{tag}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:376
+#: lib/abuuba_web/live/profile_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr ""
@@ -5002,28 +4999,28 @@ msgstr ""
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:322
-#: lib/abuuba_web/live/profile_live.ex:326
+#: lib/abuuba_web/live/profile_live.ex:320
+#: lib/abuuba_web/live/profile_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "Featured accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:182
+#: lib/abuuba_web/live/profile_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:555
+#: lib/abuuba_web/live/profile_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:276
+#: lib/abuuba_web/live/profile_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr ""
@@ -5033,7 +5030,7 @@ msgstr ""
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
@@ -5043,7 +5040,7 @@ msgstr ""
 msgid "Send it"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:295
+#: lib/abuuba_web/live/profile_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr ""
@@ -5061,7 +5058,7 @@ msgstr[1] ""
 msgid "Subject"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:558
+#: lib/abuuba_web/live/profile_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr ""
@@ -5076,7 +5073,7 @@ msgstr ""
 msgid "To stop them, open this link:"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:545
+#: lib/abuuba_web/live/profile_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
@@ -5101,7 +5098,7 @@ msgstr ""
 msgid "You have sent as many messages as you can today."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:288
+#: lib/abuuba_web/live/profile_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr ""
@@ -5545,22 +5542,22 @@ msgstr ""
 msgid "not offered"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:245
+#: lib/abuuba_web/live/profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:243
+#: lib/abuuba_web/live/profile_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:222
+#: lib/abuuba_web/live/profile_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:207
+#: lib/abuuba_web/live/profile_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr ""
@@ -5585,47 +5582,47 @@ msgstr ""
 msgid "Unmute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:451
+#: lib/abuuba_web/live/notifications_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:237
+#: lib/abuuba_web/live/profile_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:370
+#: lib/abuuba_web/live/notifications_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:374
+#: lib/abuuba_web/live/notifications_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:372
+#: lib/abuuba_web/live/notifications_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "%{name} signed up"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:363
+#: lib/abuuba_web/live/notifications_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:359
+#: lib/abuuba_web/live/notifications_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:367
+#: lib/abuuba_web/live/notifications_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:446
+#: lib/abuuba_web/live/notifications_live.ex:463
 #, elixir-autogen, elixir-format
 msgid "Quotes"
 msgstr ""
@@ -5774,8 +5771,8 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:148
-#: lib/abuuba_web/live/profile_live.ex:596
+#: lib/abuuba_web/live/explore_live.ex:147
+#: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
@@ -5846,17 +5843,17 @@ msgstr ""
 msgid "%{size} MB"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:155
+#: lib/abuuba_web/live/profile_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Cancel follow request"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:117
+#: lib/abuuba_web/live/explore_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:606
+#: lib/abuuba_web/live/profile_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -49,7 +49,7 @@ msgid "Change"
 msgstr ""
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:723
+#: lib/abuuba_web/live/compose_component.ex:713
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:900
+#: lib/abuuba_web/live/settings_live.ex:901
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -466,8 +466,8 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:397
-#: lib/abuuba_web/live/compose_component.ex:410
+#: lib/abuuba_web/live/compose_component.ex:387
+#: lib/abuuba_web/live/compose_component.ex:400
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -661,8 +661,8 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
-#: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2310
+#: lib/abuuba_web/live/home_live.ex:55
+#: lib/abuuba_web/live/settings_live.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -688,15 +688,15 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
-#: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2311
+#: lib/abuuba_web/live/notifications_live.ex:57
+#: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:119
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:120
+#: lib/abuuba_web/live/settings_live.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Skip to content"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:85
+#: lib/abuuba_web/live/home_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "%{count} new post"
 msgid_plural "%{count} new posts"
@@ -755,13 +755,13 @@ msgstr ""
 msgid "Favourite"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:104
+#: lib/abuuba_web/live/home_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Follow some people and their posts will appear here."
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:267
-#: lib/abuuba_web/live/compose_component.ex:603
+#: lib/abuuba_web/live/compose_component.ex:593
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:304
+#: lib/abuuba_web/live/home_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "That vote could not be counted."
 msgstr ""
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Vote"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:100
+#: lib/abuuba_web/live/home_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "You have reached the end."
 msgstr ""
@@ -791,96 +791,96 @@ msgstr ""
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/compose_component.ex:1657
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1664
+#: lib/abuuba_web/live/compose_component.ex:1655
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/compose_component.ex:1658
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1663
+#: lib/abuuba_web/live/compose_component.ex:1654
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1662
+#: lib/abuuba_web/live/compose_component.ex:1653
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1665
+#: lib/abuuba_web/live/compose_component.ex:1656
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/compose_component.ex:1659
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1141
+#: lib/abuuba_web/live/compose_component.ex:1131
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:638
+#: lib/abuuba_web/live/compose_component.ex:628
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:709
+#: lib/abuuba_web/live/compose_component.ex:699
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:650
+#: lib/abuuba_web/live/compose_component.ex:640
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1683
-#: lib/abuuba_web/live/settings_live.ex:2305
+#: lib/abuuba_web/live/compose_component.ex:1674
+#: lib/abuuba_web/live/settings_live.ex:2306
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1674
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/compose_component.ex:1665
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:614
+#: lib/abuuba_web/live/compose_component.ex:604
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:438
-#: lib/abuuba_web/live/compose_component.ex:699
+#: lib/abuuba_web/live/compose_component.ex:428
+#: lib/abuuba_web/live/compose_component.ex:689
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:800
+#: lib/abuuba_web/live/compose_component.ex:790
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:433
+#: lib/abuuba_web/live/compose_component.ex:423
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr ""
@@ -891,325 +891,325 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:403
+#: lib/abuuba_web/live/compose_component.ex:393
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:654
+#: lib/abuuba_web/live/compose_component.ex:644
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/profile_live.ex:837
+#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/profile_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3428
-#: lib/abuuba_web/live/compose_component.ex:1685
-#: lib/abuuba_web/live/settings_live.ex:2307
+#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/settings_live.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2302
+#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/settings_live.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1684
-#: lib/abuuba_web/live/settings_live.ex:2306
+#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/settings_live.ex:2307
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1441
+#: lib/abuuba_web/live/compose_component.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:683
+#: lib/abuuba_web/live/compose_component.ex:673
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1674
-#: lib/abuuba_web/live/compose_component.ex:1692
+#: lib/abuuba_web/live/compose_component.ex:1665
+#: lib/abuuba_web/live/compose_component.ex:1683
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/compose_component.ex:1666
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:719
+#: lib/abuuba_web/live/compose_component.ex:709
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:626
+#: lib/abuuba_web/live/compose_component.ex:616
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:390
+#: lib/abuuba_web/live/compose_component.ex:380
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1439
+#: lib/abuuba_web/live/compose_component.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3389
-#: lib/abuuba_web/live/compose_component.ex:465
+#: lib/abuuba_web/live/compose_component.ex:455
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1103
+#: lib/abuuba_web/live/compose_component.ex:1093
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1165
-#: lib/abuuba_web/live/compose_component.ex:1200
-#: lib/abuuba_web/live/compose_component.ex:1395
+#: lib/abuuba_web/live/compose_component.ex:1155
+#: lib/abuuba_web/live/compose_component.ex:1190
+#: lib/abuuba_web/live/compose_component.ex:1386
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:449
-#: lib/abuuba_web/live/compose_component.ex:455
+#: lib/abuuba_web/live/compose_component.ex:439
+#: lib/abuuba_web/live/compose_component.ex:445
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:443
+#: lib/abuuba_web/live/compose_component.ex:433
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:759
+#: lib/abuuba_web/live/compose_component.ex:749
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:739
+#: lib/abuuba_web/live/compose_component.ex:729
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1099
+#: lib/abuuba_web/live/compose_component.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1197
+#: lib/abuuba_web/live/compose_component.ex:1187
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1635
+#: lib/abuuba_web/live/compose_component.ex:1626
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:806
+#: lib/abuuba_web/live/compose_component.ex:796
 #, elixir-autogen, elixir-format
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:838
+#: lib/abuuba_web/live/compose_component.ex:828
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:1145
+#: lib/abuuba_web/live/compose_component.ex:1135
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:869
+#: lib/abuuba_web/live/compose_component.ex:859
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:830
+#: lib/abuuba_web/live/compose_component.ex:820
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:669
+#: lib/abuuba_web/live/compose_component.ex:659
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:820
-#: lib/abuuba_web/live/compose_component.ex:859
+#: lib/abuuba_web/live/compose_component.ex:810
+#: lib/abuuba_web/live/compose_component.ex:849
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1116
-#: lib/abuuba_web/live/compose_component.ex:1386
+#: lib/abuuba_web/live/compose_component.ex:1106
+#: lib/abuuba_web/live/compose_component.ex:1377
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:791
+#: lib/abuuba_web/live/compose_component.ex:781
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1440
+#: lib/abuuba_web/live/compose_component.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:304
+#: lib/abuuba_web/live/compose_component.ex:305
 #, elixir-autogen, elixir-format
 msgid "That draft could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:202
+#: lib/abuuba_web/live/home_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "That post is scheduled."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1150
+#: lib/abuuba_web/live/compose_component.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:300
+#: lib/abuuba_web/live/compose_component.ex:301
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1434
+#: lib/abuuba_web/live/compose_component.ex:1425
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:676
+#: lib/abuuba_web/live/compose_component.ex:666
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1113
+#: lib/abuuba_web/live/compose_component.ex:1103
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:484
+#: lib/abuuba_web/live/compose_component.ex:474
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:579
+#: lib/abuuba_web/live/compose_component.ex:569
 #, elixir-autogen, elixir-format
 msgid "Add a still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:529
+#: lib/abuuba_web/live/compose_component.ex:519
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:546
-#: lib/abuuba_web/live/compose_component.ex:554
+#: lib/abuuba_web/live/compose_component.ex:536
+#: lib/abuuba_web/live/compose_component.ex:544
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:568
+#: lib/abuuba_web/live/compose_component.ex:558
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:583
+#: lib/abuuba_web/live/compose_component.ex:573
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:541
+#: lib/abuuba_web/live/compose_component.ex:531
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:509
+#: lib/abuuba_web/live/compose_component.ex:499
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:594
+#: lib/abuuba_web/live/compose_component.ex:584
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:239
-#: lib/abuuba_web/live/compose_component.ex:1430
+#: lib/abuuba_web/live/compose_component.ex:240
+#: lib/abuuba_web/live/compose_component.ex:1421
 #, elixir-autogen, elixir-format
 msgid "That file could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1427
+#: lib/abuuba_web/live/compose_component.ex:1418
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:226
+#: lib/abuuba_web/live/compose_component.ex:227
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1428
+#: lib/abuuba_web/live/compose_component.ex:1419
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1429
+#: lib/abuuba_web/live/compose_component.ex:1420
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:488
+#: lib/abuuba_web/live/compose_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:279
+#: lib/abuuba_web/live/status_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:292
+#: lib/abuuba_web/live/profile_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:189
+#: lib/abuuba_web/live/profile_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
@@ -1231,29 +1231,29 @@ msgstr ""
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:836
+#: lib/abuuba_web/live/profile_live.ex:865
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:363
+#: lib/abuuba_web/live/profile_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:338
-#: lib/abuuba_web/live/profile_live.ex:339
+#: lib/abuuba_web/live/profile_live.ex:347
+#: lib/abuuba_web/live/profile_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:288
-#: lib/abuuba_web/live/profile_live.ex:834
+#: lib/abuuba_web/live/explore_live.ex:304
+#: lib/abuuba_web/live/profile_live.ex:863
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:122
 #: lib/abuuba_web/live/search_live.ex:264
@@ -1261,18 +1261,18 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:835
+#: lib/abuuba_web/live/profile_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:944
-#: lib/abuuba_web/live/profile_live.ex:296
+#: lib/abuuba_web/live/profile_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:320
+#: lib/abuuba_web/live/status_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "That server could not be reached, so this is all there is."
 msgstr ""
@@ -1282,19 +1282,19 @@ msgstr ""
 msgid "This account has moved to %{handle}."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:189
-#: lib/abuuba_web/live/settings_live.ex:826
+#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/settings_live.ex:827
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:155
+#: lib/abuuba_web/live/profile_live.ex:164
 #: lib/abuuba_web/live/tag_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
@@ -1304,109 +1304,109 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:300
+#: lib/abuuba_web/live/profile_live.ex:309
 #: lib/abuuba_web/live/search_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "What to show"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:83
+#: lib/abuuba_web/live/notifications_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:133
+#: lib/abuuba_web/live/notifications_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:380
+#: lib/abuuba_web/live/notifications_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:384
+#: lib/abuuba_web/live/notifications_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:391
+#: lib/abuuba_web/live/notifications_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:394
+#: lib/abuuba_web/live/notifications_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:118
+#: lib/abuuba_web/live/notifications_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:398
+#: lib/abuuba_web/live/notifications_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:347
+#: lib/abuuba_web/live/notifications_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:345
+#: lib/abuuba_web/live/notifications_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "%{name} boosted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:350
+#: lib/abuuba_web/live/notifications_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:348
+#: lib/abuuba_web/live/notifications_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:346
+#: lib/abuuba_web/live/notifications_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:344
+#: lib/abuuba_web/live/notifications_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:351
+#: lib/abuuba_web/live/notifications_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "%{name} posted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:352
+#: lib/abuuba_web/live/notifications_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:349
+#: lib/abuuba_web/live/notifications_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr ""
@@ -1431,7 +1431,7 @@ msgstr ""
 msgid "Accounts made very recently"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:430
+#: lib/abuuba_web/live/notifications_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
@@ -1461,17 +1461,17 @@ msgstr ""
 msgid "Automated accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:439
+#: lib/abuuba_web/live/notifications_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Boosts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:111
+#: lib/abuuba_web/live/notifications_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:178
+#: lib/abuuba_web/live/notifications_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -1481,12 +1481,12 @@ msgstr ""
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:444
+#: lib/abuuba_web/live/notifications_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Edits"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:442
+#: lib/abuuba_web/live/notifications_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Favourites"
 msgstr ""
@@ -1496,15 +1496,15 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:441
+#: lib/abuuba_web/live/notifications_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:440
-#: lib/abuuba_web/live/profile_live.ex:838
-#: lib/abuuba_web/live/settings_live.ex:2103
-#: lib/abuuba_web/live/settings_live.ex:2241
+#: lib/abuuba_web/live/notifications_live.ex:441
+#: lib/abuuba_web/live/profile_live.ex:867
+#: lib/abuuba_web/live/settings_live.ex:2104
+#: lib/abuuba_web/live/settings_live.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -1519,28 +1519,28 @@ msgstr ""
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:147
+#: lib/abuuba_web/live/notifications_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:107
+#: lib/abuuba_web/live/notifications_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:430
-#: lib/abuuba_web/live/notifications_live.ex:438
+#: lib/abuuba_web/live/notifications_live.ex:431
+#: lib/abuuba_web/live/notifications_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:156
+#: lib/abuuba_web/live/notifications_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:192
+#: lib/abuuba_web/live/notifications_live.ex:193
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr ""
@@ -1555,7 +1555,7 @@ msgstr ""
 msgid "People you do not follow"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:443
+#: lib/abuuba_web/live/notifications_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "Polls"
 msgstr ""
@@ -1571,28 +1571,28 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1587
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:255
-#: lib/abuuba_web/live/settings_live.ex:294
-#: lib/abuuba_web/live/settings_live.ex:388
-#: lib/abuuba_web/live/settings_live.ex:425
-#: lib/abuuba_web/live/settings_live.ex:489
-#: lib/abuuba_web/live/settings_live.ex:596
-#: lib/abuuba_web/live/settings_live.ex:641
-#: lib/abuuba_web/live/settings_live.ex:674
-#: lib/abuuba_web/live/settings_live.ex:996
+#: lib/abuuba_web/live/profile_live.ex:264
+#: lib/abuuba_web/live/settings_live.ex:295
+#: lib/abuuba_web/live/settings_live.ex:389
+#: lib/abuuba_web/live/settings_live.ex:426
+#: lib/abuuba_web/live/settings_live.ex:490
+#: lib/abuuba_web/live/settings_live.ex:597
+#: lib/abuuba_web/live/settings_live.ex:642
+#: lib/abuuba_web/live/settings_live.ex:675
+#: lib/abuuba_web/live/settings_live.ex:997
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:245
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:136
+#: lib/abuuba_web/live/settings_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:342
-#: lib/abuuba_web/live/notifications_live.ex:407
+#: lib/abuuba_web/live/notifications_live.ex:343
+#: lib/abuuba_web/live/notifications_live.ex:408
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr ""
@@ -1602,7 +1602,7 @@ msgstr ""
 msgid "Somebody a moderator here has already restricted."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:377
+#: lib/abuuba_web/live/notifications_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr ""
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "That could not be saved. Try again."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:72
+#: lib/abuuba_web/live/notifications_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr ""
@@ -1622,7 +1622,7 @@ msgstr ""
 msgid "Who can reach you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:125
+#: lib/abuuba_web/live/notifications_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr ""
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:289
+#: lib/abuuba_web/live/explore_live.ex:305
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:113
 #: lib/abuuba_web/live/search_live.ex:263
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:119
+#: lib/abuuba_web/live/explore_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:290
+#: lib/abuuba_web/live/explore_live.ex:306
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:103
 #: lib/abuuba_web/live/search_live.ex:262
@@ -1755,220 +1755,220 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:891
+#: lib/abuuba_web/live/settings_live.ex:892
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:234
+#: lib/abuuba_web/live/settings_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3379
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:290
+#: lib/abuuba_web/live/settings_live.ex:291
 #, elixir-autogen, elixir-format
 msgid "Add a field"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:807
+#: lib/abuuba_web/live/settings_live.ex:808
 #, elixir-autogen, elixir-format
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2277
+#: lib/abuuba_web/live/settings_live.ex:2278
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2130
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:947
+#: lib/abuuba_web/live/settings_live.ex:948
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2272
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:895
+#: lib/abuuba_web/live/settings_live.ex:896
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:998
-#: lib/abuuba_web/live/settings_live.ex:754
+#: lib/abuuba_web/live/settings_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:223
+#: lib/abuuba_web/live/settings_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1600
+#: lib/abuuba_web/live/settings_live.ex:1601
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:201
+#: lib/abuuba_web/live/settings_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:239
+#: lib/abuuba_web/live/settings_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2102
-#: lib/abuuba_web/live/settings_live.ex:2247
+#: lib/abuuba_web/live/settings_live.ex:2103
+#: lib/abuuba_web/live/settings_live.ex:2248
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2329
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2278
+#: lib/abuuba_web/live/settings_live.ex:2279
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2286
+#: lib/abuuba_web/live/settings_live.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:254
+#: lib/abuuba_web/live/settings_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2282
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:272
+#: lib/abuuba_web/live/settings_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:976
+#: lib/abuuba_web/live/settings_live.ex:977
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:990
+#: lib/abuuba_web/live/settings_live.ex:991
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:449
+#: lib/abuuba_web/live/settings_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2097
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2315
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2312
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2285
+#: lib/abuuba_web/live/settings_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1979,165 +1979,165 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1878
 #: lib/abuuba_web/live/admin_live.ex:2202
 #: lib/abuuba_web/live/conversations_live.ex:112
-#: lib/abuuba_web/live/settings_live.ex:280
-#: lib/abuuba_web/live/settings_live.ex:315
+#: lib/abuuba_web/live/settings_live.ex:281
+#: lib/abuuba_web/live/settings_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2104
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:908
+#: lib/abuuba_web/live/settings_live.ex:909
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:904
+#: lib/abuuba_web/live/settings_live.ex:905
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:970
+#: lib/abuuba_web/live/settings_live.ex:971
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3750
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2094
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1575
+#: lib/abuuba_web/live/settings_live.ex:1576
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:468
+#: lib/abuuba_web/live/settings_live.ex:469
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2279
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2313
+#: lib/abuuba_web/live/settings_live.ex:2314
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:849
+#: lib/abuuba_web/live/settings_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:874
+#: lib/abuuba_web/live/settings_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:241
+#: lib/abuuba_web/live/settings_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:261
+#: lib/abuuba_web/live/settings_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/settings_live.ex:2290
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:799
+#: lib/abuuba_web/live/settings_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2126
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2178
-#: lib/abuuba_web/live/settings_live.ex:761
+#: lib/abuuba_web/live/settings_live.ex:762
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:766
+#: lib/abuuba_web/live/settings_live.ex:767
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:455
+#: lib/abuuba_web/live/settings_live.ex:456
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:436
+#: lib/abuuba_web/live/settings_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:870
+#: lib/abuuba_web/live/settings_live.ex:871
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:886
+#: lib/abuuba_web/live/settings_live.ex:887
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:987
+#: lib/abuuba_web/live/settings_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2293,110 +2293,110 @@ msgstr ""
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1858
+#: lib/abuuba_web/live/settings_live.ex:1859
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1196
+#: lib/abuuba_web/live/settings_live.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2107
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1226
+#: lib/abuuba_web/live/settings_live.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1842
+#: lib/abuuba_web/live/settings_live.ex:1843
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1193
+#: lib/abuuba_web/live/settings_live.ex:1194
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1861
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1200
-#: lib/abuuba_web/live/settings_live.ex:1838
+#: lib/abuuba_web/live/settings_live.ex:1201
+#: lib/abuuba_web/live/settings_live.ex:1839
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1171
+#: lib/abuuba_web/live/settings_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1852
+#: lib/abuuba_web/live/settings_live.ex:1853
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1855
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1859
+#: lib/abuuba_web/live/settings_live.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1862
+#: lib/abuuba_web/live/settings_live.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1863
+#: lib/abuuba_web/live/settings_live.ex:1864
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1861
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1179
+#: lib/abuuba_web/live/settings_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1217
+#: lib/abuuba_web/live/settings_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1206
+#: lib/abuuba_web/live/settings_live.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1208
+#: lib/abuuba_web/live/settings_live.ex:1209
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
@@ -2692,7 +2692,7 @@ msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3340
-#: lib/abuuba_web/live/settings_live.ex:1628
+#: lib/abuuba_web/live/settings_live.ex:1629
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
@@ -2831,12 +2831,12 @@ msgstr ""
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1242
+#: lib/abuuba_web/live/settings_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
@@ -2851,7 +2851,7 @@ msgstr ""
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2136
+#: lib/abuuba_web/live/settings_live.ex:2137
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1253
+#: lib/abuuba_web/live/settings_live.ex:1254
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
@@ -2891,12 +2891,12 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2108
+#: lib/abuuba_web/live/settings_live.ex:2109
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1237
+#: lib/abuuba_web/live/settings_live.ex:1238
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
@@ -2906,7 +2906,7 @@ msgstr ""
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1260
+#: lib/abuuba_web/live/settings_live.ex:1261
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
@@ -2936,7 +2936,7 @@ msgstr ""
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1274
+#: lib/abuuba_web/live/settings_live.ex:1275
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr ""
@@ -2951,12 +2951,12 @@ msgstr ""
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1258
+#: lib/abuuba_web/live/settings_live.ex:1259
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1249
+#: lib/abuuba_web/live/settings_live.ex:1250
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr ""
@@ -2977,7 +2977,7 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1280
+#: lib/abuuba_web/live/settings_live.ex:1281
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
@@ -2987,7 +2987,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2088
+#: lib/abuuba_web/live/settings_live.ex:2089
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3101,9 +3101,9 @@ msgstr ""
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:204
-#: lib/abuuba_web/live/home_live.ex:337
-#: lib/abuuba_web/live/profile_live.ex:518
+#: lib/abuuba_web/live/explore_live.ex:208
+#: lib/abuuba_web/live/home_live.ex:338
+#: lib/abuuba_web/live/profile_live.ex:529
 #: lib/abuuba_web/live/search_live.ex:195
 #: lib/abuuba_web/live/status_live.ex:185
 #: lib/abuuba_web/live/tag_live.ex:153
@@ -3126,245 +3126,245 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1987
+#: lib/abuuba_web/live/settings_live.ex:1988
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1978
+#: lib/abuuba_web/live/settings_live.ex:1979
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1894
+#: lib/abuuba_web/live/settings_live.ex:1895
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2051
+#: lib/abuuba_web/live/settings_live.ex:2052
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1875
+#: lib/abuuba_web/live/settings_live.ex:1876
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2110
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1900
+#: lib/abuuba_web/live/settings_live.ex:1901
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2139
+#: lib/abuuba_web/live/settings_live.ex:2140
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2076
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2047
+#: lib/abuuba_web/live/settings_live.ex:2048
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2062
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2063
+#: lib/abuuba_web/live/settings_live.ex:2068
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2064
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2066
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1884
+#: lib/abuuba_web/live/settings_live.ex:1885
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2072
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1881
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1889
+#: lib/abuuba_web/live/settings_live.ex:1890
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2078
+#: lib/abuuba_web/live/settings_live.ex:2079
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2080
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2082
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2085
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2083
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1045
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:1934
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1040
+#: lib/abuuba_web/live/settings_live.ex:1041
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1951
+#: lib/abuuba_web/live/settings_live.ex:1952
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1050
+#: lib/abuuba_web/live/settings_live.ex:1051
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1038
+#: lib/abuuba_web/live/settings_live.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1007
+#: lib/abuuba_web/live/settings_live.ex:1008
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1964
+#: lib/abuuba_web/live/settings_live.ex:1965
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1941
+#: lib/abuuba_web/live/settings_live.ex:1942
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1064
-#: lib/abuuba_web/live/settings_live.ex:1913
-#: lib/abuuba_web/live/settings_live.ex:2244
+#: lib/abuuba_web/live/settings_live.ex:1065
+#: lib/abuuba_web/live/settings_live.ex:1914
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1034
+#: lib/abuuba_web/live/settings_live.ex:1035
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1018
+#: lib/abuuba_web/live/settings_live.ex:1019
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2037
+#: lib/abuuba_web/live/settings_live.ex:2038
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1002
+#: lib/abuuba_web/live/settings_live.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1937
+#: lib/abuuba_web/live/settings_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2027
+#: lib/abuuba_web/live/settings_live.ex:2028
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2038
+#: lib/abuuba_web/live/settings_live.ex:2039
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1915
+#: lib/abuuba_web/live/settings_live.ex:1916
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1028
+#: lib/abuuba_web/live/settings_live.ex:1029
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1000
+#: lib/abuuba_web/live/settings_live.ex:1001
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1930
+#: lib/abuuba_web/live/settings_live.ex:1931
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2033
+#: lib/abuuba_web/live/settings_live.ex:2034
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
@@ -3374,27 +3374,27 @@ msgstr ""
 msgid "No such post here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:244
+#: lib/abuuba_web/live/settings_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:782
+#: lib/abuuba_web/live/settings_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:795
+#: lib/abuuba_web/live/settings_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:779
+#: lib/abuuba_web/live/settings_live.ex:780
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1514
+#: lib/abuuba_web/live/settings_live.ex:1515
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
@@ -3404,54 +3404,54 @@ msgstr ""
 msgid "Why they want to join:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:307
+#: lib/abuuba_web/live/settings_live.ex:308
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:324
+#: lib/abuuba_web/live/settings_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:327
+#: lib/abuuba_web/live/settings_live.ex:328
 #, elixir-autogen, elixir-format
 msgid "Feature it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:298
+#: lib/abuuba_web/live/settings_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:300
+#: lib/abuuba_web/live/settings_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1497
+#: lib/abuuba_web/live/settings_live.ex:1498
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:331
+#: lib/abuuba_web/live/settings_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1491
+#: lib/abuuba_web/live/settings_live.ex:1492
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:482
+#: lib/abuuba_web/live/settings_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:484
+#: lib/abuuba_web/live/settings_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
@@ -3481,29 +3481,29 @@ msgstr ""
 msgid "This is not a memorial"
 msgstr ""
 
-#: lib/abuuba_web/live/collection_live.ex:64
+#: lib/abuuba_web/live/collection_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "%{count} account"
 msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/collection_live.ex:112
+#: lib/abuuba_web/live/collection_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "A collection by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/collection_live.ex:60
+#: lib/abuuba_web/live/collection_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "By"
 msgstr ""
 
-#: lib/abuuba_web/live/collection_live.ex:52
+#: lib/abuuba_web/live/collection_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Collection"
 msgstr ""
 
-#: lib/abuuba_web/live/collection_live.ex:87
+#: lib/abuuba_web/live/collection_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this list yet."
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr ""
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:645
+#: lib/abuuba_web/live/settings_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "Email updates"
 msgstr ""
@@ -3614,7 +3614,7 @@ msgstr ""
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:663
+#: lib/abuuba_web/live/settings_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr ""
@@ -3624,7 +3624,7 @@ msgstr ""
 msgid "No, remove my address"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:665
+#: lib/abuuba_web/live/settings_live.ex:666
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3677,7 +3677,7 @@ msgstr ""
 msgid "Let people collect email addresses for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:647
+#: lib/abuuba_web/live/settings_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr ""
@@ -3825,75 +3825,75 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1077
+#: lib/abuuba_web/live/settings_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2251
+#: lib/abuuba_web/live/settings_live.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:810
-#: lib/abuuba_web/live/settings_live.ex:2245
+#: lib/abuuba_web/live/settings_live.ex:811
+#: lib/abuuba_web/live/settings_live.ex:2246
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2242
+#: lib/abuuba_web/live/settings_live.ex:2243
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2246
+#: lib/abuuba_web/live/settings_live.ex:2247
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1119
+#: lib/abuuba_web/live/settings_live.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2253
+#: lib/abuuba_web/live/settings_live.ex:2254
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1102
+#: lib/abuuba_web/live/settings_live.ex:1103
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2110
+#: lib/abuuba_web/live/settings_live.ex:2111
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2243
+#: lib/abuuba_web/live/settings_live.ex:2244
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1066
+#: lib/abuuba_web/live/settings_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1387
+#: lib/abuuba_web/live/settings_live.ex:1388
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1084
+#: lib/abuuba_web/live/settings_live.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2252
+#: lib/abuuba_web/live/settings_live.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3913,13 +3913,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2250
+#: lib/abuuba_web/live/settings_live.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1108
-#: lib/abuuba_web/live/settings_live.ex:1393
+#: lib/abuuba_web/live/settings_live.ex:1109
+#: lib/abuuba_web/live/settings_live.ex:1394
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3929,7 +3929,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1079
+#: lib/abuuba_web/live/settings_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3939,67 +3939,67 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1158
+#: lib/abuuba_web/live/settings_live.ex:1159
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1156
+#: lib/abuuba_web/live/settings_live.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1122
+#: lib/abuuba_web/live/settings_live.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1061
+#: lib/abuuba_web/live/settings_live.ex:1062
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1139
+#: lib/abuuba_web/live/settings_live.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1420
+#: lib/abuuba_web/live/settings_live.ex:1421
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1417
+#: lib/abuuba_web/live/settings_live.ex:1418
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1129
+#: lib/abuuba_web/live/settings_live.ex:1130
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1413
+#: lib/abuuba_web/live/settings_live.ex:1414
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1144
+#: lib/abuuba_web/live/settings_live.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1124
+#: lib/abuuba_web/live/settings_live.ex:1125
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1134
+#: lib/abuuba_web/live/settings_live.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
@@ -4009,7 +4009,7 @@ msgstr ""
 msgid "A post"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:390
+#: lib/abuuba_web/live/profile_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "Nobody yet."
 msgstr ""
@@ -4019,7 +4019,7 @@ msgstr ""
 msgid "Public posts tagged #%{tag}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:367
+#: lib/abuuba_web/live/profile_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr ""
@@ -4045,99 +4045,99 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1449
+#: lib/abuuba_web/live/settings_live.ex:1450
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:914
+#: lib/abuuba_web/live/settings_live.ex:915
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:523
+#: lib/abuuba_web/live/settings_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:532
+#: lib/abuuba_web/live/settings_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:551
+#: lib/abuuba_web/live/settings_live.ex:552
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:578
+#: lib/abuuba_web/live/settings_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:567
+#: lib/abuuba_web/live/settings_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:563
+#: lib/abuuba_web/live/settings_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:937
+#: lib/abuuba_web/live/settings_live.ex:938
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:520
+#: lib/abuuba_web/live/settings_live.ex:521
 #, elixir-autogen, elixir-format
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:933
+#: lib/abuuba_web/live/settings_live.ex:934
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:525
+#: lib/abuuba_web/live/settings_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:589
+#: lib/abuuba_web/live/settings_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:500
+#: lib/abuuba_web/live/settings_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:912
+#: lib/abuuba_web/live/settings_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:922
+#: lib/abuuba_web/live/settings_live.ex:923
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:922
+#: lib/abuuba_web/live/settings_live.ex:923
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:514
+#: lib/abuuba_web/live/settings_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:502
+#: lib/abuuba_web/live/settings_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr ""
@@ -4949,124 +4949,124 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2220
+#: lib/abuuba_web/live/settings_live.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2221
+#: lib/abuuba_web/live/settings_live.ex:2222
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:346
+#: lib/abuuba_web/live/settings_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:565
-#: lib/abuuba_web/live/settings_live.ex:364
+#: lib/abuuba_web/live/settings_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2061
+#: lib/abuuba_web/live/settings_live.ex:2062
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:344
+#: lib/abuuba_web/live/settings_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:396
+#: lib/abuuba_web/live/settings_live.ex:397
 #, elixir-autogen, elixir-format
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2059
-#: lib/abuuba_web/live/settings_live.ex:2214
+#: lib/abuuba_web/live/settings_live.ex:2060
+#: lib/abuuba_web/live/settings_live.ex:2215
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2209
-#: lib/abuuba_web/live/settings_live.ex:2216
+#: lib/abuuba_web/live/settings_live.ex:2210
+#: lib/abuuba_web/live/settings_live.ex:2217
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:164
+#: lib/abuuba_web/live/profile_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:313
-#: lib/abuuba_web/live/profile_live.ex:317
+#: lib/abuuba_web/live/profile_live.ex:322
+#: lib/abuuba_web/live/profile_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "Featured accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:544
+#: lib/abuuba_web/live/profile_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:267
+#: lib/abuuba_web/live/profile_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:680
+#: lib/abuuba_web/live/settings_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:270
+#: lib/abuuba_web/live/profile_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:705
+#: lib/abuuba_web/live/settings_live.ex:706
 #, elixir-autogen, elixir-format
 msgid "Send it"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:286
+#: lib/abuuba_web/live/profile_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:714
+#: lib/abuuba_web/live/settings_live.ex:715
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:691
-#: lib/abuuba_web/live/settings_live.ex:1788
+#: lib/abuuba_web/live/settings_live.ex:692
+#: lib/abuuba_web/live/settings_live.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:547
+#: lib/abuuba_web/live/profile_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1368
+#: lib/abuuba_web/live/settings_live.ex:1369
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5076,17 +5076,17 @@ msgstr ""
 msgid "To stop them, open this link:"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:534
+#: lib/abuuba_web/live/profile_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:698
+#: lib/abuuba_web/live/settings_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:678
+#: lib/abuuba_web/live/settings_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr ""
@@ -5096,22 +5096,22 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1373
+#: lib/abuuba_web/live/settings_live.ex:1374
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1789
+#: lib/abuuba_web/live/settings_live.ex:1790
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:721
+#: lib/abuuba_web/live/settings_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr ""
@@ -5397,7 +5397,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:960
+#: lib/abuuba_web/live/settings_live.ex:961
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5545,22 +5545,22 @@ msgstr ""
 msgid "not offered"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:236
+#: lib/abuuba_web/live/profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:234
+#: lib/abuuba_web/live/profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:213
+#: lib/abuuba_web/live/profile_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr ""
@@ -5585,47 +5585,47 @@ msgstr ""
 msgid "Unmute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:450
+#: lib/abuuba_web/live/notifications_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:228
+#: lib/abuuba_web/live/profile_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:369
+#: lib/abuuba_web/live/notifications_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:373
+#: lib/abuuba_web/live/notifications_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:371
+#: lib/abuuba_web/live/notifications_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "%{name} signed up"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:362
+#: lib/abuuba_web/live/notifications_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:358
+#: lib/abuuba_web/live/notifications_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:366
+#: lib/abuuba_web/live/notifications_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:445
+#: lib/abuuba_web/live/notifications_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "Quotes"
 msgstr ""
@@ -5749,22 +5749,22 @@ msgstr ""
 msgid "Who may read the blocklist"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:635
+#: lib/abuuba_web/live/settings_live.ex:636
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:627
+#: lib/abuuba_web/live/settings_live.ex:628
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:839
+#: lib/abuuba_web/live/settings_live.ex:840
 #, elixir-autogen, elixir-format
 msgid "Block a server"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:812
+#: lib/abuuba_web/live/settings_live.ex:813
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr ""
@@ -5774,8 +5774,8 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:144
-#: lib/abuuba_web/live/profile_live.ex:585
+#: lib/abuuba_web/live/explore_live.ex:148
+#: lib/abuuba_web/live/profile_live.ex:596
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
@@ -5840,8 +5840,23 @@ msgstr ""
 msgid "Warned"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2234
-#: lib/abuuba_web/live/settings_live.ex:2237
+#: lib/abuuba_web/live/settings_live.ex:2235
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
+msgstr ""
+
+#: lib/abuuba_web/live/profile_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Cancel follow request"
+msgstr ""
+
+#: lib/abuuba_web/live/explore_live.ex:117
+#, elixir-autogen, elixir-format
+msgid "Requested"
+msgstr ""
+
+#: lib/abuuba_web/live/profile_live.ex:606
+#, elixir-autogen, elixir-format
+msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -124,7 +124,7 @@ msgstr ""
 msgid "Create account"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:80
+#: lib/abuuba_web/live/landing_live.ex:81
 #: lib/abuuba_web/live/registration_live.ex:37
 #: lib/abuuba_web/live/registration_live.ex:207
 #, elixir-autogen, elixir-format
@@ -330,12 +330,12 @@ msgstr ""
 msgid "you can now sign in to %{site}:"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:96
+#: lib/abuuba_web/live/two_factor_settings_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "A second factor means somebody who learns your password still cannot sign in as you."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:116
+#: lib/abuuba_web/live/two_factor_settings_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Cannot scan it? Type this in instead:"
 msgstr ""
@@ -346,7 +346,7 @@ msgid "Checking…"
 msgstr ""
 
 #: lib/abuuba_web/live/two_factor_live.ex:40
-#: lib/abuuba_web/live/two_factor_settings_live.ex:124
+#: lib/abuuba_web/live/two_factor_settings_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -361,7 +361,7 @@ msgstr ""
 msgid "Enter the code from your authenticator app, or one of your recovery codes."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:146
+#: lib/abuuba_web/live/two_factor_settings_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Make new recovery codes"
 msgstr ""
@@ -371,22 +371,22 @@ msgstr ""
 msgid "One more step"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:83
+#: lib/abuuba_web/live/two_factor_settings_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Save these recovery codes now"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:110
+#: lib/abuuba_web/live/two_factor_settings_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Scan this with your authenticator app, then type the code it shows."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:104
+#: lib/abuuba_web/live/two_factor_settings_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Set up an authenticator app"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:50
+#: lib/abuuba_web/live/two_factor_settings_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "That code is not right. Try again."
 msgstr ""
@@ -396,54 +396,54 @@ msgstr ""
 msgid "That code is not right. Try the next one."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:85
+#: lib/abuuba_web/live/two_factor_settings_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "This is the only time they are shown. Each one works once, and they are how you get back in if you lose your phone."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:534
-#: lib/abuuba_web/live/two_factor_settings_live.ex:154
+#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/two_factor_settings_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Turn it off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:534
-#: lib/abuuba_web/live/two_factor_settings_live.ex:131
+#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/two_factor_settings_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Turn it on"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:151
+#: lib/abuuba_web/live/two_factor_settings_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:899
+#: lib/abuuba_web/live/settings_live.ex:900
 #: lib/abuuba_web/live/two_factor_live.ex:16
-#: lib/abuuba_web/live/two_factor_settings_live.ex:21
-#: lib/abuuba_web/live/two_factor_settings_live.ex:80
+#: lib/abuuba_web/live/two_factor_settings_live.ex:20
+#: lib/abuuba_web/live/two_factor_settings_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:72
+#: lib/abuuba_web/live/two_factor_settings_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication is off."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:47
+#: lib/abuuba_web/live/two_factor_settings_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication is on."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:138
+#: lib/abuuba_web/live/two_factor_settings_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication is on. You have 1 recovery code left."
 msgid_plural "Two-factor authentication is on. You have %{count} recovery codes left."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:61
+#: lib/abuuba_web/live/two_factor_settings_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Your old recovery codes no longer work."
 msgstr ""
@@ -453,7 +453,7 @@ msgstr ""
 msgid "Act as a moderator (%{scope})"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1049
+#: lib/abuuba_web/live/admin_live.ex:1051
 #: lib/abuuba_web/live/authorize_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Allow"
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Authorize %{app}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1739
+#: lib/abuuba_web/live/admin_live.ex:1741
 #: lib/abuuba_web/live/authorize_live.ex:123
 #: lib/abuuba_web/live/compose_component.ex:410
 #: lib/abuuba_web/live/compose_component.ex:423
@@ -662,7 +662,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
 #: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -675,7 +675,7 @@ msgid "Keyboard shortcuts"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:254
-#: lib/abuuba_web/live/landing_live.ex:82
+#: lib/abuuba_web/live/landing_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
@@ -689,14 +689,14 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:118
-#: lib/abuuba_web/live/settings_live.ex:2112
+#: lib/abuuba_web/live/settings_live.ex:119
+#: lib/abuuba_web/live/settings_live.ex:2119
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -791,37 +791,37 @@ msgstr ""
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1682
+#: lib/abuuba_web/live/compose_component.ex:1679
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1680
+#: lib/abuuba_web/live/compose_component.ex:1677
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/compose_component.ex:1680
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1679
+#: lib/abuuba_web/live/compose_component.ex:1676
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1678
+#: lib/abuuba_web/live/compose_component.ex:1675
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1681
+#: lib/abuuba_web/live/compose_component.ex:1678
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1684
+#: lib/abuuba_web/live/compose_component.ex:1681
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
@@ -846,20 +846,20 @@ msgstr ""
 msgid "Allow more than one choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1699
-#: lib/abuuba_web/live/settings_live.ex:2292
+#: lib/abuuba_web/live/compose_component.ex:1696
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1690
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/compose_component.ex:1687
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1691
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/compose_component.ex:1688
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
@@ -886,7 +886,7 @@ msgid "Do not reply to this person"
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:432
-#: lib/abuuba_web/live/admin_live.ex:1759
+#: lib/abuuba_web/live/admin_live.ex:1761
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -901,37 +901,37 @@ msgstr ""
 msgid "Ends after"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1692
-#: lib/abuuba_web/live/profile_live.ex:866
+#: lib/abuuba_web/live/compose_component.ex:1689
+#: lib/abuuba_web/live/profile_live.ex:837
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1693
+#: lib/abuuba_web/live/compose_component.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3419
-#: lib/abuuba_web/live/compose_component.ex:1701
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/admin_live.ex:3413
+#: lib/abuuba_web/live/compose_component.ex:1698
+#: lib/abuuba_web/live/settings_live.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1692
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/compose_component.ex:1689
+#: lib/abuuba_web/live/settings_live.ex:2290
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1693
+#: lib/abuuba_web/live/compose_component.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1700
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/compose_component.ex:1697
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
@@ -946,13 +946,13 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1690
-#: lib/abuuba_web/live/compose_component.ex:1708
+#: lib/abuuba_web/live/compose_component.ex:1687
+#: lib/abuuba_web/live/compose_component.ex:1705
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1691
+#: lib/abuuba_web/live/compose_component.ex:1688
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
@@ -977,7 +977,7 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3380
+#: lib/abuuba_web/live/admin_live.ex:3374
 #: lib/abuuba_web/live/compose_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
@@ -1199,17 +1199,17 @@ msgstr ""
 msgid "or drop one on the box, or paste it"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:278
+#: lib/abuuba_web/live/status_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:301
+#: lib/abuuba_web/live/profile_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
@@ -1226,34 +1226,34 @@ msgstr ""
 msgid "Go to the new account"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:98
+#: lib/abuuba_web/live/status_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:865
+#: lib/abuuba_web/live/profile_live.ex:836
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:372
+#: lib/abuuba_web/live/profile_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:347
-#: lib/abuuba_web/live/profile_live.ex:348
+#: lib/abuuba_web/live/profile_live.ex:338
+#: lib/abuuba_web/live/profile_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:304
-#: lib/abuuba_web/live/profile_live.ex:863
+#: lib/abuuba_web/live/explore_live.ex:288
+#: lib/abuuba_web/live/profile_live.ex:834
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:122
 #: lib/abuuba_web/live/search_live.ex:264
@@ -1261,18 +1261,18 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:864
+#: lib/abuuba_web/live/profile_live.ex:835
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:929
-#: lib/abuuba_web/live/profile_live.ex:305
+#: lib/abuuba_web/live/admin_live.ex:931
+#: lib/abuuba_web/live/profile_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:322
+#: lib/abuuba_web/live/status_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "That server could not be reached, so this is all there is."
 msgstr ""
@@ -1282,19 +1282,19 @@ msgstr ""
 msgid "This account has moved to %{handle}."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
-#: lib/abuuba_web/live/settings_live.ex:825
+#: lib/abuuba_web/live/profile_live.ex:189
+#: lib/abuuba_web/live/settings_live.ex:826
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:164
+#: lib/abuuba_web/live/profile_live.ex:155
 #: lib/abuuba_web/live/tag_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:309
+#: lib/abuuba_web/live/profile_live.ex:300
 #: lib/abuuba_web/live/search_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "What to show"
@@ -1431,7 +1431,7 @@ msgstr ""
 msgid "Accounts made very recently"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:433
+#: lib/abuuba_web/live/notifications_live.ex:430
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
@@ -1461,7 +1461,7 @@ msgstr ""
 msgid "Automated accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:442
+#: lib/abuuba_web/live/notifications_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Boosts"
 msgstr ""
@@ -1481,12 +1481,12 @@ msgstr ""
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:447
+#: lib/abuuba_web/live/notifications_live.ex:444
 #, elixir-autogen, elixir-format
 msgid "Edits"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:445
+#: lib/abuuba_web/live/notifications_live.ex:442
 #, elixir-autogen, elixir-format
 msgid "Favourites"
 msgstr ""
@@ -1496,15 +1496,15 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:444
+#: lib/abuuba_web/live/notifications_live.ex:441
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:443
-#: lib/abuuba_web/live/profile_live.ex:867
-#: lib/abuuba_web/live/settings_live.ex:2096
-#: lib/abuuba_web/live/settings_live.ex:2228
+#: lib/abuuba_web/live/notifications_live.ex:440
+#: lib/abuuba_web/live/profile_live.ex:838
+#: lib/abuuba_web/live/settings_live.ex:2103
+#: lib/abuuba_web/live/settings_live.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -1529,8 +1529,8 @@ msgstr ""
 msgid "Mark as read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:433
-#: lib/abuuba_web/live/notifications_live.ex:441
+#: lib/abuuba_web/live/notifications_live.ex:430
+#: lib/abuuba_web/live/notifications_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr ""
@@ -1555,7 +1555,7 @@ msgstr ""
 msgid "People you do not follow"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:446
+#: lib/abuuba_web/live/notifications_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "Polls"
 msgstr ""
@@ -1565,28 +1565,28 @@ msgstr ""
 msgid "Private mentions out of nowhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1008
-#: lib/abuuba_web/live/admin_live.ex:1016
-#: lib/abuuba_web/live/admin_live.ex:1119
-#: lib/abuuba_web/live/admin_live.ex:1572
-#: lib/abuuba_web/live/admin_live.ex:2148
+#: lib/abuuba_web/live/admin_live.ex:1010
+#: lib/abuuba_web/live/admin_live.ex:1018
+#: lib/abuuba_web/live/admin_live.ex:1121
+#: lib/abuuba_web/live/admin_live.ex:1574
+#: lib/abuuba_web/live/admin_live.ex:2150
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:264
-#: lib/abuuba_web/live/settings_live.ex:293
-#: lib/abuuba_web/live/settings_live.ex:387
-#: lib/abuuba_web/live/settings_live.ex:424
-#: lib/abuuba_web/live/settings_live.ex:488
-#: lib/abuuba_web/live/settings_live.ex:595
-#: lib/abuuba_web/live/settings_live.ex:640
-#: lib/abuuba_web/live/settings_live.ex:673
-#: lib/abuuba_web/live/settings_live.ex:995
+#: lib/abuuba_web/live/profile_live.ex:255
+#: lib/abuuba_web/live/settings_live.ex:294
+#: lib/abuuba_web/live/settings_live.ex:388
+#: lib/abuuba_web/live/settings_live.ex:425
+#: lib/abuuba_web/live/settings_live.ex:489
+#: lib/abuuba_web/live/settings_live.ex:596
+#: lib/abuuba_web/live/settings_live.ex:641
+#: lib/abuuba_web/live/settings_live.ex:674
+#: lib/abuuba_web/live/settings_live.ex:996
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:237
+#: lib/abuuba_web/live/admin_live.ex:238
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:135
+#: lib/abuuba_web/live/settings_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
@@ -1628,7 +1628,7 @@ msgid "Your settings filed these instead of showing them."
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:186
-#: lib/abuuba_web/live/conversations_live.ex:86
+#: lib/abuuba_web/live/conversations_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "unread"
 msgstr ""
@@ -1638,14 +1638,14 @@ msgstr ""
 msgid "A name, a #tag, or some words"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2261
-#: lib/abuuba_web/live/admin_live.ex:3585
+#: lib/abuuba_web/live/admin_live.ex:2263
+#: lib/abuuba_web/live/admin_live.ex:3572
 #: lib/abuuba_web/live/search_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:305
+#: lib/abuuba_web/live/explore_live.ex:289
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:113
 #: lib/abuuba_web/live/search_live.ex:263
@@ -1653,12 +1653,12 @@ msgstr ""
 msgid "Hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:69
+#: lib/abuuba_web/live/landing_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "It runs %{software}, which is free software anybody may run."
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:83
+#: lib/abuuba_web/live/landing_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Look around first"
 msgstr ""
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "Narrowing a search"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:99
+#: lib/abuuba_web/live/landing_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted publicly here yet."
 msgstr ""
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:123
+#: lib/abuuba_web/live/explore_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:306
+#: lib/abuuba_web/live/explore_live.ex:290
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:103
 #: lib/abuuba_web/live/search_live.ex:262
@@ -1696,25 +1696,22 @@ msgstr ""
 msgid "People"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:88
+#: lib/abuuba_web/live/landing_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "Recently, from people here"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:116
-#: lib/abuuba_web/live/landing_live.ex:112
+#: lib/abuuba_web/registration_words.ex:29
 #, elixir-autogen, elixir-format
 msgid "Registration is closed here, but any other server on the network will do."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:110
-#: lib/abuuba_web/live/landing_live.ex:106
+#: lib/abuuba_web/registration_words.ex:23
 #, elixir-autogen, elixir-format
 msgid "Registration is open: anybody may sign up."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:113
-#: lib/abuuba_web/live/landing_live.ex:109
+#: lib/abuuba_web/registration_words.ex:26
 #, elixir-autogen, elixir-format
 msgid "Registration needs approval: you sign up and an admin reads your request."
 msgstr ""
@@ -1728,7 +1725,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:63
+#: lib/abuuba_web/live/landing_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr ""
@@ -1758,389 +1755,389 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:890
+#: lib/abuuba_web/live/settings_live.ex:891
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:233
+#: lib/abuuba_web/live/settings_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3370
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/admin_live.ex:3364
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:289
+#: lib/abuuba_web/live/settings_live.ex:290
 #, elixir-autogen, elixir-format
 msgid "Add a field"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:806
+#: lib/abuuba_web/live/settings_live.ex:807
 #, elixir-autogen, elixir-format
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:946
+#: lib/abuuba_web/live/settings_live.ex:947
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/settings_live.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:894
+#: lib/abuuba_web/live/settings_live.ex:895
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:983
-#: lib/abuuba_web/live/settings_live.ex:753
+#: lib/abuuba_web/live/admin_live.ex:985
+#: lib/abuuba_web/live/settings_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:222
+#: lib/abuuba_web/live/settings_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1599
+#: lib/abuuba_web/live/settings_live.ex:1600
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2121
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:200
+#: lib/abuuba_web/live/settings_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:238
+#: lib/abuuba_web/live/settings_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2095
-#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2235
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2316
+#: lib/abuuba_web/live/settings_live.ex:2317
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2317
+#: lib/abuuba_web/live/settings_live.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:253
+#: lib/abuuba_web/live/settings_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2264
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2268
+#: lib/abuuba_web/live/settings_live.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:271
+#: lib/abuuba_web/live/settings_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:975
+#: lib/abuuba_web/live/settings_live.ex:976
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:989
+#: lib/abuuba_web/live/settings_live.ex:990
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:448
+#: lib/abuuba_web/live/settings_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2097
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2094
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2272
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:544
-#: lib/abuuba_web/live/admin_live.ex:1654
-#: lib/abuuba_web/live/admin_live.ex:1770
-#: lib/abuuba_web/live/admin_live.ex:1862
-#: lib/abuuba_web/live/admin_live.ex:2186
-#: lib/abuuba_web/live/conversations_live.ex:111
-#: lib/abuuba_web/live/settings_live.ex:279
-#: lib/abuuba_web/live/settings_live.ex:314
+#: lib/abuuba_web/live/admin_live.ex:546
+#: lib/abuuba_web/live/admin_live.ex:1656
+#: lib/abuuba_web/live/admin_live.ex:1772
+#: lib/abuuba_web/live/admin_live.ex:1864
+#: lib/abuuba_web/live/admin_live.ex:2188
+#: lib/abuuba_web/live/conversations_live.ex:112
+#: lib/abuuba_web/live/settings_live.ex:280
+#: lib/abuuba_web/live/settings_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2097
+#: lib/abuuba_web/live/settings_live.ex:2104
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:907
+#: lib/abuuba_web/live/settings_live.ex:908
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:903
+#: lib/abuuba_web/live/settings_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2283
+#: lib/abuuba_web/live/settings_live.ex:2284
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:969
+#: lib/abuuba_web/live/settings_live.ex:970
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3748
-#: lib/abuuba_web/live/settings_live.ex:2086
+#: lib/abuuba_web/live/admin_live.ex:3735
+#: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1574
+#: lib/abuuba_web/live/settings_live.ex:1575
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:467
+#: lib/abuuba_web/live/settings_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2266
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2267
+#: lib/abuuba_web/live/settings_live.ex:2268
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:848
+#: lib/abuuba_web/live/settings_live.ex:849
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:873
+#: lib/abuuba_web/live/settings_live.ex:874
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:240
+#: lib/abuuba_web/live/settings_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:260
+#: lib/abuuba_web/live/settings_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:798
+#: lib/abuuba_web/live/settings_live.ex:799
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2162
-#: lib/abuuba_web/live/settings_live.ex:760
+#: lib/abuuba_web/live/admin_live.ex:2164
+#: lib/abuuba_web/live/settings_live.ex:761
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:765
+#: lib/abuuba_web/live/settings_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:2126
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:454
+#: lib/abuuba_web/live/settings_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:435
+#: lib/abuuba_web/live/settings_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2120
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:869
+#: lib/abuuba_web/live/settings_live.ex:870
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:2263
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:885
+#: lib/abuuba_web/live/settings_live.ex:886
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2123
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:986
+#: lib/abuuba_web/live/settings_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2150,13 +2147,13 @@ msgstr ""
 msgid "A handle looks like name@server."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:44
+#: lib/abuuba_web/live/about_live.ex:45
 #, elixir-autogen, elixir-format
 msgid "A server on the fediverse, running %{software}."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:23
-#: lib/abuuba_web/live/admin_live.ex:619
+#: lib/abuuba_web/live/about_live.ex:24
+#: lib/abuuba_web/live/admin_live.ex:621
 #: lib/abuuba_web/live/document_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "About"
@@ -2172,7 +2169,7 @@ msgstr ""
 msgid "Do this from your own server"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:79
+#: lib/abuuba_web/live/about_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Getting in touch"
 msgstr ""
@@ -2187,8 +2184,8 @@ msgstr ""
 msgid "No password is asked for and nothing is done on your behalf: you are simply sent to your own server's search with this address filled in."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:92
-#: lib/abuuba_web/live/admin_live.ex:1944
+#: lib/abuuba_web/live/about_live.ex:93
+#: lib/abuuba_web/live/admin_live.ex:1946
 #: lib/abuuba_web/live/document_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
@@ -2204,7 +2201,7 @@ msgstr ""
 msgid "Share"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:62
+#: lib/abuuba_web/live/about_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Signing up"
 msgstr ""
@@ -2224,8 +2221,8 @@ msgstr ""
 msgid "Take me to my server"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:91
-#: lib/abuuba_web/live/admin_live.ex:2191
+#: lib/abuuba_web/live/about_live.ex:92
+#: lib/abuuba_web/live/admin_live.ex:2193
 #: lib/abuuba_web/live/document_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
@@ -2236,17 +2233,17 @@ msgstr ""
 msgid "That is this server. Use the buttons on the post itself once you are signed in."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:52
+#: lib/abuuba_web/live/about_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "The numbers"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:67
+#: lib/abuuba_web/live/about_live.ex:68
 #, elixir-autogen, elixir-format
 msgid "The rules"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:89
+#: lib/abuuba_web/live/about_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "The small print"
 msgstr ""
@@ -2256,7 +2253,7 @@ msgstr ""
 msgid "This has not been written yet. Whoever runs this server can add it in the admin settings."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:84
+#: lib/abuuba_web/live/about_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Whoever runs this server has not published an address yet."
 msgstr ""
@@ -2271,560 +2268,560 @@ msgstr ""
 msgid "Your handle"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:102
+#: lib/abuuba_web/live/about_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "people"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:106
+#: lib/abuuba_web/live/about_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "people active this half-year"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:105
+#: lib/abuuba_web/live/about_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "people active this month"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:103
+#: lib/abuuba_web/live/about_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "posts"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:104
+#: lib/abuuba_web/live/about_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1851
+#: lib/abuuba_web/live/settings_live.ex:1858
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1195
+#: lib/abuuba_web/live/settings_live.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1225
+#: lib/abuuba_web/live/settings_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1835
+#: lib/abuuba_web/live/settings_live.ex:1842
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1192
+#: lib/abuuba_web/live/settings_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1861
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1199
-#: lib/abuuba_web/live/settings_live.ex:1831
+#: lib/abuuba_web/live/settings_live.ex:1200
+#: lib/abuuba_web/live/settings_live.ex:1838
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1170
+#: lib/abuuba_web/live/settings_live.ex:1171
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1846
+#: lib/abuuba_web/live/settings_live.ex:1853
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1845
+#: lib/abuuba_web/live/settings_live.ex:1852
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1847
+#: lib/abuuba_web/live/settings_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1852
+#: lib/abuuba_web/live/settings_live.ex:1859
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1855
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1856
+#: lib/abuuba_web/live/settings_live.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1178
+#: lib/abuuba_web/live/settings_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1216
+#: lib/abuuba_web/live/settings_live.ex:1217
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1205
+#: lib/abuuba_web/live/settings_live.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1207
+#: lib/abuuba_web/live/settings_live.ex:1208
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2246
+#: lib/abuuba_web/live/admin_live.ex:2248
 #, elixir-autogen, elixir-format
 msgid "A new rule"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2831
+#: lib/abuuba_web/live/admin_live.ex:2833
 #, elixir-autogen, elixir-format
 msgid "A rule needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3369
+#: lib/abuuba_web/live/admin_live.ex:3363
 #, elixir-autogen, elixir-format
 msgid "Accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1601
-#: lib/abuuba_web/live/admin_live.ex:1819
-#: lib/abuuba_web/live/admin_live.ex:2249
+#: lib/abuuba_web/live/admin_live.ex:1603
+#: lib/abuuba_web/live/admin_live.ex:1821
+#: lib/abuuba_web/live/admin_live.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1989
+#: lib/abuuba_web/live/admin_live.ex:1991
 #, elixir-autogen, elixir-format
 msgid "Address people can write to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:220
-#: lib/abuuba_web/live/admin_live.ex:3387
+#: lib/abuuba_web/live/admin_live.ex:221
+#: lib/abuuba_web/live/admin_live.ex:3381
 #, elixir-autogen, elixir-format
 msgid "Administration"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3731
+#: lib/abuuba_web/live/admin_live.ex:3718
 #, elixir-autogen, elixir-format
 msgid "An open server left unattended fills with spam registrations within days. Put sign-ups behind approval unless somebody is watching."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:737
+#: lib/abuuba_web/live/admin_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Any state"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3716
+#: lib/abuuba_web/live/admin_live.ex:3703
 #, elixir-autogen, elixir-format
 msgid "Anybody may sign up without being checked"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3418
+#: lib/abuuba_web/live/admin_live.ex:3412
 #, elixir-autogen, elixir-format
 msgid "Anybody, after somebody here says yes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3417
+#: lib/abuuba_web/live/admin_live.ex:3411
 #, elixir-autogen, elixir-format
 msgid "Anybody, straight away"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:730
+#: lib/abuuba_web/live/admin_live.ex:732
 #, elixir-autogen, elixir-format
 msgid "Anywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:375
-#: lib/abuuba_web/live/admin_live.ex:379
+#: lib/abuuba_web/live/admin_live.ex:377
+#: lib/abuuba_web/live/admin_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "Appeals waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3386
+#: lib/abuuba_web/live/admin_live.ex:3380
 #, elixir-autogen, elixir-format
 msgid "Audit log"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1019
+#: lib/abuuba_web/live/admin_live.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Change an address only when somebody cannot reach their own."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3368
+#: lib/abuuba_web/live/admin_live.ex:3362
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2865
+#: lib/abuuba_web/live/admin_live.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Deleting posts needs the posts named, which this page cannot do yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3428
+#: lib/abuuba_web/live/admin_live.ex:3422
 #, elixir-autogen, elixir-format
 msgid "Disable: they cannot sign in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:872
+#: lib/abuuba_web/live/admin_live.ex:874
 #, elixir-autogen, elixir-format
 msgid "Do it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:733
+#: lib/abuuba_web/live/admin_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Elsewhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1013
+#: lib/abuuba_web/live/admin_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3721
+#: lib/abuuba_web/live/admin_live.ex:3708
 #, elixir-autogen, elixir-format
 msgid "Everything else on this page is guesswork until that is fixed."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:746
-#: lib/abuuba_web/live/admin_live.ex:1470
+#: lib/abuuba_web/live/admin_live.ex:748
+#: lib/abuuba_web/live/admin_live.ex:1472
 #, elixir-autogen, elixir-format
 msgid "Find"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:731
+#: lib/abuuba_web/live/admin_live.ex:733
 #, elixir-autogen, elixir-format
 msgid "Here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:809
+#: lib/abuuba_web/live/admin_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "Let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:893
-#: lib/abuuba_web/live/admin_live.ex:1191
-#: lib/abuuba_web/live/admin_live.ex:1218
-#: lib/abuuba_web/live/admin_live.ex:1246
-#: lib/abuuba_web/live/admin_live.ex:1270
+#: lib/abuuba_web/live/admin_live.ex:895
+#: lib/abuuba_web/live/admin_live.ex:1193
+#: lib/abuuba_web/live/admin_live.ex:1220
+#: lib/abuuba_web/live/admin_live.ex:1248
+#: lib/abuuba_web/live/admin_live.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Lift it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3410
+#: lib/abuuba_web/live/admin_live.ex:3404
 #, elixir-autogen, elixir-format
 msgid "Limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3429
+#: lib/abuuba_web/live/admin_live.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Mark everything they post sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:726
+#: lib/abuuba_web/live/admin_live.ex:728
 #, elixir-autogen, elixir-format
 msgid "Name or name@server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3737
+#: lib/abuuba_web/live/admin_live.ex:3724
 #, elixir-autogen, elixir-format
 msgid "Nobody can grant roles or change settings that need it. Give somebody a role holding the administrator permission."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3717
+#: lib/abuuba_web/live/admin_live.ex:3704
 #, elixir-autogen, elixir-format
 msgid "Nobody here is an administrator"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:827
+#: lib/abuuba_web/live/admin_live.ex:829
 #, elixir-autogen, elixir-format
 msgid "Nobody here matches that."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:998
+#: lib/abuuba_web/live/admin_live.ex:1000
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2281
+#: lib/abuuba_web/live/admin_live.ex:2283
 #, elixir-autogen, elixir-format
 msgid "Nothing has been done yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:416
-#: lib/abuuba_web/live/admin_live.ex:441
-#: lib/abuuba_web/live/admin_live.ex:699
-#: lib/abuuba_web/live/admin_live.ex:898
+#: lib/abuuba_web/live/admin_live.ex:418
+#: lib/abuuba_web/live/admin_live.ex:443
+#: lib/abuuba_web/live/admin_live.ex:701
+#: lib/abuuba_web/live/admin_live.ex:900
 #, elixir-autogen, elixir-format
 msgid "Nothing yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:455
+#: lib/abuuba_web/live/admin_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "Nothing. Every check this server knows how to make came back fine."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:383
+#: lib/abuuba_web/live/admin_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "People waiting to be let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:367
+#: lib/abuuba_web/live/admin_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Reports waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2239
+#: lib/abuuba_web/live/admin_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Retire it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:996
+#: lib/abuuba_web/live/admin_live.ex:998
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2225
+#: lib/abuuba_web/live/admin_live.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Rules people agree to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3425
+#: lib/abuuba_web/live/admin_live.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Send a warning and nothing else"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1467
-#: lib/abuuba_web/live/admin_live.ex:1907
+#: lib/abuuba_web/live/admin_live.ex:1469
+#: lib/abuuba_web/live/admin_live.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Server name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3385
+#: lib/abuuba_web/live/admin_live.ex:3379
 #, elixir-autogen, elixir-format
 msgid "Server settings"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3725
+#: lib/abuuba_web/live/admin_live.ex:3712
 #, elixir-autogen, elixir-format
 msgid "Servers running authorized fetch will refuse this one. It is created on first use, so this usually means something went wrong writing it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2264
+#: lib/abuuba_web/live/admin_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2227
+#: lib/abuuba_web/live/admin_live.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Shown when somebody signs up and when they file a report."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3426
+#: lib/abuuba_web/live/admin_live.ex:3420
 #, elixir-autogen, elixir-format
 msgid "Silence: out of everywhere nobody asked for them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3427
+#: lib/abuuba_web/live/admin_live.ex:3421
 #, elixir-autogen, elixir-format
 msgid "Suspend: hidden, and deleted after the grace window"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3411
+#: lib/abuuba_web/live/admin_live.ex:3405
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2057
+#: lib/abuuba_web/live/admin_live.ex:2059
 #, elixir-autogen, elixir-format
 msgid "Talk only to servers on the allowlist"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3333
+#: lib/abuuba_web/live/admin_live.ex:3330
 #, elixir-autogen, elixir-format
 msgid "That account outranks yours, so there is nothing here you can do to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2869
-#: lib/abuuba_web/live/admin_live.ex:2881
+#: lib/abuuba_web/live/admin_live.ex:2871
+#: lib/abuuba_web/live/admin_live.ex:2883
 #, elixir-autogen, elixir-format
 msgid "That could not be done."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2458
+#: lib/abuuba_web/live/admin_live.ex:2460
 #, elixir-autogen, elixir-format
 msgid "That is not a role you can hand out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2473
+#: lib/abuuba_web/live/admin_live.ex:2475
 #, elixir-autogen, elixir-format
 msgid "That is not an address."
 msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
-#: lib/abuuba_web/live/admin_live.ex:3328
-#: lib/abuuba_web/live/settings_live.ex:1627
+#: lib/abuuba_web/live/admin_live.ex:3325
+#: lib/abuuba_web/live/settings_live.ex:1628
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3714
+#: lib/abuuba_web/live/admin_live.ex:3701
 #, elixir-autogen, elixir-format
 msgid "The database is not answering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:846
+#: lib/abuuba_web/live/admin_live.ex:848
 #, elixir-autogen, elixir-format
 msgid "This account outranks yours, so there is nothing here you can do to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:817
+#: lib/abuuba_web/live/admin_live.ex:819
 #, elixir-autogen, elixir-format
 msgid "This deletes the account as well. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3715
+#: lib/abuuba_web/live/admin_live.ex:3702
 #, elixir-autogen, elixir-format
 msgid "This server has no actor of its own"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:819
+#: lib/abuuba_web/live/admin_live.ex:821
 #, elixir-autogen, elixir-format
 msgid "Turn away"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3409
+#: lib/abuuba_web/live/admin_live.ex:3403
 #, elixir-autogen, elixir-format
 msgid "Waiting to be let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:875
+#: lib/abuuba_web/live/admin_live.ex:877
 #, elixir-autogen, elixir-format
 msgid "What has been decided about them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:444
+#: lib/abuuba_web/live/admin_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "What needs attention"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1912
+#: lib/abuuba_web/live/admin_live.ex:1914
 #, elixir-autogen, elixir-format
 msgid "What this server is for"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:861
+#: lib/abuuba_web/live/admin_live.ex:863
 #, elixir-autogen, elixir-format
 msgid "What to do"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2012
+#: lib/abuuba_web/live/admin_live.ex:2014
 #, elixir-autogen, elixir-format
 msgid "What to say when nobody may sign up"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:868
+#: lib/abuuba_web/live/admin_live.ex:870
 #, elixir-autogen, elixir-format
 msgid "What to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1999
+#: lib/abuuba_web/live/admin_live.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Who may sign up"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:884
+#: lib/abuuba_web/live/admin_live.ex:886
 #, elixir-autogen, elixir-format
 msgid "lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:799
+#: lib/abuuba_web/live/admin_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:798
+#: lib/abuuba_web/live/admin_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2270
+#: lib/abuuba_web/live/admin_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "the server"
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:307
-#: lib/abuuba_web/live/admin_live.ex:1075
+#: lib/abuuba_web/live/admin_live.ex:1077
 #, elixir-autogen, elixir-format
 msgid "%{count} person"
 msgid_plural "%{count} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1031
+#: lib/abuuba_web/live/admin_live.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Nothing appears in the trending lists until somebody here has looked at it. This is what is waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1090
+#: lib/abuuba_web/live/admin_live.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Nothing is trending. That is what a quiet day looks like."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1065
+#: lib/abuuba_web/live/admin_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting to be looked at."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1058
+#: lib/abuuba_web/live/admin_live.ex:1060
 #, elixir-autogen, elixir-format
 msgid "Refuse"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1084
-#: lib/abuuba_web/live/admin_live.ex:1142
+#: lib/abuuba_web/live/admin_live.ex:1086
+#: lib/abuuba_web/live/admin_live.ex:1144
 #, elixir-autogen, elixir-format
 msgid "Take it down"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3375
+#: lib/abuuba_web/live/admin_live.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Trends"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1068
+#: lib/abuuba_web/live/admin_live.ex:1070
 #, elixir-autogen, elixir-format
 msgid "What is trending now"
 msgstr ""
@@ -2834,32 +2831,32 @@ msgstr ""
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1241
+#: lib/abuuba_web/live/settings_live.ex:1242
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2513
+#: lib/abuuba_web/live/admin_live.ex:2515
 #, elixir-autogen, elixir-format
 msgid "An announcement needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3376
+#: lib/abuuba_web/live/admin_live.ex:3370
 #, elixir-autogen, elixir-format
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2136
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2193
+#: lib/abuuba_web/live/admin_live.ex:2195
 #, elixir-autogen, elixir-format
 msgid "Each version is kept with the day it takes effect, so somebody can still read what they agreed to."
 msgstr ""
@@ -2869,22 +2866,22 @@ msgstr ""
 msgid "Earlier versions"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3794
+#: lib/abuuba_web/live/admin_live.ex:3781
 #, elixir-autogen, elixir-format
 msgid "Everybody has already been told about that one."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1130
+#: lib/abuuba_web/live/admin_live.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1252
+#: lib/abuuba_web/live/settings_live.ex:1253
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2201
+#: lib/abuuba_web/live/admin_live.ex:2203
 #, elixir-autogen, elixir-format
 msgid "In effect from"
 msgstr ""
@@ -2894,83 +2891,83 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1236
+#: lib/abuuba_web/live/settings_live.ex:1237
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1115
+#: lib/abuuba_web/live/admin_live.ex:1117
 #, elixir-autogen, elixir-format
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1259
+#: lib/abuuba_web/live/settings_live.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1133
+#: lib/abuuba_web/live/admin_live.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Not published"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1148
+#: lib/abuuba_web/live/admin_live.ex:1150
 #, elixir-autogen, elixir-format
 msgid "Nothing has been announced."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2204
+#: lib/abuuba_web/live/admin_live.ex:2206
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1127
+#: lib/abuuba_web/live/admin_live.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Published"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1100
+#: lib/abuuba_web/live/admin_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1273
+#: lib/abuuba_web/live/settings_live.ex:1274
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2220
+#: lib/abuuba_web/live/admin_live.ex:2222
 #, elixir-autogen, elixir-format
 msgid "Tell everybody"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2539
+#: lib/abuuba_web/live/admin_live.ex:2541
 #, elixir-autogen, elixir-format
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1257
+#: lib/abuuba_web/live/settings_live.ex:1258
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1248
+#: lib/abuuba_web/live/settings_live.ex:1249
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1107
-#: lib/abuuba_web/live/admin_live.ex:2085
+#: lib/abuuba_web/live/admin_live.ex:1109
+#: lib/abuuba_web/live/admin_live.ex:2087
 #, elixir-autogen, elixir-format
 msgid "What to say"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1112
+#: lib/abuuba_web/live/admin_live.ex:1114
 #, elixir-autogen, elixir-format
 msgid "When to publish it"
 msgstr ""
@@ -2980,76 +2977,76 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1279
+#: lib/abuuba_web/live/settings_live.ex:1280
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2211
+#: lib/abuuba_web/live/admin_live.ex:2213
 #, elixir-autogen, elixir-format
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2088
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1198
+#: lib/abuuba_web/live/admin_live.ex:1200
 #, elixir-autogen, elixir-format
 msgid "Addresses"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1230
+#: lib/abuuba_web/live/admin_live.ex:1232
 #, elixir-autogen, elixir-format
 msgid "Anywhere in a name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3776
+#: lib/abuuba_web/live/admin_live.ex:3763
 #, elixir-autogen, elixir-format
 msgid "Ask for approval"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1175
-#: lib/abuuba_web/live/admin_live.ex:1204
-#: lib/abuuba_web/live/admin_live.ex:1232
+#: lib/abuuba_web/live/admin_live.ex:1177
+#: lib/abuuba_web/live/admin_live.ex:1206
+#: lib/abuuba_web/live/admin_live.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Block it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1253
+#: lib/abuuba_web/live/admin_live.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Email addresses"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1255
+#: lib/abuuba_web/live/admin_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "Kept as hashes rather than addresses. The list has to recognise somebody coming back, not be readable."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1164
+#: lib/abuuba_web/live/admin_live.ex:1166
 #, elixir-autogen, elixir-format
 msgid "Mail domains"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3778
+#: lib/abuuba_web/live/admin_live.ex:3765
 #, elixir-autogen, elixir-format
 msgid "No access at all"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3777
+#: lib/abuuba_web/live/admin_live.ex:3764
 #, elixir-autogen, elixir-format
 msgid "No sign-ups"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1276
+#: lib/abuuba_web/live/admin_live.ex:1278
 #, elixir-autogen, elixir-format
 msgid "None. One is added when an account is suspended and you ask for it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1173
+#: lib/abuuba_web/live/admin_live.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Only ask for approval"
 msgstr ""
@@ -3059,7 +3056,7 @@ msgstr ""
 msgid "Please complete the puzzle so we know you are a person."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3377
+#: lib/abuuba_web/live/admin_live.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Sign-up blocks"
 msgstr ""
@@ -3079,22 +3076,22 @@ msgstr ""
 msgid "This server asks new accounts to solve a puzzle first."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1225
+#: lib/abuuba_web/live/admin_live.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Usernames"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1158
+#: lib/abuuba_web/live/admin_live.ex:1160
 #, elixir-autogen, elixir-format
 msgid "What this server refuses at the door. Most of these have a middle setting that asks somebody to look rather than shutting the door."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1238
+#: lib/abuuba_web/live/admin_live.ex:1240
 #, elixir-autogen, elixir-format
 msgid "anywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1182
+#: lib/abuuba_web/live/admin_live.ex:1184
 #, elixir-autogen, elixir-format
 msgid "approval only"
 msgstr ""
@@ -3104,11 +3101,11 @@ msgstr ""
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:208
+#: lib/abuuba_web/live/explore_live.ex:204
 #: lib/abuuba_web/live/home_live.ex:337
-#: lib/abuuba_web/live/profile_live.ex:529
+#: lib/abuuba_web/live/profile_live.ex:518
 #: lib/abuuba_web/live/search_live.ex:195
-#: lib/abuuba_web/live/status_live.ex:184
+#: lib/abuuba_web/live/status_live.ex:185
 #: lib/abuuba_web/live/tag_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "That could not be translated just now."
@@ -3129,245 +3126,245 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1980
+#: lib/abuuba_web/live/settings_live.ex:1987
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1971
+#: lib/abuuba_web/live/settings_live.ex:1978
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1887
+#: lib/abuuba_web/live/settings_live.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2044
+#: lib/abuuba_web/live/settings_live.ex:2051
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1868
+#: lib/abuuba_web/live/settings_live.ex:1875
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2109
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1893
+#: lib/abuuba_web/live/settings_live.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2066
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2132
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2068
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2040
+#: lib/abuuba_web/live/settings_live.ex:2047
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2055
-#: lib/abuuba_web/live/settings_live.ex:2060
+#: lib/abuuba_web/live/settings_live.ex:2062
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2057
+#: lib/abuuba_web/live/settings_live.ex:2064
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2058
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1877
+#: lib/abuuba_web/live/settings_live.ex:1884
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2072
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1874
+#: lib/abuuba_web/live/settings_live.ex:1881
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1882
+#: lib/abuuba_web/live/settings_live.ex:1889
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2071
+#: lib/abuuba_web/live/settings_live.ex:2078
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2080
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2077
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2082
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2076
+#: lib/abuuba_web/live/settings_live.ex:2083
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1044
+#: lib/abuuba_web/live/settings_live.ex:1045
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1926
+#: lib/abuuba_web/live/settings_live.ex:1933
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1039
+#: lib/abuuba_web/live/settings_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1944
+#: lib/abuuba_web/live/settings_live.ex:1951
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1049
+#: lib/abuuba_web/live/settings_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1037
+#: lib/abuuba_web/live/settings_live.ex:1038
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1006
+#: lib/abuuba_web/live/settings_live.ex:1007
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1957
+#: lib/abuuba_web/live/settings_live.ex:1964
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1934
+#: lib/abuuba_web/live/settings_live.ex:1941
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1063
-#: lib/abuuba_web/live/settings_live.ex:1906
-#: lib/abuuba_web/live/settings_live.ex:2231
+#: lib/abuuba_web/live/settings_live.ex:1064
+#: lib/abuuba_web/live/settings_live.ex:1913
+#: lib/abuuba_web/live/settings_live.ex:2232
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1033
+#: lib/abuuba_web/live/settings_live.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1017
+#: lib/abuuba_web/live/settings_live.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2030
+#: lib/abuuba_web/live/settings_live.ex:2037
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1001
+#: lib/abuuba_web/live/settings_live.ex:1002
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1930
+#: lib/abuuba_web/live/settings_live.ex:1937
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2020
+#: lib/abuuba_web/live/settings_live.ex:2027
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2031
+#: lib/abuuba_web/live/settings_live.ex:2038
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1908
+#: lib/abuuba_web/live/settings_live.ex:1915
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1027
+#: lib/abuuba_web/live/settings_live.ex:1028
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:999
+#: lib/abuuba_web/live/settings_live.ex:1000
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1923
+#: lib/abuuba_web/live/settings_live.ex:1930
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2026
+#: lib/abuuba_web/live/settings_live.ex:2033
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
@@ -3377,109 +3374,109 @@ msgstr ""
 msgid "No such post here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:243
+#: lib/abuuba_web/live/settings_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:781
+#: lib/abuuba_web/live/settings_live.ex:782
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:794
+#: lib/abuuba_web/live/settings_live.ex:795
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:778
+#: lib/abuuba_web/live/settings_live.ex:779
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1513
+#: lib/abuuba_web/live/settings_live.ex:1514
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:796
+#: lib/abuuba_web/live/admin_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "Why they want to join:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:306
+#: lib/abuuba_web/live/settings_live.ex:307
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:323
+#: lib/abuuba_web/live/settings_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:326
+#: lib/abuuba_web/live/settings_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "Feature it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:297
+#: lib/abuuba_web/live/settings_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:299
+#: lib/abuuba_web/live/settings_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1496
+#: lib/abuuba_web/live/settings_live.ex:1497
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:330
+#: lib/abuuba_web/live/settings_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1490
+#: lib/abuuba_web/live/settings_live.ex:1491
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:481
+#: lib/abuuba_web/live/settings_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:483
+#: lib/abuuba_web/live/settings_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:915
+#: lib/abuuba_web/live/admin_live.ex:917
 #, elixir-autogen, elixir-format
 msgid "Mark as a memorial"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:902
+#: lib/abuuba_web/live/admin_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "Marking an account as a memorial stops it being signed in to and marks the profile as one. Nothing is hidden and nothing is deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2304
+#: lib/abuuba_web/live/admin_live.ex:2306
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:910
+#: lib/abuuba_web/live/admin_live.ex:912
 #, elixir-autogen, elixir-format
 msgid "This also disables their login. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:914
+#: lib/abuuba_web/live/admin_live.ex:916
 #, elixir-autogen, elixir-format
 msgid "This is not a memorial"
 msgstr ""
@@ -3491,7 +3488,7 @@ msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/collection_live.ex:115
+#: lib/abuuba_web/live/collection_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "A collection by %{name}"
 msgstr ""
@@ -3511,7 +3508,7 @@ msgstr ""
 msgid "Nobody is on this list yet."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:117
+#: lib/abuuba_web/live/annual_report_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "%{count} posts in %{year}"
 msgstr ""
@@ -3521,7 +3518,7 @@ msgstr ""
 msgid "%{name}'s year"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:109
+#: lib/abuuba_web/live/annual_report_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "Asked a lot of questions."
 msgstr ""
@@ -3531,7 +3528,7 @@ msgstr ""
 msgid "Counted from public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:108
+#: lib/abuuba_web/live/annual_report_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Mostly here to pass on what other people said."
 msgstr ""
@@ -3546,12 +3543,12 @@ msgstr ""
 msgid "Posts this year"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:107
+#: lib/abuuba_web/live/annual_report_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Read a lot more than they wrote."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:110
+#: lib/abuuba_web/live/annual_report_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Spent the year in other people's threads."
 msgstr ""
@@ -3561,22 +3558,22 @@ msgstr ""
 msgid "Written about most"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:111
+#: lib/abuuba_web/live/annual_report_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Wrote things other people replied to."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2098
+#: lib/abuuba_web/live/admin_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "An http or https address. Anything else is refused and nothing is shown."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2077
+#: lib/abuuba_web/live/admin_live.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Asking for money"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2079
+#: lib/abuuba_web/live/admin_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Clients show this to people signed in here. Leave the message empty to show nothing."
 msgstr ""
@@ -3596,13 +3593,13 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2072
+#: lib/abuuba_web/live/admin_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "Each person still has to turn it on for themselves, and every address has to confirm before anything is sent to it."
 msgstr ""
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:644
+#: lib/abuuba_web/live/settings_live.ex:645
 #, elixir-autogen, elixir-format
 msgid "Email updates"
 msgstr ""
@@ -3617,7 +3614,7 @@ msgstr ""
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:662
+#: lib/abuuba_web/live/settings_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr ""
@@ -3627,7 +3624,7 @@ msgstr ""
 msgid "No, remove my address"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:664
+#: lib/abuuba_web/live/settings_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3655,12 +3652,12 @@ msgstr ""
 msgid "This address is getting updates. You can stop them at any time."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2103
+#: lib/abuuba_web/live/admin_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "What the button says"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2090
+#: lib/abuuba_web/live/admin_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Where the button goes"
 msgstr ""
@@ -3675,12 +3672,12 @@ msgstr ""
 msgid "somebody gave this address to receive updates from %{name} on %{site}. If that was you, confirm it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2069
+#: lib/abuuba_web/live/admin_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "Let people collect email addresses for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:646
+#: lib/abuuba_web/live/settings_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr ""
@@ -3828,75 +3825,75 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1076
+#: lib/abuuba_web/live/settings_live.ex:1077
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2239
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:809
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:810
+#: lib/abuuba_web/live/settings_live.ex:2233
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1301
-#: lib/abuuba_web/live/admin_live.ex:1316
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/admin_live.ex:1303
+#: lib/abuuba_web/live/admin_live.ex:1318
+#: lib/abuuba_web/live/settings_live.ex:2230
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2234
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1118
+#: lib/abuuba_web/live/settings_live.ex:1119
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2240
+#: lib/abuuba_web/live/settings_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1101
+#: lib/abuuba_web/live/settings_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2103
+#: lib/abuuba_web/live/settings_live.ex:2110
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2230
+#: lib/abuuba_web/live/settings_live.ex:2231
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1065
+#: lib/abuuba_web/live/settings_live.ex:1066
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1386
+#: lib/abuuba_web/live/settings_live.ex:1387
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1083
+#: lib/abuuba_web/live/settings_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3916,13 +3913,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2237
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1107
-#: lib/abuuba_web/live/settings_live.ex:1392
+#: lib/abuuba_web/live/settings_live.ex:1108
+#: lib/abuuba_web/live/settings_live.ex:1393
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3932,7 +3929,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1078
+#: lib/abuuba_web/live/settings_live.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3942,87 +3939,87 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1157
+#: lib/abuuba_web/live/settings_live.ex:1158
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1155
+#: lib/abuuba_web/live/settings_live.ex:1156
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1121
+#: lib/abuuba_web/live/settings_live.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1060
+#: lib/abuuba_web/live/settings_live.ex:1061
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2135
+#: lib/abuuba_web/live/settings_live.ex:2142
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1138
+#: lib/abuuba_web/live/settings_live.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1419
+#: lib/abuuba_web/live/settings_live.ex:1420
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1416
+#: lib/abuuba_web/live/settings_live.ex:1417
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1128
+#: lib/abuuba_web/live/settings_live.ex:1129
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1412
+#: lib/abuuba_web/live/settings_live.ex:1413
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1143
+#: lib/abuuba_web/live/settings_live.ex:1144
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1123
+#: lib/abuuba_web/live/settings_live.ex:1124
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1133
+#: lib/abuuba_web/live/settings_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
 
-#: lib/abuuba_web/controllers/feed_controller.ex:131
+#: lib/abuuba_web/controllers/feed_controller.ex:132
 #, elixir-autogen, elixir-format
 msgid "A post"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:399
+#: lib/abuuba_web/live/profile_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Nobody yet."
 msgstr ""
 
-#: lib/abuuba_web/controllers/feed_controller.ex:76
+#: lib/abuuba_web/controllers/feed_controller.ex:77
 #, elixir-autogen, elixir-format
 msgid "Public posts tagged #%{tag}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:376
+#: lib/abuuba_web/live/profile_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr ""
@@ -4048,99 +4045,99 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1448
+#: lib/abuuba_web/live/settings_live.ex:1449
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:913
+#: lib/abuuba_web/live/settings_live.ex:914
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:522
+#: lib/abuuba_web/live/settings_live.ex:523
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:531
+#: lib/abuuba_web/live/settings_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:550
+#: lib/abuuba_web/live/settings_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:577
+#: lib/abuuba_web/live/settings_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:566
+#: lib/abuuba_web/live/settings_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:562
+#: lib/abuuba_web/live/settings_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:936
+#: lib/abuuba_web/live/settings_live.ex:937
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:519
+#: lib/abuuba_web/live/settings_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:932
+#: lib/abuuba_web/live/settings_live.ex:933
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:524
+#: lib/abuuba_web/live/settings_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:588
+#: lib/abuuba_web/live/settings_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:499
+#: lib/abuuba_web/live/settings_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:911
+#: lib/abuuba_web/live/settings_live.ex:912
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:921
+#: lib/abuuba_web/live/settings_live.ex:922
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:921
+#: lib/abuuba_web/live/settings_live.ex:922
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:513
+#: lib/abuuba_web/live/settings_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:501
+#: lib/abuuba_web/live/settings_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr ""
@@ -4150,7 +4147,7 @@ msgstr ""
 msgid "Mail about your own account — password resets and the like — still comes."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2141
+#: lib/abuuba_web/live/admin_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Served from this server and linked from every page. It goes out exactly as typed."
 msgstr ""
@@ -4176,7 +4173,7 @@ msgstr ""
 msgid "You will not get that kind of email from us again."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2139
+#: lib/abuuba_web/live/admin_live.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Your own CSS"
 msgstr ""
@@ -4196,649 +4193,649 @@ msgstr ""
 msgid "the occasional summary of what you missed"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1588
+#: lib/abuuba_web/live/admin_live.ex:1590
 #, elixir-autogen, elixir-format
 msgid "A relay forwards every public post it is sent on to everybody subscribed to it. On a young server it is the quickest way to have a federated timeline with anything in it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1511
-#: lib/abuuba_web/live/admin_live.ex:1623
+#: lib/abuuba_web/live/admin_live.ex:1513
+#: lib/abuuba_web/live/admin_live.ex:1625
 #, elixir-autogen, elixir-format
 msgid "Last error:"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1660
+#: lib/abuuba_web/live/admin_live.ex:1662
 #, elixir-autogen, elixir-format
 msgid "No relays yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3679
+#: lib/abuuba_web/live/admin_live.ex:3666
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3681
+#: lib/abuuba_web/live/admin_live.ex:3668
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/admin_live.ex:3372
 #, elixir-autogen, elixir-format
 msgid "Relays"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1652
+#: lib/abuuba_web/live/admin_live.ex:1654
 #, elixir-autogen, elixir-format
 msgid "Remove this relay?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2811
+#: lib/abuuba_web/live/admin_live.ex:2813
 #, elixir-autogen, elixir-format
 msgid "That is not an https inbox address, or it is already here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3682
+#: lib/abuuba_web/live/admin_live.ex:3669
 #, elixir-autogen, elixir-format
 msgid "The relay refused"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1605
+#: lib/abuuba_web/live/admin_live.ex:1607
 #, elixir-autogen, elixir-format
 msgid "The relay's inbox address, which its operator publishes. Adding and turning on are separate steps, so a mistyped address can be corrected before anything is sent to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1644
-#: lib/abuuba_web/live/admin_live.ex:1842
+#: lib/abuuba_web/live/admin_live.ex:1646
+#: lib/abuuba_web/live/admin_live.ex:1844
 #, elixir-autogen, elixir-format
 msgid "Turn off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1634
-#: lib/abuuba_web/live/admin_live.ex:1842
+#: lib/abuuba_web/live/admin_live.ex:1636
+#: lib/abuuba_web/live/admin_live.ex:1844
 #, elixir-autogen, elixir-format
 msgid "Turn on"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3680
+#: lib/abuuba_web/live/admin_live.ex:3667
 #, elixir-autogen, elixir-format
 msgid "Waiting for the relay to answer"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1617
+#: lib/abuuba_web/live/admin_live.ex:1619
 #, elixir-autogen, elixir-format
 msgid "last sent %{when}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1823
+#: lib/abuuba_web/live/admin_live.ex:1825
 #, elixir-autogen, elixir-format
 msgid "Added turned off, so a URL typed wrong can be corrected before anything goes to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1798
+#: lib/abuuba_web/live/admin_live.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Copy it now. It is not shown again."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1852
+#: lib/abuuba_web/live/admin_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "New secret"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1894
+#: lib/abuuba_web/live/admin_live.ex:1896
 #, elixir-autogen, elixir-format
 msgid "No webhooks yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1889
+#: lib/abuuba_web/live/admin_live.ex:1891
 #, elixir-autogen, elixir-format
 msgid "Nothing sent yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1860
+#: lib/abuuba_web/live/admin_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Remove this webhook?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3097
-#: lib/abuuba_web/live/admin_live.ex:3675
+#: lib/abuuba_web/live/admin_live.ex:3094
+#: lib/abuuba_web/live/admin_live.ex:3662
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3672
+#: lib/abuuba_web/live/admin_live.ex:3659
 #, elixir-autogen, elixir-format
 msgid "That is not an event this server sends."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3669
+#: lib/abuuba_web/live/admin_live.ex:3656
 #, elixir-autogen, elixir-format
 msgid "That is not an https address, or it is already here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1850
+#: lib/abuuba_web/live/admin_live.ex:1852
 #, elixir-autogen, elixir-format
 msgid "The old secret stops working immediately. Continue?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1796
+#: lib/abuuba_web/live/admin_live.ex:1798
 #, elixir-autogen, elixir-format
 msgid "The signing secret"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1790
+#: lib/abuuba_web/live/admin_live.ex:1792
 #, elixir-autogen, elixir-format
 msgid "This server posts to a webhook when something happens that a moderator would want to know about."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3384
+#: lib/abuuba_web/live/admin_live.ex:3378
 #, elixir-autogen, elixir-format
 msgid "Webhooks"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1875
+#: lib/abuuba_web/live/admin_live.ex:1877
 #, elixir-autogen, elixir-format
 msgid "no answer"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1672
+#: lib/abuuba_web/live/admin_live.ex:1674
 #, elixir-autogen, elixir-format
 msgid "A role is a set of permissions and a position. Position is what decides who may act on whom: nobody may edit a role at or above their own, and nobody may grant a permission they do not hold themselves."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1774
+#: lib/abuuba_web/live/admin_live.ex:1776
 #, elixir-autogen, elixir-format
 msgid "Above yours"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3588
+#: lib/abuuba_web/live/admin_live.ex:3575
 #, elixir-autogen, elixir-format
 msgid "Act on accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3592
+#: lib/abuuba_web/live/admin_live.ex:3579
 #, elixir-autogen, elixir-format
 msgid "Answer appeals"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3618
+#: lib/abuuba_web/live/admin_live.ex:3605
 #, elixir-autogen, elixir-format
 msgid "Approve registrations, and turn two-factor off for somebody locked out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3596
+#: lib/abuuba_web/live/admin_live.ex:3583
 #, elixir-autogen, elixir-format
 msgid "Approve what trends"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3626
+#: lib/abuuba_web/live/admin_live.ex:3613
 #, elixir-autogen, elixir-format
 msgid "Block and unblock other servers, and set up relays."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3594
+#: lib/abuuba_web/live/admin_live.ex:3581
 #, elixir-autogen, elixir-format
 msgid "Block sign-ups"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3595
+#: lib/abuuba_web/live/admin_live.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Change the server's settings"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1697
+#: lib/abuuba_web/live/admin_live.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Colour"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1736
+#: lib/abuuba_web/live/admin_live.ex:1738
 #, elixir-autogen, elixir-format
 msgid "Create the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3593
+#: lib/abuuba_web/live/admin_live.ex:3580
 #, elixir-autogen, elixir-format
 msgid "Decide about other servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3632
+#: lib/abuuba_web/live/admin_live.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Decide which hashtags, links and posts may appear in what is trending."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3590
+#: lib/abuuba_web/live/admin_live.ex:3577
 #, elixir-autogen, elixir-format
 msgid "Delete an account's data"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3621
+#: lib/abuuba_web/live/admin_live.ex:3608
 #, elixir-autogen, elixir-format
 msgid "Delete somebody's posts and files. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3607
+#: lib/abuuba_web/live/admin_live.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Every permission below, including ones added later. Give it to very few people."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3591
+#: lib/abuuba_web/live/admin_live.ex:3578
 #, elixir-autogen, elixir-format
 msgid "Handle reports"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3589
+#: lib/abuuba_web/live/admin_live.ex:3576
 #, elixir-autogen, elixir-format
 msgid "Let people in and out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3636
+#: lib/abuuba_web/live/admin_live.ex:3623
 #, elixir-autogen, elixir-format
 msgid "Make and change roles, never above their own and never granting more than they hold."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3601
+#: lib/abuuba_web/live/admin_live.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Manage custom emoji"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3597
+#: lib/abuuba_web/live/admin_live.ex:3584
 #, elixir-autogen, elixir-format
 msgid "Manage everybody's invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3603
+#: lib/abuuba_web/live/admin_live.ex:3590
 #, elixir-autogen, elixir-format
 msgid "Manage roles"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3602
+#: lib/abuuba_web/live/admin_live.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Manage webhooks"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1682
+#: lib/abuuba_web/live/admin_live.ex:1684
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1779
+#: lib/abuuba_web/live/admin_live.ex:1781
 #, elixir-autogen, elixir-format
 msgid "No roles yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1687
+#: lib/abuuba_web/live/admin_live.ex:1689
 #, elixir-autogen, elixir-format
 msgid "Position"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1750
+#: lib/abuuba_web/live/admin_live.ex:1752
 #, elixir-autogen, elixir-format
 msgid "Position %{position}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3587
+#: lib/abuuba_web/live/admin_live.ex:3574
 #, elixir-autogen, elixir-format
 msgid "Read the audit log"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3623
+#: lib/abuuba_web/live/admin_live.ex:3610
 #, elixir-autogen, elixir-format
 msgid "Read the queue, resolve and reopen."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1768
+#: lib/abuuba_web/live/admin_live.ex:1770
 #, elixir-autogen, elixir-format
 msgid "Remove this role? Anybody holding it keeps their account."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3383
+#: lib/abuuba_web/live/admin_live.ex:3377
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1736
+#: lib/abuuba_web/live/admin_live.ex:1738
 #, elixir-autogen, elixir-format
 msgid "Save the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3586
+#: lib/abuuba_web/live/admin_live.ex:3573
 #, elixir-autogen, elixir-format
 msgid "See the admin area"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3615
+#: lib/abuuba_web/live/admin_live.ex:3602
 #, elixir-autogen, elixir-format
 msgid "Silence, suspend, approve and reject accounts on this server."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3500
-#: lib/abuuba_web/live/admin_live.ex:3526
+#: lib/abuuba_web/live/admin_live.ex:3487
+#: lib/abuuba_web/live/admin_live.ex:3513
 #, elixir-autogen, elixir-format
 msgid "That role could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3612
+#: lib/abuuba_web/live/admin_live.ex:3599
 #, elixir-autogen, elixir-format
 msgid "What every moderator has done, including this person's own actions."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1709
+#: lib/abuuba_web/live/admin_live.ex:1711
 #, elixir-autogen, elixir-format
 msgid "What this role may do"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3629
+#: lib/abuuba_web/live/admin_live.ex:3616
 #, elixir-autogen, elixir-format
 msgid "Who may sign up, the server's name and description, and the rest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3609
+#: lib/abuuba_web/live/admin_live.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Without this the admin area is closed."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3600
+#: lib/abuuba_web/live/admin_live.ex:3587
 #, elixir-autogen, elixir-format
 msgid "Write announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3598
+#: lib/abuuba_web/live/admin_live.ex:3585
 #, elixir-autogen, elixir-format
 msgid "Write invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3599
+#: lib/abuuba_web/live/admin_live.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Write the server rules"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3579
+#: lib/abuuba_web/live/admin_live.ex:3566
 #, elixir-autogen, elixir-format
 msgid "You cannot make a role at or above your own position, or grant a permission you do not hold."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1729
+#: lib/abuuba_web/live/admin_live.ex:1731
 #, elixir-autogen, elixir-format
 msgid "You do not hold this yourself, so you cannot grant it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3649
+#: lib/abuuba_web/live/admin_live.ex:3636
 #, elixir-autogen, elixir-format
 msgid "nothing in particular"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:920
-#: lib/abuuba_web/live/admin_live.ex:1569
+#: lib/abuuba_web/live/admin_live.ex:922
+#: lib/abuuba_web/live/admin_live.ex:1571
 #, elixir-autogen, elixir-format
 msgid "A note for the other moderators"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1546
+#: lib/abuuba_web/live/admin_live.ex:1548
 #, elixir-autogen, elixir-format
 msgid "Blocked: %{severity}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1504
+#: lib/abuuba_web/live/admin_live.ex:1506
 #, elixir-autogen, elixir-format
 msgid "Delivering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1490
+#: lib/abuuba_web/live/admin_live.ex:1492
 #, elixir-autogen, elixir-format
 msgid "Delivery stopped by a moderator"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1457
+#: lib/abuuba_web/live/admin_live.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Every server this one has heard from, busiest first. A peer that has quietly stopped accepting deliveries looks exactly like a peer whose people have gone quiet, and this is where the two are told apart."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1542
+#: lib/abuuba_web/live/admin_live.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Forget the failures"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1578
+#: lib/abuuba_web/live/admin_live.ex:1580
 #, elixir-autogen, elixir-format
 msgid "No other servers yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1482
+#: lib/abuuba_web/live/admin_live.ex:1484
 #, elixir-autogen, elixir-format
 msgid "One account"
 msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3382
+#: lib/abuuba_web/live/admin_live.ex:3376
 #, elixir-autogen, elixir-format
 msgid "Other servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1559
+#: lib/abuuba_web/live/admin_live.ex:1561
 #, elixir-autogen, elixir-format
 msgid "Silence this server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1556
+#: lib/abuuba_web/live/admin_live.ex:1558
 #, elixir-autogen, elixir-format
 msgid "Silence this server? Its posts stop appearing in public timelines."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1532
+#: lib/abuuba_web/live/admin_live.ex:1534
 #, elixir-autogen, elixir-format
 msgid "Start again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1522
+#: lib/abuuba_web/live/admin_live.ex:1524
 #, elixir-autogen, elixir-format
 msgid "Stop delivering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2668
+#: lib/abuuba_web/live/admin_live.ex:2670
 #, elixir-autogen, elixir-format
 msgid "That server could not be blocked."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1496
+#: lib/abuuba_web/live/admin_live.ex:1498
 #, elixir-autogen, elixir-format
 msgid "Treated as down since %{when}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1507
+#: lib/abuuba_web/live/admin_live.ex:1509
 #, elixir-autogen, elixir-format
 msgid "one bad day"
 msgid_plural "%{count} bad days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1482
+#: lib/abuuba_web/live/admin_live.ex:1484
 #, elixir-autogen, elixir-format
 msgid "one post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:953
+#: lib/abuuba_web/live/admin_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Ask their server for it again. Worth doing when the name or picture here is out of date and waiting for their next post is waiting for something that may not come."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:980
+#: lib/abuuba_web/live/admin_live.ex:982
 #, elixir-autogen, elixir-format
 msgid "Delete this post? Other servers are told to delete it too."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:965
+#: lib/abuuba_web/live/admin_live.ex:967
 #, elixir-autogen, elixir-format
 msgid "Deleting one from here is the same delete they would do themselves."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:958
+#: lib/abuuba_web/live/admin_live.ex:960
 #, elixir-autogen, elixir-format
 msgid "Fetch it again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:946
+#: lib/abuuba_web/live/admin_live.ex:948
 #, elixir-autogen, elixir-format
 msgid "Force a password reset"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:934
+#: lib/abuuba_web/live/admin_live.ex:936
 #, elixir-autogen, elixir-format
 msgid "Locked out, or somebody else is in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:922
+#: lib/abuuba_web/live/admin_live.ex:924
 #, elixir-autogen, elixir-format
 msgid "Nobody is told and nothing is applied. This is for the context that otherwise lives in one person's head: that this is the third report about the same joke, or that somebody spoke to them and they understood."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:989
+#: lib/abuuba_web/live/admin_live.ex:991
 #, elixir-autogen, elixir-format
 msgid "Nothing posted."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:943
+#: lib/abuuba_web/live/admin_live.ex:945
 #, elixir-autogen, elixir-format
 msgid "Sign them out everywhere and send a reset link?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2686
+#: lib/abuuba_web/live/admin_live.ex:2688
 #, elixir-autogen, elixir-format
 msgid "That account has nobody to sign in as."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:963
+#: lib/abuuba_web/live/admin_live.ex:965
 #, elixir-autogen, elixir-format
 msgid "Their most recent posts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:951
+#: lib/abuuba_web/live/admin_live.ex:953
 #, elixir-autogen, elixir-format
 msgid "Their profile here is a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2699
+#: lib/abuuba_web/live/admin_live.ex:2701
 #, elixir-autogen, elixir-format
 msgid "Their server did not answer."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:936
+#: lib/abuuba_web/live/admin_live.ex:938
 #, elixir-autogen, elixir-format
 msgid "This ends every session and every app, and emails them a link to set a new password. It does not choose one for them: a password a moderator picked is a password a moderator knows."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2135
+#: lib/abuuba_web/live/admin_live.ex:2137
 #, elixir-autogen, elixir-format
 msgid "%{latest} is out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1287
+#: lib/abuuba_web/live/admin_live.ex:1289
 #, elixir-autogen, elixir-format
 msgid "A server that has decided about four hundred domains has made four hundred decisions, and the way those get shared is a list somebody publishes. This reads and writes those lists."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2755
+#: lib/abuuba_web/live/admin_live.ex:2757
 #, elixir-autogen, elixir-format
 msgid "Added %{added}. %{skipped} were already decided about."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1429
+#: lib/abuuba_web/live/admin_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Addresses that asked one account here to write to them. Only the confirmed ones are counted: an unconfirmed address is a claim somebody typed, not a subscriber."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1302
-#: lib/abuuba_web/live/admin_live.ex:1317
+#: lib/abuuba_web/live/admin_live.ex:1304
+#: lib/abuuba_web/live/admin_live.ex:1319
 #, elixir-autogen, elixir-format
 msgid "Allows"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2112
+#: lib/abuuba_web/live/admin_live.ex:2114
 #, elixir-autogen, elixir-format
 msgid "Checking for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/admin_live.ex:3375
 #, elixir-autogen, elixir-format
 msgid "Domain lists"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1307
+#: lib/abuuba_web/live/admin_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Domains this server has already decided about are left exactly as they are. An import adds and never removes: one paste should not be able to undo every decision made here, silently and unrecoverably."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3379
+#: lib/abuuba_web/live/admin_live.ex:3373
 #, elixir-autogen, elixir-format
 msgid "Email subscriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1446
+#: lib/abuuba_web/live/admin_live.ex:1448
 #, elixir-autogen, elixir-format
 msgid "Nobody here has any subscribers."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1419
+#: lib/abuuba_web/live/admin_live.ex:1421
 #, elixir-autogen, elixir-format
 msgid "Nobody is being suggested yet. It needs a few follows to work from."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1401
+#: lib/abuuba_web/live/admin_live.ex:1403
 #, elixir-autogen, elixir-format
 msgid "Not suggested"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2114
+#: lib/abuuba_web/live/admin_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. It asks %{url} whether there is a newer abuuba. What that tells them is what any web request tells anybody: this server's address, a user agent, and that somebody asked. Nothing about the accounts here, their number or their posts is sent, and there is nowhere in the request for it to go."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1440
+#: lib/abuuba_web/live/admin_live.ex:1442
 #, elixir-autogen, elixir-format
 msgid "One address"
 msgid_plural "%{count} addresses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1294
+#: lib/abuuba_web/live/admin_live.ex:1296
 #, elixir-autogen, elixir-format
 msgid "One blocked domain"
 msgid_plural "%{count} blocked domains"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1328
+#: lib/abuuba_web/live/admin_live.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Read it in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1305
+#: lib/abuuba_web/live/admin_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Read one in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2133
+#: lib/abuuba_web/live/admin_live.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Running %{version}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1413
+#: lib/abuuba_web/live/admin_live.ex:1415
 #, elixir-autogen, elixir-format
 msgid "Stop suggesting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1412
+#: lib/abuuba_web/live/admin_live.ex:1414
 #, elixir-autogen, elixir-format
 msgid "Suggest again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1292
+#: lib/abuuba_web/live/admin_live.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Take a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2129
+#: lib/abuuba_web/live/admin_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Tell me when there is a newer version"
 msgstr ""
@@ -4848,228 +4845,228 @@ msgstr ""
 msgid "There is no list of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1314
+#: lib/abuuba_web/live/admin_live.ex:1316
 #, elixir-autogen, elixir-format
 msgid "Which list"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1389
+#: lib/abuuba_web/live/admin_live.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Who this server puts in front of a newcomer. Taking somebody out is not a block and not a silence: their account carries on exactly as before and nobody is told."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1294
+#: lib/abuuba_web/live/admin_live.ex:1296
 #, elixir-autogen, elixir-format
 msgid "one allowed domain"
 msgid_plural "%{count} allowed domains"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:342
+#: lib/abuuba_web/live/admin_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "%{label}, highest %{top}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3703
+#: lib/abuuba_web/live/admin_live.ex:3690
 #, elixir-autogen, elixir-format
 msgid "Favourites, boosts and replies"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3708
+#: lib/abuuba_web/live/admin_live.ex:3695
 #, elixir-autogen, elixir-format
 msgid "Languages people write in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3701
+#: lib/abuuba_web/live/admin_live.ex:3688
 #, elixir-autogen, elixir-format
 msgid "New accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:423
+#: lib/abuuba_web/live/admin_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Of the people who signed up in a given week, how many were still posting in the weeks after. A number that only means something once the server has been running a while."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3700
+#: lib/abuuba_web/live/admin_live.ex:3687
 #, elixir-autogen, elixir-format
 msgid "People who posted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3702
+#: lib/abuuba_web/live/admin_live.ex:3689
 #, elixir-autogen, elixir-format
 msgid "Posts written here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3704
+#: lib/abuuba_web/live/admin_live.ex:3691
 #, elixir-autogen, elixir-format
 msgid "Reports opened"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3705
+#: lib/abuuba_web/live/admin_live.ex:3692
 #, elixir-autogen, elixir-format
 msgid "Reports resolved"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3710
+#: lib/abuuba_web/live/admin_live.ex:3697
 #, elixir-autogen, elixir-format
 msgid "Servers we hear most from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:387
+#: lib/abuuba_web/live/admin_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "The last thirty days"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:389
+#: lib/abuuba_web/live/admin_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "The same numbers a moderation client draws from the API, so what you see here and what it shows are the same figures rather than two answers to one question."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3711
+#: lib/abuuba_web/live/admin_live.ex:3698
 #, elixir-autogen, elixir-format
 msgid "What those servers run"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3709
+#: lib/abuuba_web/live/admin_live.ex:3696
 #, elixir-autogen, elixir-format
 msgid "Where accounts signed up from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:402
+#: lib/abuuba_web/live/admin_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "Where things come from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:421
+#: lib/abuuba_web/live/admin_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "Who stayed"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:432
+#: lib/abuuba_web/live/admin_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "one signed up"
 msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2219
+#: lib/abuuba_web/live/settings_live.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2220
+#: lib/abuuba_web/live/settings_live.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:345
+#: lib/abuuba_web/live/settings_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:550
-#: lib/abuuba_web/live/settings_live.ex:363
+#: lib/abuuba_web/live/admin_live.ex:552
+#: lib/abuuba_web/live/settings_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2054
+#: lib/abuuba_web/live/settings_live.ex:2061
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:343
+#: lib/abuuba_web/live/settings_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:395
+#: lib/abuuba_web/live/settings_live.ex:396
 #, elixir-autogen, elixir-format
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2052
-#: lib/abuuba_web/live/settings_live.ex:2213
+#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2214
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2208
-#: lib/abuuba_web/live/settings_live.ex:2215
+#: lib/abuuba_web/live/settings_live.ex:2209
+#: lib/abuuba_web/live/settings_live.ex:2216
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2049
+#: lib/abuuba_web/live/settings_live.ex:2056
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:322
-#: lib/abuuba_web/live/profile_live.ex:326
+#: lib/abuuba_web/live/profile_live.ex:313
+#: lib/abuuba_web/live/profile_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Featured accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:182
+#: lib/abuuba_web/live/profile_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:555
+#: lib/abuuba_web/live/profile_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:276
+#: lib/abuuba_web/live/profile_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:679
+#: lib/abuuba_web/live/settings_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:704
+#: lib/abuuba_web/live/settings_live.ex:705
 #, elixir-autogen, elixir-format
 msgid "Send it"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:295
+#: lib/abuuba_web/live/profile_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:713
+#: lib/abuuba_web/live/settings_live.ex:714
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:690
-#: lib/abuuba_web/live/settings_live.ex:1781
+#: lib/abuuba_web/live/settings_live.ex:691
+#: lib/abuuba_web/live/settings_live.ex:1788
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:558
+#: lib/abuuba_web/live/profile_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1367
+#: lib/abuuba_web/live/settings_live.ex:1368
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5079,17 +5076,17 @@ msgstr ""
 msgid "To stop them, open this link:"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:545
+#: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:697
+#: lib/abuuba_web/live/settings_live.ex:698
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:677
+#: lib/abuuba_web/live/settings_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr ""
@@ -5099,253 +5096,253 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1372
+#: lib/abuuba_web/live/settings_live.ex:1373
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:288
+#: lib/abuuba_web/live/profile_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1782
+#: lib/abuuba_web/live/settings_live.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:720
+#: lib/abuuba_web/live/settings_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2421
+#: lib/abuuba_web/live/admin_live.ex:2423
 #, elixir-autogen, elixir-format
 msgid "A preset needs both."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:492
-#: lib/abuuba_web/live/admin_live.ex:708
+#: lib/abuuba_web/live/admin_live.ex:494
+#: lib/abuuba_web/live/admin_live.ex:710
 #, elixir-autogen, elixir-format
 msgid "Add it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:568
+#: lib/abuuba_web/live/admin_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "All of them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:566
+#: lib/abuuba_web/live/admin_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:775
+#: lib/abuuba_web/live/admin_live.ex:777
 #, elixir-autogen, elixir-format
 msgid "Do it to all of them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:627
+#: lib/abuuba_web/live/admin_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Filed as %{category} on %{date}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:685
+#: lib/abuuba_web/live/admin_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "For whoever picks this up next. The person reported never sees any of it, and neither does whoever filed it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:661
+#: lib/abuuba_web/live/admin_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "I am on this"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2171
+#: lib/abuuba_web/live/admin_live.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3298
+#: lib/abuuba_web/live/admin_live.ex:3295
 #, elixir-autogen, elixir-format
 msgid "Limit them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:670
+#: lib/abuuba_web/live/admin_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "Mark it dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:599
+#: lib/abuuba_web/live/admin_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Nothing waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:853
+#: lib/abuuba_web/live/admin_live.ex:855
 #, elixir-autogen, elixir-format
 msgid "Nothing, I will write it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:755
+#: lib/abuuba_web/live/admin_live.ex:757
 #, elixir-autogen, elixir-format
 msgid "One account ticked."
 msgid_plural "%{count} accounts ticked."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:679
+#: lib/abuuba_web/live/admin_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Put it back in the queue"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2153
+#: lib/abuuba_web/live/admin_live.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Ready-made texts a moderator picks instead of retyping. Kept for the server rather than for one moderator, so two people writing about the same thing say the same thing."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3373
+#: lib/abuuba_web/live/admin_live.ex:3367
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:576
+#: lib/abuuba_web/live/admin_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Report %{id}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3371
+#: lib/abuuba_web/live/admin_live.ex:3365
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:851
+#: lib/abuuba_web/live/admin_live.ex:853
 #, elixir-autogen, elixir-format
 msgid "Start from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:564
+#: lib/abuuba_web/live/admin_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "Still open"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3300
+#: lib/abuuba_web/live/admin_live.ex:3297
 #, elixir-autogen, elixir-format
 msgid "Stop them signing in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3299
+#: lib/abuuba_web/live/admin_live.ex:3296
 #, elixir-autogen, elixir-format
 msgid "Suspend them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:637
+#: lib/abuuba_web/live/admin_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "The posts it names"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:768
+#: lib/abuuba_web/live/admin_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "This does the same thing to one account and tells them. Go ahead?"
 msgid_plural "This does the same thing to all %{count} accounts and tells each of them. Go ahead?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:786
+#: lib/abuuba_web/live/admin_live.ex:788
 #, elixir-autogen, elixir-format
 msgid "Tick %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:753
+#: lib/abuuba_web/live/admin_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Tick some accounts to do one thing to all of them."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2151
+#: lib/abuuba_web/live/admin_live.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Warning presets"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2168
+#: lib/abuuba_web/live/admin_live.ex:2170
 #, elixir-autogen, elixir-format
 msgid "What it says"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:683
+#: lib/abuuba_web/live/admin_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "What moderators have written here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:705
+#: lib/abuuba_web/live/admin_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "What you found"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:562
+#: lib/abuuba_web/live/admin_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Which ones"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:580
+#: lib/abuuba_web/live/admin_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "about"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:587
+#: lib/abuuba_web/live/admin_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:580
-#: lib/abuuba_web/live/admin_live.ex:622
+#: lib/abuuba_web/live/admin_live.ex:582
+#: lib/abuuba_web/live/admin_live.ex:624
 #, elixir-autogen, elixir-format
 msgid "from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3316
+#: lib/abuuba_web/live/admin_live.ex:3313
 #, elixir-autogen, elixir-format
 msgid "somebody who is gone"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:589
+#: lib/abuuba_web/live/admin_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "taken"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3275
+#: lib/abuuba_web/live/admin_live.ex:3272
 #, elixir-autogen, elixir-format
 msgid "One account could not be changed."
 msgid_plural "%{count} accounts could not be changed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3268
+#: lib/abuuba_web/live/admin_live.ex:3265
 #, elixir-autogen, elixir-format
 msgid "One account was left alone because it outranks yours."
 msgid_plural "%{count} accounts were left alone because they outrank yours."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:603
+#: lib/abuuba_web/live/admin_live.ex:605
 #, elixir-autogen, elixir-format
 msgid "Showing the newest %{count}. Deal with some to see the ones that have waited longest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3233
+#: lib/abuuba_web/live/admin_live.ex:3230
 #, elixir-autogen, elixir-format
 msgid "That is not something this list can do."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:642
+#: lib/abuuba_web/live/admin_live.ex:644
 #, elixir-autogen, elixir-format
 msgid "Warning:"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:182
-#: lib/abuuba_web/live/admin_live.ex:186
+#: lib/abuuba_web/live/admin_live.ex:183
+#: lib/abuuba_web/live/admin_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Your account may not do that."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:648
+#: lib/abuuba_web/live/admin_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "has pictures or video"
 msgstr ""
@@ -5400,7 +5397,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:959
+#: lib/abuuba_web/live/settings_live.ex:960
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5455,115 +5452,115 @@ msgstr ""
 msgid "Show anyway"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:488
+#: lib/abuuba_web/live/admin_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "A PNG or a GIF, at most %{size}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3200
+#: lib/abuuba_web/live/admin_live.ex:3197
 #, elixir-autogen, elixir-format
 msgid "A shortcode is letters, numbers and underscores, and nothing else."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3133
+#: lib/abuuba_web/live/admin_live.ex:3179
+#, elixir-autogen, elixir-format
+msgid "An emoji has to be a PNG or a GIF."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3123
+#: lib/abuuba_web/live/admin_live.ex:3157
+#, elixir-autogen, elixir-format
+msgid "Choose a picture for it."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3366
+#, elixir-autogen, elixir-format
+msgid "Custom emoji"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:543
+#, elixir-autogen, elixir-format
+msgid "Every post that used it loses its picture. Go ahead?"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:481
+#, elixir-autogen, elixir-format
+msgid "Group it under"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:518
+#, elixir-autogen, elixir-format
+msgid "Offer it"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:468
+#, elixir-autogen, elixir-format
+msgid "Pictures people here can type into a post by name. One uploaded here is held on this server, so it outlives whoever made it."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:476
+#, elixir-autogen, elixir-format
+msgid "Shortcode"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:517
+#, elixir-autogen, elixir-format
+msgid "Stop offering it"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3199
+#, elixir-autogen, elixir-format
+msgid "That emoji could not be saved."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3185
+#, elixir-autogen, elixir-format
+msgid "That picture could not be stored."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3139
+#, elixir-autogen, elixir-format
+msgid "That picture could not be used."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3136
 #: lib/abuuba_web/live/admin_live.ex:3182
 #, elixir-autogen, elixir-format
-msgid "An emoji has to be a PNG or a GIF."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3126
-#: lib/abuuba_web/live/admin_live.ex:3160
-#, elixir-autogen, elixir-format
-msgid "Choose a picture for it."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3372
-#, elixir-autogen, elixir-format
-msgid "Custom emoji"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:541
-#, elixir-autogen, elixir-format
-msgid "Every post that used it loses its picture. Go ahead?"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:479
-#, elixir-autogen, elixir-format
-msgid "Group it under"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:516
-#, elixir-autogen, elixir-format
-msgid "Offer it"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:466
-#, elixir-autogen, elixir-format
-msgid "Pictures people here can type into a post by name. One uploaded here is held on this server, so it outlives whoever made it."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:474
-#, elixir-autogen, elixir-format
-msgid "Shortcode"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:515
-#, elixir-autogen, elixir-format
-msgid "Stop offering it"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3202
-#, elixir-autogen, elixir-format
-msgid "That emoji could not be saved."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3188
-#, elixir-autogen, elixir-format
-msgid "That picture could not be stored."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3142
-#, elixir-autogen, elixir-format
-msgid "That picture could not be used."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3139
-#: lib/abuuba_web/live/admin_live.ex:3185
-#, elixir-autogen, elixir-format
 msgid "That picture is too large for an emoji."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:485
+#: lib/abuuba_web/live/admin_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "The picture"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3123
+#: lib/abuuba_web/live/admin_live.ex:3120
 #, elixir-autogen, elixir-format
 msgid "The picture is still uploading. Try again in a moment."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:503
+#: lib/abuuba_web/live/admin_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "not offered"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:245
+#: lib/abuuba_web/live/profile_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:243
+#: lib/abuuba_web/live/profile_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:222
+#: lib/abuuba_web/live/profile_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:207
+#: lib/abuuba_web/live/profile_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr ""
@@ -5588,12 +5585,12 @@ msgstr ""
 msgid "Unmute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:453
+#: lib/abuuba_web/live/notifications_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:237
+#: lib/abuuba_web/live/profile_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr ""
@@ -5628,146 +5625,146 @@ msgstr ""
 msgid "Your year on this server is ready to read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:448
+#: lib/abuuba_web/live/notifications_live.ex:445
 #, elixir-autogen, elixir-format
 msgid "Quotes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2017
+#: lib/abuuba_web/live/admin_live.ex:2019
 #, elixir-autogen, elixir-format
 msgid "Days to keep other servers' files"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2026
+#: lib/abuuba_web/live/admin_live.ex:2028
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them indefinitely. Anything older goes off this server's disk each night. The posts stay, and a file is fetched again if somebody opens it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:528
+#: lib/abuuba_web/live/admin_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Every post that used it loses its picture until you turn it back on. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:501
+#: lib/abuuba_web/live/admin_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "turned off"
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:97
+#: lib/abuuba_web/live/conversations_live.ex:98
 #, elixir-autogen, elixir-format
 msgid "Mark unread"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:239
-#: lib/abuuba_web/live/conversations_live.ex:44
-#: lib/abuuba_web/live/conversations_live.ex:60
+#: lib/abuuba_web/live/conversations_live.ex:45
+#: lib/abuuba_web/live/conversations_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:63
+#: lib/abuuba_web/live/conversations_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. A post addressed to only the people you name arrives as a message, and its replies stay with it."
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:82
+#: lib/abuuba_web/live/conversations_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Open the conversation with %{people}"
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:224
+#: lib/abuuba_web/live/conversations_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "The last message has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:105
+#: lib/abuuba_web/live/conversations_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "This takes it out of your inbox only. Nobody else loses anything, and a later message brings it back. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2033
+#: lib/abuuba_web/live/admin_live.ex:2035
 #, elixir-autogen, elixir-format
 msgid "Days to keep other servers' posts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2042
+#: lib/abuuba_web/live/admin_live.ex:2044
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them for ever. Anything older is deleted each night, except a post somebody here favourited, bookmarked, pinned, boosted, quoted, replied to or was mentioned in."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1917
+#: lib/abuuba_web/live/admin_live.ex:1919
 #, elixir-autogen, elixir-format
 msgid "The longer version, for the about page"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1968
-#: lib/abuuba_web/live/admin_live.ex:1977
+#: lib/abuuba_web/live/admin_live.ex:1970
+#: lib/abuuba_web/live/admin_live.ex:1979
 #, elixir-autogen, elixir-format
 msgid "Anybody, including people with no account"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1983
+#: lib/abuuba_web/live/admin_live.ex:1985
 #, elixir-autogen, elixir-format
 msgid "Nobody: turn them off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1965
-#: lib/abuuba_web/live/admin_live.ex:1980
+#: lib/abuuba_web/live/admin_live.ex:1967
+#: lib/abuuba_web/live/admin_live.ex:1982
 #, elixir-autogen, elixir-format
 msgid "Only people signed in here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1974
+#: lib/abuuba_web/live/admin_live.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Who may read the public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1949
+#: lib/abuuba_web/live/admin_live.ex:1951
 #, elixir-autogen, elixir-format
 msgid "The privacy policy takes effect on"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1933
+#: lib/abuuba_web/live/admin_live.ex:1935
 #, elixir-autogen, elixir-format
 msgid "The account to write to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1938
+#: lib/abuuba_web/live/admin_live.ex:1940
 #, elixir-autogen, elixir-format
 msgid "a username on this server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1922
+#: lib/abuuba_web/live/admin_live.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Status page"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1962
+#: lib/abuuba_web/live/admin_live.ex:1964
 #, elixir-autogen, elixir-format
 msgid "Nobody: the server does not say"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1959
+#: lib/abuuba_web/live/admin_live.ex:1961
 #, elixir-autogen, elixir-format
 msgid "Who may read the blocklist"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:634
+#: lib/abuuba_web/live/settings_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:626
+#: lib/abuuba_web/live/settings_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:838
+#: lib/abuuba_web/live/settings_live.ex:839
 #, elixir-autogen, elixir-format
 msgid "Block a server"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:811
+#: lib/abuuba_web/live/settings_live.ex:812
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr ""
@@ -5777,83 +5774,68 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:148
-#: lib/abuuba_web/live/profile_live.ex:596
+#: lib/abuuba_web/live/explore_live.ex:144
+#: lib/abuuba_web/live/profile_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3361
+#: lib/abuuba_web/live/admin_live.ex:3355
 #, elixir-autogen, elixir-format
 msgid "Account disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3364
+#: lib/abuuba_web/live/admin_live.ex:3358
 #, elixir-autogen, elixir-format
 msgid "Account limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3365
+#: lib/abuuba_web/live/admin_live.ex:3359
 #, elixir-autogen, elixir-format
 msgid "Account suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3374
+#: lib/abuuba_web/live/admin_live.ex:3368
 #, elixir-autogen, elixir-format
 msgid "Appeals"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1379
+#: lib/abuuba_web/live/admin_live.ex:1381
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting. Appeals against a strike show up here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3363
+#: lib/abuuba_web/live/admin_live.ex:3357
 #, elixir-autogen, elixir-format
 msgid "Posts deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3362
+#: lib/abuuba_web/live/admin_live.ex:3356
 #, elixir-autogen, elixir-format
 msgid "Posts marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1338
+#: lib/abuuba_web/live/admin_live.ex:1340
 #, elixir-autogen, elixir-format
 msgid "Somebody who was warned, silenced or suspended saying it was a mistake. Upholding an appeal undoes the action where it can be undone; where it cannot, the appeal is still recorded as upheld. Either way the account's owner is told."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3073
+#: lib/abuuba_web/live/admin_live.ex:3070
 #, elixir-autogen, elixir-format
 msgid "That appeal is no longer waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1372
+#: lib/abuuba_web/live/admin_live.ex:1374
 #, elixir-autogen, elixir-format
 msgid "Turn down"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1364
+#: lib/abuuba_web/live/admin_live.ex:1366
 #, elixir-autogen, elixir-format
 msgid "Uphold and undo"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3360
+#: lib/abuuba_web/live/admin_live.ex:3354
 #, elixir-autogen, elixir-format
 msgid "Warned"
-msgstr ""
-
-#: lib/abuuba_web/live/profile_live.ex:155
-#, elixir-autogen, elixir-format
-msgid "Cancel follow request"
-msgstr ""
-
-#: lib/abuuba_web/live/explore_live.ex:117
-#, elixir-autogen, elixir-format
-msgid "Requested"
-msgstr ""
-
-#: lib/abuuba_web/live/profile_live.ex:606
-#, elixir-autogen, elixir-format
-msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -49,7 +49,7 @@ msgid "Change"
 msgstr ""
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:736
+#: lib/abuuba_web/live/compose_component.ex:723
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -401,13 +401,13 @@ msgstr ""
 msgid "This is the only time they are shown. Each one works once, and they are how you get back in if you lose your phone."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/admin_live.ex:549
 #: lib/abuuba_web/live/two_factor_settings_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Turn it off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/admin_live.ex:549
 #: lib/abuuba_web/live/two_factor_settings_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Turn it on"
@@ -453,7 +453,7 @@ msgstr ""
 msgid "Act as a moderator (%{scope})"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1051
+#: lib/abuuba_web/live/admin_live.ex:1064
 #: lib/abuuba_web/live/authorize_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Allow"
@@ -464,10 +464,10 @@ msgstr ""
 msgid "Authorize %{app}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1741
+#: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
+#: lib/abuuba_web/live/compose_component.ex:397
 #: lib/abuuba_web/live/compose_component.ex:410
-#: lib/abuuba_web/live/compose_component.ex:423
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -662,7 +662,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
 #: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2310
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -689,7 +689,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
@@ -761,7 +761,7 @@ msgid "Follow some people and their posts will appear here."
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:267
-#: lib/abuuba_web/live/compose_component.ex:616
+#: lib/abuuba_web/live/compose_component.ex:603
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
@@ -791,303 +791,303 @@ msgstr ""
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1679
+#: lib/abuuba_web/live/compose_component.ex:1666
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1664
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1680
+#: lib/abuuba_web/live/compose_component.ex:1667
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/compose_component.ex:1663
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/compose_component.ex:1662
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1678
+#: lib/abuuba_web/live/compose_component.ex:1665
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1681
+#: lib/abuuba_web/live/compose_component.ex:1668
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1156
+#: lib/abuuba_web/live/compose_component.ex:1141
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:651
+#: lib/abuuba_web/live/compose_component.ex:638
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:722
+#: lib/abuuba_web/live/compose_component.ex:709
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:663
+#: lib/abuuba_web/live/compose_component.ex:650
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1696
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/settings_live.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1687
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/compose_component.ex:1674
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1688
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:627
+#: lib/abuuba_web/live/compose_component.ex:614
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:451
-#: lib/abuuba_web/live/compose_component.ex:712
+#: lib/abuuba_web/live/compose_component.ex:438
+#: lib/abuuba_web/live/compose_component.ex:699
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:813
+#: lib/abuuba_web/live/compose_component.ex:800
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:446
+#: lib/abuuba_web/live/compose_component.ex:433
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:432
-#: lib/abuuba_web/live/admin_live.ex:1761
+#: lib/abuuba_web/live/admin_live.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:416
+#: lib/abuuba_web/live/compose_component.ex:403
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:667
+#: lib/abuuba_web/live/compose_component.ex:654
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1689
+#: lib/abuuba_web/live/compose_component.ex:1676
 #: lib/abuuba_web/live/profile_live.ex:837
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1677
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3413
-#: lib/abuuba_web/live/compose_component.ex:1698
-#: lib/abuuba_web/live/settings_live.ex:2295
+#: lib/abuuba_web/live/admin_live.ex:3428
+#: lib/abuuba_web/live/compose_component.ex:1685
+#: lib/abuuba_web/live/settings_live.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1689
-#: lib/abuuba_web/live/settings_live.ex:2290
+#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1677
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1697
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/compose_component.ex:1684
+#: lib/abuuba_web/live/settings_live.ex:2306
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1456
+#: lib/abuuba_web/live/compose_component.ex:1441
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:696
+#: lib/abuuba_web/live/compose_component.ex:683
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1687
-#: lib/abuuba_web/live/compose_component.ex:1705
+#: lib/abuuba_web/live/compose_component.ex:1674
+#: lib/abuuba_web/live/compose_component.ex:1692
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1688
+#: lib/abuuba_web/live/compose_component.ex:1675
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:732
+#: lib/abuuba_web/live/compose_component.ex:719
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:639
+#: lib/abuuba_web/live/compose_component.ex:626
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:403
+#: lib/abuuba_web/live/compose_component.ex:390
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1454
+#: lib/abuuba_web/live/compose_component.ex:1439
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3374
-#: lib/abuuba_web/live/compose_component.ex:478
+#: lib/abuuba_web/live/admin_live.ex:3389
+#: lib/abuuba_web/live/compose_component.ex:465
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1118
+#: lib/abuuba_web/live/compose_component.ex:1103
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1180
-#: lib/abuuba_web/live/compose_component.ex:1215
-#: lib/abuuba_web/live/compose_component.ex:1410
+#: lib/abuuba_web/live/compose_component.ex:1165
+#: lib/abuuba_web/live/compose_component.ex:1200
+#: lib/abuuba_web/live/compose_component.ex:1395
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:462
-#: lib/abuuba_web/live/compose_component.ex:468
+#: lib/abuuba_web/live/compose_component.ex:449
+#: lib/abuuba_web/live/compose_component.ex:455
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:456
+#: lib/abuuba_web/live/compose_component.ex:443
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:772
+#: lib/abuuba_web/live/compose_component.ex:759
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:752
+#: lib/abuuba_web/live/compose_component.ex:739
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1114
+#: lib/abuuba_web/live/compose_component.ex:1099
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1212
+#: lib/abuuba_web/live/compose_component.ex:1197
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1652
+#: lib/abuuba_web/live/compose_component.ex:1635
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:819
+#: lib/abuuba_web/live/compose_component.ex:806
 #, elixir-autogen, elixir-format
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:851
+#: lib/abuuba_web/live/compose_component.ex:838
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:1160
+#: lib/abuuba_web/live/compose_component.ex:1145
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:882
+#: lib/abuuba_web/live/compose_component.ex:869
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:843
+#: lib/abuuba_web/live/compose_component.ex:830
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:682
+#: lib/abuuba_web/live/compose_component.ex:669
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:833
-#: lib/abuuba_web/live/compose_component.ex:872
+#: lib/abuuba_web/live/compose_component.ex:820
+#: lib/abuuba_web/live/compose_component.ex:859
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1131
-#: lib/abuuba_web/live/compose_component.ex:1401
+#: lib/abuuba_web/live/compose_component.ex:1116
+#: lib/abuuba_web/live/compose_component.ex:1386
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:804
+#: lib/abuuba_web/live/compose_component.ex:791
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1455
+#: lib/abuuba_web/live/compose_component.ex:1440
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:317
+#: lib/abuuba_web/live/compose_component.ex:304
 #, elixir-autogen, elixir-format
 msgid "That draft could not be saved."
 msgstr ""
@@ -1097,104 +1097,104 @@ msgstr ""
 msgid "That post is scheduled."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1165
+#: lib/abuuba_web/live/compose_component.ex:1150
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:313
+#: lib/abuuba_web/live/compose_component.ex:300
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1449
+#: lib/abuuba_web/live/compose_component.ex:1434
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:689
+#: lib/abuuba_web/live/compose_component.ex:676
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1128
+#: lib/abuuba_web/live/compose_component.ex:1113
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:497
+#: lib/abuuba_web/live/compose_component.ex:484
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:592
+#: lib/abuuba_web/live/compose_component.ex:579
 #, elixir-autogen, elixir-format
 msgid "Add a still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:542
+#: lib/abuuba_web/live/compose_component.ex:529
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:559
-#: lib/abuuba_web/live/compose_component.ex:567
+#: lib/abuuba_web/live/compose_component.ex:546
+#: lib/abuuba_web/live/compose_component.ex:554
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:581
+#: lib/abuuba_web/live/compose_component.ex:568
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:596
+#: lib/abuuba_web/live/compose_component.ex:583
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:554
+#: lib/abuuba_web/live/compose_component.ex:541
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:522
+#: lib/abuuba_web/live/compose_component.ex:509
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:607
+#: lib/abuuba_web/live/compose_component.ex:594
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:252
-#: lib/abuuba_web/live/compose_component.ex:1445
+#: lib/abuuba_web/live/compose_component.ex:239
+#: lib/abuuba_web/live/compose_component.ex:1430
 #, elixir-autogen, elixir-format
 msgid "That file could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1442
+#: lib/abuuba_web/live/compose_component.ex:1427
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:239
+#: lib/abuuba_web/live/compose_component.ex:226
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1443
+#: lib/abuuba_web/live/compose_component.ex:1428
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1444
+#: lib/abuuba_web/live/compose_component.ex:1429
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:501
+#: lib/abuuba_web/live/compose_component.ex:488
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr ""
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "Posts and replies"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:931
+#: lib/abuuba_web/live/admin_live.ex:944
 #: lib/abuuba_web/live/profile_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Save the note"
@@ -1504,7 +1504,7 @@ msgstr ""
 #: lib/abuuba_web/live/notifications_live.ex:440
 #: lib/abuuba_web/live/profile_live.ex:838
 #: lib/abuuba_web/live/settings_live.ex:2103
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -1565,11 +1565,11 @@ msgstr ""
 msgid "Private mentions out of nowhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1010
-#: lib/abuuba_web/live/admin_live.ex:1018
-#: lib/abuuba_web/live/admin_live.ex:1121
-#: lib/abuuba_web/live/admin_live.ex:1574
-#: lib/abuuba_web/live/admin_live.ex:2150
+#: lib/abuuba_web/live/admin_live.ex:1023
+#: lib/abuuba_web/live/admin_live.ex:1031
+#: lib/abuuba_web/live/admin_live.ex:1134
+#: lib/abuuba_web/live/admin_live.ex:1587
+#: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
 #: lib/abuuba_web/live/profile_live.ex:255
 #: lib/abuuba_web/live/settings_live.ex:294
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:238
+#: lib/abuuba_web/live/admin_live.ex:245
 #: lib/abuuba_web/live/notification_settings_live.ex:54
 #: lib/abuuba_web/live/settings_live.ex:136
 #, elixir-autogen, elixir-format
@@ -1638,8 +1638,8 @@ msgstr ""
 msgid "A name, a #tag, or some words"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2263
-#: lib/abuuba_web/live/admin_live.ex:3572
+#: lib/abuuba_web/live/admin_live.ex:2277
+#: lib/abuuba_web/live/admin_live.ex:3587
 #: lib/abuuba_web/live/search_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Everything"
@@ -1765,7 +1765,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3364
+#: lib/abuuba_web/live/admin_live.ex:3379
 #: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Account"
@@ -1786,7 +1786,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
@@ -1806,7 +1806,7 @@ msgstr ""
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
@@ -1816,7 +1816,7 @@ msgstr ""
 msgid "Change the password"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:985
+#: lib/abuuba_web/live/admin_live.ex:998
 #: lib/abuuba_web/live/settings_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Delete"
@@ -1827,7 +1827,7 @@ msgstr ""
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
@@ -1837,7 +1837,7 @@ msgstr ""
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
@@ -1858,27 +1858,27 @@ msgid "Fields"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:2102
-#: lib/abuuba_web/live/settings_live.ex:2235
+#: lib/abuuba_web/live/settings_live.ex:2247
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2317
+#: lib/abuuba_web/live/settings_live.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2318
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2266
+#: lib/abuuba_web/live/settings_live.ex:2278
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
@@ -1893,17 +1893,17 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2269
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
@@ -1933,7 +1933,7 @@ msgstr ""
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
@@ -1958,26 +1958,26 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2302
+#: lib/abuuba_web/live/settings_live.ex:2314
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2285
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:546
-#: lib/abuuba_web/live/admin_live.ex:1656
-#: lib/abuuba_web/live/admin_live.ex:1772
-#: lib/abuuba_web/live/admin_live.ex:1864
-#: lib/abuuba_web/live/admin_live.ex:2188
+#: lib/abuuba_web/live/admin_live.ex:559
+#: lib/abuuba_web/live/admin_live.ex:1669
+#: lib/abuuba_web/live/admin_live.ex:1786
+#: lib/abuuba_web/live/admin_live.ex:1878
+#: lib/abuuba_web/live/admin_live.ex:2202
 #: lib/abuuba_web/live/conversations_live.ex:112
 #: lib/abuuba_web/live/settings_live.ex:280
 #: lib/abuuba_web/live/settings_live.ex:315
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2284
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
@@ -2010,7 +2010,7 @@ msgstr ""
 msgid "Take it back out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3735
+#: lib/abuuba_web/live/admin_live.ex:3750
 #: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
@@ -2026,17 +2026,17 @@ msgstr ""
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2267
+#: lib/abuuba_web/live/settings_live.ex:2279
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2268
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
@@ -2056,7 +2056,7 @@ msgstr ""
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
@@ -2066,7 +2066,7 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2277
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
@@ -2081,7 +2081,7 @@ msgstr ""
 msgid "What the compose box starts with."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2164
+#: lib/abuuba_web/live/admin_live.ex:2178
 #: lib/abuuba_web/live/settings_live.ex:761
 #, elixir-autogen, elixir-format
 msgid "What to call it"
@@ -2117,7 +2117,7 @@ msgstr ""
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
@@ -2153,7 +2153,7 @@ msgid "A server on the fediverse, running %{software}."
 msgstr ""
 
 #: lib/abuuba_web/live/about_live.ex:24
-#: lib/abuuba_web/live/admin_live.ex:621
+#: lib/abuuba_web/live/admin_live.ex:634
 #: lib/abuuba_web/live/document_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "About"
@@ -2185,7 +2185,7 @@ msgid "No password is asked for and nothing is done on your behalf: you are simp
 msgstr ""
 
 #: lib/abuuba_web/live/about_live.ex:93
-#: lib/abuuba_web/live/admin_live.ex:1946
+#: lib/abuuba_web/live/admin_live.ex:1960
 #: lib/abuuba_web/live/document_live.ex:133
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
@@ -2222,7 +2222,7 @@ msgid "Take me to my server"
 msgstr ""
 
 #: lib/abuuba_web/live/about_live.ex:92
-#: lib/abuuba_web/live/admin_live.ex:2193
+#: lib/abuuba_web/live/admin_live.ex:2207
 #: lib/abuuba_web/live/document_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
@@ -2401,427 +2401,427 @@ msgstr ""
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2248
+#: lib/abuuba_web/live/admin_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "A new rule"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2833
+#: lib/abuuba_web/live/admin_live.ex:2847
 #, elixir-autogen, elixir-format
 msgid "A rule needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3363
+#: lib/abuuba_web/live/admin_live.ex:3378
 #, elixir-autogen, elixir-format
 msgid "Accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1603
-#: lib/abuuba_web/live/admin_live.ex:1821
-#: lib/abuuba_web/live/admin_live.ex:2251
+#: lib/abuuba_web/live/admin_live.ex:1616
+#: lib/abuuba_web/live/admin_live.ex:1835
+#: lib/abuuba_web/live/admin_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1991
+#: lib/abuuba_web/live/admin_live.ex:2005
 #, elixir-autogen, elixir-format
 msgid "Address people can write to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:221
-#: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/admin_live.ex:228
+#: lib/abuuba_web/live/admin_live.ex:3396
 #, elixir-autogen, elixir-format
 msgid "Administration"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3718
+#: lib/abuuba_web/live/admin_live.ex:3733
 #, elixir-autogen, elixir-format
 msgid "An open server left unattended fills with spam registrations within days. Put sign-ups behind approval unless somebody is watching."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:739
+#: lib/abuuba_web/live/admin_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "Any state"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3703
+#: lib/abuuba_web/live/admin_live.ex:3718
 #, elixir-autogen, elixir-format
 msgid "Anybody may sign up without being checked"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3412
+#: lib/abuuba_web/live/admin_live.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Anybody, after somebody here says yes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3411
+#: lib/abuuba_web/live/admin_live.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Anybody, straight away"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:732
+#: lib/abuuba_web/live/admin_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "Anywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:377
-#: lib/abuuba_web/live/admin_live.ex:381
+#: lib/abuuba_web/live/admin_live.ex:390
+#: lib/abuuba_web/live/admin_live.ex:394
 #, elixir-autogen, elixir-format
 msgid "Appeals waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3380
+#: lib/abuuba_web/live/admin_live.ex:3395
 #, elixir-autogen, elixir-format
 msgid "Audit log"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1021
+#: lib/abuuba_web/live/admin_live.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Change an address only when somebody cannot reach their own."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3362
+#: lib/abuuba_web/live/admin_live.ex:3377
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2867
+#: lib/abuuba_web/live/admin_live.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Deleting posts needs the posts named, which this page cannot do yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3422
+#: lib/abuuba_web/live/admin_live.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Disable: they cannot sign in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:874
+#: lib/abuuba_web/live/admin_live.ex:887
 #, elixir-autogen, elixir-format
 msgid "Do it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:735
+#: lib/abuuba_web/live/admin_live.ex:748
 #, elixir-autogen, elixir-format
 msgid "Elsewhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1015
+#: lib/abuuba_web/live/admin_live.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3708
+#: lib/abuuba_web/live/admin_live.ex:3723
 #, elixir-autogen, elixir-format
 msgid "Everything else on this page is guesswork until that is fixed."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:748
-#: lib/abuuba_web/live/admin_live.ex:1472
+#: lib/abuuba_web/live/admin_live.ex:761
+#: lib/abuuba_web/live/admin_live.ex:1485
 #, elixir-autogen, elixir-format
 msgid "Find"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:733
+#: lib/abuuba_web/live/admin_live.ex:746
 #, elixir-autogen, elixir-format
 msgid "Here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:811
+#: lib/abuuba_web/live/admin_live.ex:824
 #, elixir-autogen, elixir-format
 msgid "Let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:895
-#: lib/abuuba_web/live/admin_live.ex:1193
-#: lib/abuuba_web/live/admin_live.ex:1220
-#: lib/abuuba_web/live/admin_live.ex:1248
-#: lib/abuuba_web/live/admin_live.ex:1272
+#: lib/abuuba_web/live/admin_live.ex:908
+#: lib/abuuba_web/live/admin_live.ex:1206
+#: lib/abuuba_web/live/admin_live.ex:1233
+#: lib/abuuba_web/live/admin_live.ex:1261
+#: lib/abuuba_web/live/admin_live.ex:1285
 #, elixir-autogen, elixir-format
 msgid "Lift it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3404
+#: lib/abuuba_web/live/admin_live.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3423
+#: lib/abuuba_web/live/admin_live.ex:3438
 #, elixir-autogen, elixir-format
 msgid "Mark everything they post sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:728
+#: lib/abuuba_web/live/admin_live.ex:741
 #, elixir-autogen, elixir-format
 msgid "Name or name@server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3724
+#: lib/abuuba_web/live/admin_live.ex:3739
 #, elixir-autogen, elixir-format
 msgid "Nobody can grant roles or change settings that need it. Give somebody a role holding the administrator permission."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3704
+#: lib/abuuba_web/live/admin_live.ex:3719
 #, elixir-autogen, elixir-format
 msgid "Nobody here is an administrator"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:829
+#: lib/abuuba_web/live/admin_live.ex:842
 #, elixir-autogen, elixir-format
 msgid "Nobody here matches that."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1000
+#: lib/abuuba_web/live/admin_live.ex:1013
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2283
+#: lib/abuuba_web/live/admin_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Nothing has been done yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:418
-#: lib/abuuba_web/live/admin_live.ex:443
-#: lib/abuuba_web/live/admin_live.ex:701
-#: lib/abuuba_web/live/admin_live.ex:900
+#: lib/abuuba_web/live/admin_live.ex:431
+#: lib/abuuba_web/live/admin_live.ex:456
+#: lib/abuuba_web/live/admin_live.ex:714
+#: lib/abuuba_web/live/admin_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Nothing yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:457
+#: lib/abuuba_web/live/admin_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Nothing. Every check this server knows how to make came back fine."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:385
+#: lib/abuuba_web/live/admin_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "People waiting to be let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:369
+#: lib/abuuba_web/live/admin_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Reports waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2241
+#: lib/abuuba_web/live/admin_live.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Retire it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:998
+#: lib/abuuba_web/live/admin_live.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2227
+#: lib/abuuba_web/live/admin_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Rules people agree to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3419
+#: lib/abuuba_web/live/admin_live.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Send a warning and nothing else"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1469
-#: lib/abuuba_web/live/admin_live.ex:1909
+#: lib/abuuba_web/live/admin_live.ex:1482
+#: lib/abuuba_web/live/admin_live.ex:1923
 #, elixir-autogen, elixir-format
 msgid "Server name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3379
+#: lib/abuuba_web/live/admin_live.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Server settings"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3712
+#: lib/abuuba_web/live/admin_live.ex:3727
 #, elixir-autogen, elixir-format
 msgid "Servers running authorized fetch will refuse this one. It is created on first use, so this usually means something went wrong writing it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2266
+#: lib/abuuba_web/live/admin_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2229
+#: lib/abuuba_web/live/admin_live.ex:2243
 #, elixir-autogen, elixir-format
 msgid "Shown when somebody signs up and when they file a report."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3420
+#: lib/abuuba_web/live/admin_live.ex:3435
 #, elixir-autogen, elixir-format
 msgid "Silence: out of everywhere nobody asked for them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3421
+#: lib/abuuba_web/live/admin_live.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Suspend: hidden, and deleted after the grace window"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3405
+#: lib/abuuba_web/live/admin_live.ex:3420
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2059
+#: lib/abuuba_web/live/admin_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Talk only to servers on the allowlist"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3330
+#: lib/abuuba_web/live/admin_live.ex:3345
 #, elixir-autogen, elixir-format
 msgid "That account outranks yours, so there is nothing here you can do to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2871
-#: lib/abuuba_web/live/admin_live.ex:2883
+#: lib/abuuba_web/live/admin_live.ex:2885
+#: lib/abuuba_web/live/admin_live.ex:2897
 #, elixir-autogen, elixir-format
 msgid "That could not be done."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2460
+#: lib/abuuba_web/live/admin_live.ex:2474
 #, elixir-autogen, elixir-format
 msgid "That is not a role you can hand out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2475
+#: lib/abuuba_web/live/admin_live.ex:2489
 #, elixir-autogen, elixir-format
 msgid "That is not an address."
 msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
-#: lib/abuuba_web/live/admin_live.ex:3325
+#: lib/abuuba_web/live/admin_live.ex:3340
 #: lib/abuuba_web/live/settings_live.ex:1628
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3701
+#: lib/abuuba_web/live/admin_live.ex:3716
 #, elixir-autogen, elixir-format
 msgid "The database is not answering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:848
+#: lib/abuuba_web/live/admin_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "This account outranks yours, so there is nothing here you can do to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:819
+#: lib/abuuba_web/live/admin_live.ex:832
 #, elixir-autogen, elixir-format
 msgid "This deletes the account as well. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3702
+#: lib/abuuba_web/live/admin_live.ex:3717
 #, elixir-autogen, elixir-format
 msgid "This server has no actor of its own"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:821
+#: lib/abuuba_web/live/admin_live.ex:834
 #, elixir-autogen, elixir-format
 msgid "Turn away"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3403
+#: lib/abuuba_web/live/admin_live.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Waiting to be let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:877
+#: lib/abuuba_web/live/admin_live.ex:890
 #, elixir-autogen, elixir-format
 msgid "What has been decided about them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:446
+#: lib/abuuba_web/live/admin_live.ex:459
 #, elixir-autogen, elixir-format
 msgid "What needs attention"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1914
+#: lib/abuuba_web/live/admin_live.ex:1928
 #, elixir-autogen, elixir-format
 msgid "What this server is for"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:863
+#: lib/abuuba_web/live/admin_live.ex:876
 #, elixir-autogen, elixir-format
 msgid "What to do"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2014
+#: lib/abuuba_web/live/admin_live.ex:2028
 #, elixir-autogen, elixir-format
 msgid "What to say when nobody may sign up"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:870
+#: lib/abuuba_web/live/admin_live.ex:883
 #, elixir-autogen, elixir-format
 msgid "What to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2001
+#: lib/abuuba_web/live/admin_live.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Who may sign up"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:886
+#: lib/abuuba_web/live/admin_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:801
+#: lib/abuuba_web/live/admin_live.ex:814
 #, elixir-autogen, elixir-format
 msgid "limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:800
+#: lib/abuuba_web/live/admin_live.ex:813
 #, elixir-autogen, elixir-format
 msgid "suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2272
+#: lib/abuuba_web/live/admin_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "the server"
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:307
-#: lib/abuuba_web/live/admin_live.ex:1077
+#: lib/abuuba_web/live/admin_live.ex:1090
 #, elixir-autogen, elixir-format
 msgid "%{count} person"
 msgid_plural "%{count} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1033
+#: lib/abuuba_web/live/admin_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Nothing appears in the trending lists until somebody here has looked at it. This is what is waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1092
+#: lib/abuuba_web/live/admin_live.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Nothing is trending. That is what a quiet day looks like."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1067
+#: lib/abuuba_web/live/admin_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting to be looked at."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1060
+#: lib/abuuba_web/live/admin_live.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Refuse"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1086
-#: lib/abuuba_web/live/admin_live.ex:1144
+#: lib/abuuba_web/live/admin_live.ex:1099
+#: lib/abuuba_web/live/admin_live.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Take it down"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3369
+#: lib/abuuba_web/live/admin_live.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Trends"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1070
+#: lib/abuuba_web/live/admin_live.ex:1083
 #, elixir-autogen, elixir-format
 msgid "What is trending now"
 msgstr ""
@@ -2841,12 +2841,12 @@ msgstr ""
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2515
+#: lib/abuuba_web/live/admin_live.ex:2529
 #, elixir-autogen, elixir-format
 msgid "An announcement needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3370
+#: lib/abuuba_web/live/admin_live.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Announcements"
 msgstr ""
@@ -2856,7 +2856,7 @@ msgstr ""
 msgid "Codes that let somebody you know sign up."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2195
+#: lib/abuuba_web/live/admin_live.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Each version is kept with the day it takes effect, so somebody can still read what they agreed to."
 msgstr ""
@@ -2866,12 +2866,12 @@ msgstr ""
 msgid "Earlier versions"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3781
+#: lib/abuuba_web/live/admin_live.ex:3796
 #, elixir-autogen, elixir-format
 msgid "Everybody has already been told about that one."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1132
+#: lib/abuuba_web/live/admin_live.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Goes up"
 msgstr ""
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "How many people"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2203
+#: lib/abuuba_web/live/admin_live.ex:2217
 #, elixir-autogen, elixir-format
 msgid "In effect from"
 msgstr ""
@@ -2901,7 +2901,7 @@ msgstr ""
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1117
+#: lib/abuuba_web/live/admin_live.ex:1130
 #, elixir-autogen, elixir-format
 msgid "Leave this empty to publish it now."
 msgstr ""
@@ -2911,27 +2911,27 @@ msgstr ""
 msgid "Make one"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1135
+#: lib/abuuba_web/live/admin_live.ex:1148
 #, elixir-autogen, elixir-format
 msgid "Not published"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1150
+#: lib/abuuba_web/live/admin_live.ex:1163
 #, elixir-autogen, elixir-format
 msgid "Nothing has been announced."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2206
+#: lib/abuuba_web/live/admin_live.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1129
+#: lib/abuuba_web/live/admin_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Published"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1102
+#: lib/abuuba_web/live/admin_live.ex:1115
 #, elixir-autogen, elixir-format
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
@@ -2941,12 +2941,12 @@ msgstr ""
 msgid "Take it back"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2222
+#: lib/abuuba_web/live/admin_live.ex:2236
 #, elixir-autogen, elixir-format
 msgid "Tell everybody"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2541
+#: lib/abuuba_web/live/admin_live.ex:2555
 #, elixir-autogen, elixir-format
 msgid "Terms need some text and a day they take effect."
 msgstr ""
@@ -2961,13 +2961,13 @@ msgstr ""
 msgid "What it is for"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1109
-#: lib/abuuba_web/live/admin_live.ex:2087
+#: lib/abuuba_web/live/admin_live.ex:1122
+#: lib/abuuba_web/live/admin_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "What to say"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1114
+#: lib/abuuba_web/live/admin_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "When to publish it"
 msgstr ""
@@ -2982,7 +2982,7 @@ msgstr ""
 msgid "You have not made any."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2213
+#: lib/abuuba_web/live/admin_live.ex:2227
 #, elixir-autogen, elixir-format
 msgid "everybody was told"
 msgstr ""
@@ -2994,59 +2994,59 @@ msgid_plural "used %{count} times"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1200
+#: lib/abuuba_web/live/admin_live.ex:1213
 #, elixir-autogen, elixir-format
 msgid "Addresses"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1232
+#: lib/abuuba_web/live/admin_live.ex:1245
 #, elixir-autogen, elixir-format
 msgid "Anywhere in a name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3763
+#: lib/abuuba_web/live/admin_live.ex:3778
 #, elixir-autogen, elixir-format
 msgid "Ask for approval"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1177
-#: lib/abuuba_web/live/admin_live.ex:1206
-#: lib/abuuba_web/live/admin_live.ex:1234
+#: lib/abuuba_web/live/admin_live.ex:1190
+#: lib/abuuba_web/live/admin_live.ex:1219
+#: lib/abuuba_web/live/admin_live.ex:1247
 #, elixir-autogen, elixir-format
 msgid "Block it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1255
+#: lib/abuuba_web/live/admin_live.ex:1268
 #, elixir-autogen, elixir-format
 msgid "Email addresses"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1257
+#: lib/abuuba_web/live/admin_live.ex:1270
 #, elixir-autogen, elixir-format
 msgid "Kept as hashes rather than addresses. The list has to recognise somebody coming back, not be readable."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1166
+#: lib/abuuba_web/live/admin_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "Mail domains"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3765
+#: lib/abuuba_web/live/admin_live.ex:3780
 #, elixir-autogen, elixir-format
 msgid "No access at all"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3764
+#: lib/abuuba_web/live/admin_live.ex:3779
 #, elixir-autogen, elixir-format
 msgid "No sign-ups"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1278
+#: lib/abuuba_web/live/admin_live.ex:1291
 #, elixir-autogen, elixir-format
 msgid "None. One is added when an account is suspended and you ask for it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1175
+#: lib/abuuba_web/live/admin_live.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Only ask for approval"
 msgstr ""
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "Please complete the puzzle so we know you are a person."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3371
+#: lib/abuuba_web/live/admin_live.ex:3386
 #, elixir-autogen, elixir-format
 msgid "Sign-up blocks"
 msgstr ""
@@ -3076,22 +3076,22 @@ msgstr ""
 msgid "This server asks new accounts to solve a puzzle first."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1227
+#: lib/abuuba_web/live/admin_live.ex:1240
 #, elixir-autogen, elixir-format
 msgid "Usernames"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1160
+#: lib/abuuba_web/live/admin_live.ex:1173
 #, elixir-autogen, elixir-format
 msgid "What this server refuses at the door. Most of these have a middle setting that asks somebody to look rather than shutting the door."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1240
+#: lib/abuuba_web/live/admin_live.ex:1253
 #, elixir-autogen, elixir-format
 msgid "anywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1184
+#: lib/abuuba_web/live/admin_live.ex:1197
 #, elixir-autogen, elixir-format
 msgid "approval only"
 msgstr ""
@@ -3304,7 +3304,7 @@ msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:1064
 #: lib/abuuba_web/live/settings_live.ex:1913
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:2244
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
@@ -3399,7 +3399,7 @@ msgstr ""
 msgid "A filter needs at least one word to look for."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:798
+#: lib/abuuba_web/live/admin_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "Why they want to join:"
 msgstr ""
@@ -3456,27 +3456,27 @@ msgstr ""
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:917
+#: lib/abuuba_web/live/admin_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Mark as a memorial"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:904
+#: lib/abuuba_web/live/admin_live.ex:917
 #, elixir-autogen, elixir-format
 msgid "Marking an account as a memorial stops it being signed in to and marks the profile as one. Nothing is hidden and nothing is deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2306
+#: lib/abuuba_web/live/admin_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "That could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:912
+#: lib/abuuba_web/live/admin_live.ex:925
 #, elixir-autogen, elixir-format
 msgid "This also disables their login. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:916
+#: lib/abuuba_web/live/admin_live.ex:929
 #, elixir-autogen, elixir-format
 msgid "This is not a memorial"
 msgstr ""
@@ -3563,17 +3563,17 @@ msgstr ""
 msgid "Wrote things other people replied to."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2100
+#: lib/abuuba_web/live/admin_live.ex:2114
 #, elixir-autogen, elixir-format
 msgid "An http or https address. Anything else is refused and nothing is shown."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2079
+#: lib/abuuba_web/live/admin_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Asking for money"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2081
+#: lib/abuuba_web/live/admin_live.ex:2095
 #, elixir-autogen, elixir-format
 msgid "Clients show this to people signed in here. Leave the message empty to show nothing."
 msgstr ""
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2074
+#: lib/abuuba_web/live/admin_live.ex:2088
 #, elixir-autogen, elixir-format
 msgid "Each person still has to turn it on for themselves, and every address has to confirm before anything is sent to it."
 msgstr ""
@@ -3652,12 +3652,12 @@ msgstr ""
 msgid "This address is getting updates. You can stop them at any time."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2105
+#: lib/abuuba_web/live/admin_live.ex:2119
 #, elixir-autogen, elixir-format
 msgid "What the button says"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2092
+#: lib/abuuba_web/live/admin_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Where the button goes"
 msgstr ""
@@ -3672,7 +3672,7 @@ msgstr ""
 msgid "somebody gave this address to receive updates from %{name} on %{site}. If that was you, confirm it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2071
+#: lib/abuuba_web/live/admin_live.ex:2085
 #, elixir-autogen, elixir-format
 msgid "Let people collect email addresses for updates"
 msgstr ""
@@ -3830,25 +3830,25 @@ msgstr ""
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:810
-#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1303
-#: lib/abuuba_web/live/admin_live.ex:1318
-#: lib/abuuba_web/live/settings_live.ex:2230
+#: lib/abuuba_web/live/admin_live.ex:1316
+#: lib/abuuba_web/live/admin_live.ex:1331
+#: lib/abuuba_web/live/settings_live.ex:2242
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2246
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
@@ -3858,7 +3858,7 @@ msgstr ""
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2241
+#: lib/abuuba_web/live/settings_live.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
@@ -3873,7 +3873,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2231
+#: lib/abuuba_web/live/settings_live.ex:2243
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr ""
@@ -3893,7 +3893,7 @@ msgstr ""
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2240
+#: lib/abuuba_web/live/settings_live.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2250
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr ""
@@ -4147,7 +4147,7 @@ msgstr ""
 msgid "Mail about your own account — password resets and the like — still comes."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2143
+#: lib/abuuba_web/live/admin_live.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Served from this server and linked from every page. It goes out exactly as typed."
 msgstr ""
@@ -4173,7 +4173,7 @@ msgstr ""
 msgid "You will not get that kind of email from us again."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2141
+#: lib/abuuba_web/live/admin_live.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Your own CSS"
 msgstr ""
@@ -4193,649 +4193,649 @@ msgstr ""
 msgid "the occasional summary of what you missed"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1590
+#: lib/abuuba_web/live/admin_live.ex:1603
 #, elixir-autogen, elixir-format
 msgid "A relay forwards every public post it is sent on to everybody subscribed to it. On a young server it is the quickest way to have a federated timeline with anything in it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1513
-#: lib/abuuba_web/live/admin_live.ex:1625
+#: lib/abuuba_web/live/admin_live.ex:1526
+#: lib/abuuba_web/live/admin_live.ex:1638
 #, elixir-autogen, elixir-format
 msgid "Last error:"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1662
+#: lib/abuuba_web/live/admin_live.ex:1675
 #, elixir-autogen, elixir-format
 msgid "No relays yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3666
+#: lib/abuuba_web/live/admin_live.ex:3681
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3668
+#: lib/abuuba_web/live/admin_live.ex:3683
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3372
+#: lib/abuuba_web/live/admin_live.ex:3387
 #, elixir-autogen, elixir-format
 msgid "Relays"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1654
+#: lib/abuuba_web/live/admin_live.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Remove this relay?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2813
+#: lib/abuuba_web/live/admin_live.ex:2827
 #, elixir-autogen, elixir-format
 msgid "That is not an https inbox address, or it is already here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3669
+#: lib/abuuba_web/live/admin_live.ex:3684
 #, elixir-autogen, elixir-format
 msgid "The relay refused"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1607
+#: lib/abuuba_web/live/admin_live.ex:1620
 #, elixir-autogen, elixir-format
 msgid "The relay's inbox address, which its operator publishes. Adding and turning on are separate steps, so a mistyped address can be corrected before anything is sent to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1646
-#: lib/abuuba_web/live/admin_live.ex:1844
+#: lib/abuuba_web/live/admin_live.ex:1659
+#: lib/abuuba_web/live/admin_live.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Turn off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1636
-#: lib/abuuba_web/live/admin_live.ex:1844
+#: lib/abuuba_web/live/admin_live.ex:1649
+#: lib/abuuba_web/live/admin_live.ex:1858
 #, elixir-autogen, elixir-format
 msgid "Turn on"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3667
+#: lib/abuuba_web/live/admin_live.ex:3682
 #, elixir-autogen, elixir-format
 msgid "Waiting for the relay to answer"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1619
+#: lib/abuuba_web/live/admin_live.ex:1632
 #, elixir-autogen, elixir-format
 msgid "last sent %{when}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1825
+#: lib/abuuba_web/live/admin_live.ex:1839
 #, elixir-autogen, elixir-format
 msgid "Added turned off, so a URL typed wrong can be corrected before anything goes to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1800
+#: lib/abuuba_web/live/admin_live.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Copy it now. It is not shown again."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1854
+#: lib/abuuba_web/live/admin_live.ex:1868
 #, elixir-autogen, elixir-format
 msgid "New secret"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1896
+#: lib/abuuba_web/live/admin_live.ex:1910
 #, elixir-autogen, elixir-format
 msgid "No webhooks yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1891
+#: lib/abuuba_web/live/admin_live.ex:1905
 #, elixir-autogen, elixir-format
 msgid "Nothing sent yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1862
+#: lib/abuuba_web/live/admin_live.ex:1876
 #, elixir-autogen, elixir-format
 msgid "Remove this webhook?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3094
-#: lib/abuuba_web/live/admin_live.ex:3662
+#: lib/abuuba_web/live/admin_live.ex:3109
+#: lib/abuuba_web/live/admin_live.ex:3677
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3659
+#: lib/abuuba_web/live/admin_live.ex:3674
 #, elixir-autogen, elixir-format
 msgid "That is not an event this server sends."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3656
+#: lib/abuuba_web/live/admin_live.ex:3671
 #, elixir-autogen, elixir-format
 msgid "That is not an https address, or it is already here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1852
+#: lib/abuuba_web/live/admin_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "The old secret stops working immediately. Continue?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1798
+#: lib/abuuba_web/live/admin_live.ex:1812
 #, elixir-autogen, elixir-format
 msgid "The signing secret"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1792
+#: lib/abuuba_web/live/admin_live.ex:1806
 #, elixir-autogen, elixir-format
 msgid "This server posts to a webhook when something happens that a moderator would want to know about."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/admin_live.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Webhooks"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1877
+#: lib/abuuba_web/live/admin_live.ex:1891
 #, elixir-autogen, elixir-format
 msgid "no answer"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1674
+#: lib/abuuba_web/live/admin_live.ex:1688
 #, elixir-autogen, elixir-format
 msgid "A role is a set of permissions and a position. Position is what decides who may act on whom: nobody may edit a role at or above their own, and nobody may grant a permission they do not hold themselves."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1776
+#: lib/abuuba_web/live/admin_live.ex:1790
 #, elixir-autogen, elixir-format
 msgid "Above yours"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3575
+#: lib/abuuba_web/live/admin_live.ex:3590
 #, elixir-autogen, elixir-format
 msgid "Act on accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3579
+#: lib/abuuba_web/live/admin_live.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Answer appeals"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3605
+#: lib/abuuba_web/live/admin_live.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Approve registrations, and turn two-factor off for somebody locked out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3583
+#: lib/abuuba_web/live/admin_live.ex:3598
 #, elixir-autogen, elixir-format
 msgid "Approve what trends"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3613
+#: lib/abuuba_web/live/admin_live.ex:3628
 #, elixir-autogen, elixir-format
 msgid "Block and unblock other servers, and set up relays."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3581
+#: lib/abuuba_web/live/admin_live.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Block sign-ups"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3582
+#: lib/abuuba_web/live/admin_live.ex:3597
 #, elixir-autogen, elixir-format
 msgid "Change the server's settings"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1699
+#: lib/abuuba_web/live/admin_live.ex:1713
 #, elixir-autogen, elixir-format
 msgid "Colour"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1738
+#: lib/abuuba_web/live/admin_live.ex:1752
 #, elixir-autogen, elixir-format
 msgid "Create the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3580
+#: lib/abuuba_web/live/admin_live.ex:3595
 #, elixir-autogen, elixir-format
 msgid "Decide about other servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3619
+#: lib/abuuba_web/live/admin_live.ex:3634
 #, elixir-autogen, elixir-format
 msgid "Decide which hashtags, links and posts may appear in what is trending."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3577
+#: lib/abuuba_web/live/admin_live.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Delete an account's data"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3608
+#: lib/abuuba_web/live/admin_live.ex:3623
 #, elixir-autogen, elixir-format
 msgid "Delete somebody's posts and files. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3594
+#: lib/abuuba_web/live/admin_live.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Every permission below, including ones added later. Give it to very few people."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3578
+#: lib/abuuba_web/live/admin_live.ex:3593
 #, elixir-autogen, elixir-format
 msgid "Handle reports"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3576
+#: lib/abuuba_web/live/admin_live.ex:3591
 #, elixir-autogen, elixir-format
 msgid "Let people in and out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3623
+#: lib/abuuba_web/live/admin_live.ex:3638
 #, elixir-autogen, elixir-format
 msgid "Make and change roles, never above their own and never granting more than they hold."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3588
+#: lib/abuuba_web/live/admin_live.ex:3603
 #, elixir-autogen, elixir-format
 msgid "Manage custom emoji"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3584
+#: lib/abuuba_web/live/admin_live.ex:3599
 #, elixir-autogen, elixir-format
 msgid "Manage everybody's invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3590
+#: lib/abuuba_web/live/admin_live.ex:3605
 #, elixir-autogen, elixir-format
 msgid "Manage roles"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3589
+#: lib/abuuba_web/live/admin_live.ex:3604
 #, elixir-autogen, elixir-format
 msgid "Manage webhooks"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1684
+#: lib/abuuba_web/live/admin_live.ex:1698
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1781
+#: lib/abuuba_web/live/admin_live.ex:1795
 #, elixir-autogen, elixir-format
 msgid "No roles yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1689
+#: lib/abuuba_web/live/admin_live.ex:1703
 #, elixir-autogen, elixir-format
 msgid "Position"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1752
+#: lib/abuuba_web/live/admin_live.ex:1766
 #, elixir-autogen, elixir-format
 msgid "Position %{position}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3574
+#: lib/abuuba_web/live/admin_live.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Read the audit log"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3610
+#: lib/abuuba_web/live/admin_live.ex:3625
 #, elixir-autogen, elixir-format
 msgid "Read the queue, resolve and reopen."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1770
+#: lib/abuuba_web/live/admin_live.ex:1784
 #, elixir-autogen, elixir-format
 msgid "Remove this role? Anybody holding it keeps their account."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3377
+#: lib/abuuba_web/live/admin_live.ex:3392
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1738
+#: lib/abuuba_web/live/admin_live.ex:1752
 #, elixir-autogen, elixir-format
 msgid "Save the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3573
+#: lib/abuuba_web/live/admin_live.ex:3588
 #, elixir-autogen, elixir-format
 msgid "See the admin area"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3602
+#: lib/abuuba_web/live/admin_live.ex:3617
 #, elixir-autogen, elixir-format
 msgid "Silence, suspend, approve and reject accounts on this server."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3487
-#: lib/abuuba_web/live/admin_live.ex:3513
+#: lib/abuuba_web/live/admin_live.ex:3502
+#: lib/abuuba_web/live/admin_live.ex:3528
 #, elixir-autogen, elixir-format
 msgid "That role could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3599
+#: lib/abuuba_web/live/admin_live.ex:3614
 #, elixir-autogen, elixir-format
 msgid "What every moderator has done, including this person's own actions."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1711
+#: lib/abuuba_web/live/admin_live.ex:1725
 #, elixir-autogen, elixir-format
 msgid "What this role may do"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3616
+#: lib/abuuba_web/live/admin_live.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Who may sign up, the server's name and description, and the rest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3596
+#: lib/abuuba_web/live/admin_live.ex:3611
 #, elixir-autogen, elixir-format
 msgid "Without this the admin area is closed."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3587
+#: lib/abuuba_web/live/admin_live.ex:3602
 #, elixir-autogen, elixir-format
 msgid "Write announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3585
+#: lib/abuuba_web/live/admin_live.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Write invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3586
+#: lib/abuuba_web/live/admin_live.ex:3601
 #, elixir-autogen, elixir-format
 msgid "Write the server rules"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3566
+#: lib/abuuba_web/live/admin_live.ex:3581
 #, elixir-autogen, elixir-format
 msgid "You cannot make a role at or above your own position, or grant a permission you do not hold."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1731
+#: lib/abuuba_web/live/admin_live.ex:1745
 #, elixir-autogen, elixir-format
 msgid "You do not hold this yourself, so you cannot grant it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3636
+#: lib/abuuba_web/live/admin_live.ex:3651
 #, elixir-autogen, elixir-format
 msgid "nothing in particular"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:922
-#: lib/abuuba_web/live/admin_live.ex:1571
+#: lib/abuuba_web/live/admin_live.ex:935
+#: lib/abuuba_web/live/admin_live.ex:1584
 #, elixir-autogen, elixir-format
 msgid "A note for the other moderators"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1548
+#: lib/abuuba_web/live/admin_live.ex:1561
 #, elixir-autogen, elixir-format
 msgid "Blocked: %{severity}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1506
+#: lib/abuuba_web/live/admin_live.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Delivering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1492
+#: lib/abuuba_web/live/admin_live.ex:1505
 #, elixir-autogen, elixir-format
 msgid "Delivery stopped by a moderator"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1459
+#: lib/abuuba_web/live/admin_live.ex:1472
 #, elixir-autogen, elixir-format
 msgid "Every server this one has heard from, busiest first. A peer that has quietly stopped accepting deliveries looks exactly like a peer whose people have gone quiet, and this is where the two are told apart."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1544
+#: lib/abuuba_web/live/admin_live.ex:1557
 #, elixir-autogen, elixir-format
 msgid "Forget the failures"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1580
+#: lib/abuuba_web/live/admin_live.ex:1593
 #, elixir-autogen, elixir-format
 msgid "No other servers yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1484
+#: lib/abuuba_web/live/admin_live.ex:1497
 #, elixir-autogen, elixir-format
 msgid "One account"
 msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3376
+#: lib/abuuba_web/live/admin_live.ex:3391
 #, elixir-autogen, elixir-format
 msgid "Other servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1561
+#: lib/abuuba_web/live/admin_live.ex:1574
 #, elixir-autogen, elixir-format
 msgid "Silence this server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1558
+#: lib/abuuba_web/live/admin_live.ex:1571
 #, elixir-autogen, elixir-format
 msgid "Silence this server? Its posts stop appearing in public timelines."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1534
+#: lib/abuuba_web/live/admin_live.ex:1547
 #, elixir-autogen, elixir-format
 msgid "Start again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1524
+#: lib/abuuba_web/live/admin_live.ex:1537
 #, elixir-autogen, elixir-format
 msgid "Stop delivering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2670
+#: lib/abuuba_web/live/admin_live.ex:2684
 #, elixir-autogen, elixir-format
 msgid "That server could not be blocked."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1498
+#: lib/abuuba_web/live/admin_live.ex:1511
 #, elixir-autogen, elixir-format
 msgid "Treated as down since %{when}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1509
+#: lib/abuuba_web/live/admin_live.ex:1522
 #, elixir-autogen, elixir-format
 msgid "one bad day"
 msgid_plural "%{count} bad days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1484
+#: lib/abuuba_web/live/admin_live.ex:1497
 #, elixir-autogen, elixir-format
 msgid "one post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:955
+#: lib/abuuba_web/live/admin_live.ex:968
 #, elixir-autogen, elixir-format
 msgid "Ask their server for it again. Worth doing when the name or picture here is out of date and waiting for their next post is waiting for something that may not come."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:982
+#: lib/abuuba_web/live/admin_live.ex:995
 #, elixir-autogen, elixir-format
 msgid "Delete this post? Other servers are told to delete it too."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:967
+#: lib/abuuba_web/live/admin_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "Deleting one from here is the same delete they would do themselves."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:960
+#: lib/abuuba_web/live/admin_live.ex:973
 #, elixir-autogen, elixir-format
 msgid "Fetch it again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:948
+#: lib/abuuba_web/live/admin_live.ex:961
 #, elixir-autogen, elixir-format
 msgid "Force a password reset"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:936
+#: lib/abuuba_web/live/admin_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Locked out, or somebody else is in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:924
+#: lib/abuuba_web/live/admin_live.ex:937
 #, elixir-autogen, elixir-format
 msgid "Nobody is told and nothing is applied. This is for the context that otherwise lives in one person's head: that this is the third report about the same joke, or that somebody spoke to them and they understood."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:991
+#: lib/abuuba_web/live/admin_live.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Nothing posted."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:945
+#: lib/abuuba_web/live/admin_live.ex:958
 #, elixir-autogen, elixir-format
 msgid "Sign them out everywhere and send a reset link?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2688
+#: lib/abuuba_web/live/admin_live.ex:2702
 #, elixir-autogen, elixir-format
 msgid "That account has nobody to sign in as."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:965
+#: lib/abuuba_web/live/admin_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "Their most recent posts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:953
+#: lib/abuuba_web/live/admin_live.ex:966
 #, elixir-autogen, elixir-format
 msgid "Their profile here is a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2701
+#: lib/abuuba_web/live/admin_live.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Their server did not answer."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:938
+#: lib/abuuba_web/live/admin_live.ex:951
 #, elixir-autogen, elixir-format
 msgid "This ends every session and every app, and emails them a link to set a new password. It does not choose one for them: a password a moderator picked is a password a moderator knows."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2137
+#: lib/abuuba_web/live/admin_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "%{latest} is out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1289
+#: lib/abuuba_web/live/admin_live.ex:1302
 #, elixir-autogen, elixir-format
 msgid "A server that has decided about four hundred domains has made four hundred decisions, and the way those get shared is a list somebody publishes. This reads and writes those lists."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2757
+#: lib/abuuba_web/live/admin_live.ex:2771
 #, elixir-autogen, elixir-format
 msgid "Added %{added}. %{skipped} were already decided about."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1431
+#: lib/abuuba_web/live/admin_live.ex:1444
 #, elixir-autogen, elixir-format
 msgid "Addresses that asked one account here to write to them. Only the confirmed ones are counted: an unconfirmed address is a claim somebody typed, not a subscriber."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1304
-#: lib/abuuba_web/live/admin_live.ex:1319
+#: lib/abuuba_web/live/admin_live.ex:1317
+#: lib/abuuba_web/live/admin_live.ex:1332
 #, elixir-autogen, elixir-format
 msgid "Allows"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2114
+#: lib/abuuba_web/live/admin_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Checking for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3375
+#: lib/abuuba_web/live/admin_live.ex:3390
 #, elixir-autogen, elixir-format
 msgid "Domain lists"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1309
+#: lib/abuuba_web/live/admin_live.ex:1322
 #, elixir-autogen, elixir-format
 msgid "Domains this server has already decided about are left exactly as they are. An import adds and never removes: one paste should not be able to undo every decision made here, silently and unrecoverably."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3373
+#: lib/abuuba_web/live/admin_live.ex:3388
 #, elixir-autogen, elixir-format
 msgid "Email subscriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1448
+#: lib/abuuba_web/live/admin_live.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Nobody here has any subscribers."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1421
+#: lib/abuuba_web/live/admin_live.ex:1434
 #, elixir-autogen, elixir-format
 msgid "Nobody is being suggested yet. It needs a few follows to work from."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1403
+#: lib/abuuba_web/live/admin_live.ex:1416
 #, elixir-autogen, elixir-format
 msgid "Not suggested"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2116
+#: lib/abuuba_web/live/admin_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. It asks %{url} whether there is a newer abuuba. What that tells them is what any web request tells anybody: this server's address, a user agent, and that somebody asked. Nothing about the accounts here, their number or their posts is sent, and there is nowhere in the request for it to go."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1442
+#: lib/abuuba_web/live/admin_live.ex:1455
 #, elixir-autogen, elixir-format
 msgid "One address"
 msgid_plural "%{count} addresses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1296
+#: lib/abuuba_web/live/admin_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "One blocked domain"
 msgid_plural "%{count} blocked domains"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1330
+#: lib/abuuba_web/live/admin_live.ex:1343
 #, elixir-autogen, elixir-format
 msgid "Read it in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1307
+#: lib/abuuba_web/live/admin_live.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Read one in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2135
+#: lib/abuuba_web/live/admin_live.ex:2149
 #, elixir-autogen, elixir-format
 msgid "Running %{version}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1415
+#: lib/abuuba_web/live/admin_live.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Stop suggesting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1414
+#: lib/abuuba_web/live/admin_live.ex:1427
 #, elixir-autogen, elixir-format
 msgid "Suggest again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1294
+#: lib/abuuba_web/live/admin_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Take a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2131
+#: lib/abuuba_web/live/admin_live.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Tell me when there is a newer version"
 msgstr ""
@@ -4845,104 +4845,104 @@ msgstr ""
 msgid "There is no list of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1316
+#: lib/abuuba_web/live/admin_live.ex:1329
 #, elixir-autogen, elixir-format
 msgid "Which list"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1391
+#: lib/abuuba_web/live/admin_live.ex:1404
 #, elixir-autogen, elixir-format
 msgid "Who this server puts in front of a newcomer. Taking somebody out is not a block and not a silence: their account carries on exactly as before and nobody is told."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1296
+#: lib/abuuba_web/live/admin_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "one allowed domain"
 msgid_plural "%{count} allowed domains"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:344
+#: lib/abuuba_web/live/admin_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "%{label}, highest %{top}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3690
+#: lib/abuuba_web/live/admin_live.ex:3705
 #, elixir-autogen, elixir-format
 msgid "Favourites, boosts and replies"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3695
+#: lib/abuuba_web/live/admin_live.ex:3710
 #, elixir-autogen, elixir-format
 msgid "Languages people write in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3688
+#: lib/abuuba_web/live/admin_live.ex:3703
 #, elixir-autogen, elixir-format
 msgid "New accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:425
+#: lib/abuuba_web/live/admin_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Of the people who signed up in a given week, how many were still posting in the weeks after. A number that only means something once the server has been running a while."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3687
+#: lib/abuuba_web/live/admin_live.ex:3702
 #, elixir-autogen, elixir-format
 msgid "People who posted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3689
+#: lib/abuuba_web/live/admin_live.ex:3704
 #, elixir-autogen, elixir-format
 msgid "Posts written here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3691
+#: lib/abuuba_web/live/admin_live.ex:3706
 #, elixir-autogen, elixir-format
 msgid "Reports opened"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3692
+#: lib/abuuba_web/live/admin_live.ex:3707
 #, elixir-autogen, elixir-format
 msgid "Reports resolved"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3697
+#: lib/abuuba_web/live/admin_live.ex:3712
 #, elixir-autogen, elixir-format
 msgid "Servers we hear most from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:389
+#: lib/abuuba_web/live/admin_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "The last thirty days"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:391
+#: lib/abuuba_web/live/admin_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "The same numbers a moderation client draws from the API, so what you see here and what it shows are the same figures rather than two answers to one question."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3698
+#: lib/abuuba_web/live/admin_live.ex:3713
 #, elixir-autogen, elixir-format
 msgid "What those servers run"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3696
+#: lib/abuuba_web/live/admin_live.ex:3711
 #, elixir-autogen, elixir-format
 msgid "Where accounts signed up from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:404
+#: lib/abuuba_web/live/admin_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Where things come from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:423
+#: lib/abuuba_web/live/admin_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Who stayed"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:434
+#: lib/abuuba_web/live/admin_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "one signed up"
 msgid_plural "%{count} signed up"
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:552
+#: lib/abuuba_web/live/admin_live.ex:565
 #: lib/abuuba_web/live/settings_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "None yet."
@@ -5116,222 +5116,222 @@ msgstr ""
 msgid "On its way."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2423
+#: lib/abuuba_web/live/admin_live.ex:2437
 #, elixir-autogen, elixir-format
 msgid "A preset needs both."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:494
-#: lib/abuuba_web/live/admin_live.ex:710
+#: lib/abuuba_web/live/admin_live.ex:507
+#: lib/abuuba_web/live/admin_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "Add it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:570
+#: lib/abuuba_web/live/admin_live.ex:583
 #, elixir-autogen, elixir-format
 msgid "All of them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:568
+#: lib/abuuba_web/live/admin_live.ex:581
 #, elixir-autogen, elixir-format
 msgid "Dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:777
+#: lib/abuuba_web/live/admin_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "Do it to all of them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:629
+#: lib/abuuba_web/live/admin_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "Filed as %{category} on %{date}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:687
+#: lib/abuuba_web/live/admin_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "For whoever picks this up next. The person reported never sees any of it, and neither does whoever filed it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:663
+#: lib/abuuba_web/live/admin_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "I am on this"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2173
+#: lib/abuuba_web/live/admin_live.ex:2187
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3295
+#: lib/abuuba_web/live/admin_live.ex:3310
 #, elixir-autogen, elixir-format
 msgid "Limit them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:672
+#: lib/abuuba_web/live/admin_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "Mark it dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:601
+#: lib/abuuba_web/live/admin_live.ex:614
 #, elixir-autogen, elixir-format
 msgid "Nothing waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:855
+#: lib/abuuba_web/live/admin_live.ex:868
 #, elixir-autogen, elixir-format
 msgid "Nothing, I will write it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:757
+#: lib/abuuba_web/live/admin_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "One account ticked."
 msgid_plural "%{count} accounts ticked."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:681
+#: lib/abuuba_web/live/admin_live.ex:694
 #, elixir-autogen, elixir-format
 msgid "Put it back in the queue"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2155
+#: lib/abuuba_web/live/admin_live.ex:2169
 #, elixir-autogen, elixir-format
 msgid "Ready-made texts a moderator picks instead of retyping. Kept for the server rather than for one moderator, so two people writing about the same thing say the same thing."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3367
+#: lib/abuuba_web/live/admin_live.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:578
+#: lib/abuuba_web/live/admin_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "Report %{id}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3365
+#: lib/abuuba_web/live/admin_live.ex:3380
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:853
+#: lib/abuuba_web/live/admin_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "Start from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:566
+#: lib/abuuba_web/live/admin_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Still open"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3297
+#: lib/abuuba_web/live/admin_live.ex:3312
 #, elixir-autogen, elixir-format
 msgid "Stop them signing in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3296
+#: lib/abuuba_web/live/admin_live.ex:3311
 #, elixir-autogen, elixir-format
 msgid "Suspend them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:639
+#: lib/abuuba_web/live/admin_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "The posts it names"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:770
+#: lib/abuuba_web/live/admin_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "This does the same thing to one account and tells them. Go ahead?"
 msgid_plural "This does the same thing to all %{count} accounts and tells each of them. Go ahead?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:788
+#: lib/abuuba_web/live/admin_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "Tick %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:755
+#: lib/abuuba_web/live/admin_live.ex:768
 #, elixir-autogen, elixir-format
 msgid "Tick some accounts to do one thing to all of them."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2153
+#: lib/abuuba_web/live/admin_live.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Warning presets"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2170
+#: lib/abuuba_web/live/admin_live.ex:2184
 #, elixir-autogen, elixir-format
 msgid "What it says"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:685
+#: lib/abuuba_web/live/admin_live.ex:698
 #, elixir-autogen, elixir-format
 msgid "What moderators have written here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:707
+#: lib/abuuba_web/live/admin_live.ex:720
 #, elixir-autogen, elixir-format
 msgid "What you found"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:564
+#: lib/abuuba_web/live/admin_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Which ones"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:582
+#: lib/abuuba_web/live/admin_live.ex:595
 #, elixir-autogen, elixir-format
 msgid "about"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:589
+#: lib/abuuba_web/live/admin_live.ex:602
 #, elixir-autogen, elixir-format
 msgid "dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:582
-#: lib/abuuba_web/live/admin_live.ex:624
+#: lib/abuuba_web/live/admin_live.ex:595
+#: lib/abuuba_web/live/admin_live.ex:637
 #, elixir-autogen, elixir-format
 msgid "from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3313
+#: lib/abuuba_web/live/admin_live.ex:3328
 #, elixir-autogen, elixir-format
 msgid "somebody who is gone"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:591
+#: lib/abuuba_web/live/admin_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "taken"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3272
+#: lib/abuuba_web/live/admin_live.ex:3287
 #, elixir-autogen, elixir-format
 msgid "One account could not be changed."
 msgid_plural "%{count} accounts could not be changed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3265
+#: lib/abuuba_web/live/admin_live.ex:3280
 #, elixir-autogen, elixir-format
 msgid "One account was left alone because it outranks yours."
 msgid_plural "%{count} accounts were left alone because they outrank yours."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:605
+#: lib/abuuba_web/live/admin_live.ex:618
 #, elixir-autogen, elixir-format
 msgid "Showing the newest %{count}. Deal with some to see the ones that have waited longest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3230
+#: lib/abuuba_web/live/admin_live.ex:3245
 #, elixir-autogen, elixir-format
 msgid "That is not something this list can do."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:644
+#: lib/abuuba_web/live/admin_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Warning:"
 msgstr ""
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Your account may not do that."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:650
+#: lib/abuuba_web/live/admin_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "has pictures or video"
 msgstr ""
@@ -5452,95 +5452,95 @@ msgstr ""
 msgid "Show anyway"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:490
+#: lib/abuuba_web/live/admin_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "A PNG or a GIF, at most %{size}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3197
+#: lib/abuuba_web/live/admin_live.ex:3212
 #, elixir-autogen, elixir-format
 msgid "A shortcode is letters, numbers and underscores, and nothing else."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3133
-#: lib/abuuba_web/live/admin_live.ex:3179
+#: lib/abuuba_web/live/admin_live.ex:3148
+#: lib/abuuba_web/live/admin_live.ex:3194
 #, elixir-autogen, elixir-format
 msgid "An emoji has to be a PNG or a GIF."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3123
-#: lib/abuuba_web/live/admin_live.ex:3157
+#: lib/abuuba_web/live/admin_live.ex:3138
+#: lib/abuuba_web/live/admin_live.ex:3172
 #, elixir-autogen, elixir-format
 msgid "Choose a picture for it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3366
+#: lib/abuuba_web/live/admin_live.ex:3381
 #, elixir-autogen, elixir-format
 msgid "Custom emoji"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:543
+#: lib/abuuba_web/live/admin_live.ex:556
 #, elixir-autogen, elixir-format
 msgid "Every post that used it loses its picture. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:481
+#: lib/abuuba_web/live/admin_live.ex:494
 #, elixir-autogen, elixir-format
 msgid "Group it under"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:518
+#: lib/abuuba_web/live/admin_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "Offer it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:468
+#: lib/abuuba_web/live/admin_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Pictures people here can type into a post by name. One uploaded here is held on this server, so it outlives whoever made it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:476
+#: lib/abuuba_web/live/admin_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Shortcode"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:517
+#: lib/abuuba_web/live/admin_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Stop offering it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3199
+#: lib/abuuba_web/live/admin_live.ex:3214
 #, elixir-autogen, elixir-format
 msgid "That emoji could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3185
+#: lib/abuuba_web/live/admin_live.ex:3200
 #, elixir-autogen, elixir-format
 msgid "That picture could not be stored."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3139
+#: lib/abuuba_web/live/admin_live.ex:3154
 #, elixir-autogen, elixir-format
 msgid "That picture could not be used."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3136
-#: lib/abuuba_web/live/admin_live.ex:3182
+#: lib/abuuba_web/live/admin_live.ex:3151
+#: lib/abuuba_web/live/admin_live.ex:3197
 #, elixir-autogen, elixir-format
 msgid "That picture is too large for an emoji."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:487
+#: lib/abuuba_web/live/admin_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "The picture"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3120
+#: lib/abuuba_web/live/admin_live.ex:3135
 #, elixir-autogen, elixir-format
 msgid "The picture is still uploading. Try again in a moment."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:505
+#: lib/abuuba_web/live/admin_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "not offered"
 msgstr ""
@@ -5630,22 +5630,22 @@ msgstr ""
 msgid "Quotes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2019
+#: lib/abuuba_web/live/admin_live.ex:2033
 #, elixir-autogen, elixir-format
 msgid "Days to keep other servers' files"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2028
+#: lib/abuuba_web/live/admin_live.ex:2042
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them indefinitely. Anything older goes off this server's disk each night. The posts stay, and a file is fetched again if somebody opens it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:530
+#: lib/abuuba_web/live/admin_live.ex:543
 #, elixir-autogen, elixir-format
 msgid "Every post that used it loses its picture until you turn it back on. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:503
+#: lib/abuuba_web/live/admin_live.ex:516
 #, elixir-autogen, elixir-format
 msgid "turned off"
 msgstr ""
@@ -5682,69 +5682,69 @@ msgstr ""
 msgid "This takes it out of your inbox only. Nobody else loses anything, and a later message brings it back. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2035
+#: lib/abuuba_web/live/admin_live.ex:2049
 #, elixir-autogen, elixir-format
 msgid "Days to keep other servers' posts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2044
+#: lib/abuuba_web/live/admin_live.ex:2058
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them for ever. Anything older is deleted each night, except a post somebody here favourited, bookmarked, pinned, boosted, quoted, replied to or was mentioned in."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1919
+#: lib/abuuba_web/live/admin_live.ex:1933
 #, elixir-autogen, elixir-format
 msgid "The longer version, for the about page"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1970
-#: lib/abuuba_web/live/admin_live.ex:1979
+#: lib/abuuba_web/live/admin_live.ex:1984
+#: lib/abuuba_web/live/admin_live.ex:1993
 #, elixir-autogen, elixir-format
 msgid "Anybody, including people with no account"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1985
+#: lib/abuuba_web/live/admin_live.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Nobody: turn them off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1967
-#: lib/abuuba_web/live/admin_live.ex:1982
+#: lib/abuuba_web/live/admin_live.ex:1981
+#: lib/abuuba_web/live/admin_live.ex:1996
 #, elixir-autogen, elixir-format
 msgid "Only people signed in here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1976
+#: lib/abuuba_web/live/admin_live.ex:1990
 #, elixir-autogen, elixir-format
 msgid "Who may read the public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1951
+#: lib/abuuba_web/live/admin_live.ex:1965
 #, elixir-autogen, elixir-format
 msgid "The privacy policy takes effect on"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1935
+#: lib/abuuba_web/live/admin_live.ex:1949
 #, elixir-autogen, elixir-format
 msgid "The account to write to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1940
+#: lib/abuuba_web/live/admin_live.ex:1954
 #, elixir-autogen, elixir-format
 msgid "a username on this server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1924
+#: lib/abuuba_web/live/admin_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "Status page"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1964
+#: lib/abuuba_web/live/admin_live.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Nobody: the server does not say"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1961
+#: lib/abuuba_web/live/admin_live.ex:1975
 #, elixir-autogen, elixir-format
 msgid "Who may read the blocklist"
 msgstr ""
@@ -5780,62 +5780,68 @@ msgstr ""
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3355
+#: lib/abuuba_web/live/admin_live.ex:3370
 #, elixir-autogen, elixir-format
 msgid "Account disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3358
+#: lib/abuuba_web/live/admin_live.ex:3373
 #, elixir-autogen, elixir-format
 msgid "Account limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3359
+#: lib/abuuba_web/live/admin_live.ex:3374
 #, elixir-autogen, elixir-format
 msgid "Account suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3368
+#: lib/abuuba_web/live/admin_live.ex:3383
 #, elixir-autogen, elixir-format
 msgid "Appeals"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1381
+#: lib/abuuba_web/live/admin_live.ex:1394
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting. Appeals against a strike show up here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3357
+#: lib/abuuba_web/live/admin_live.ex:3372
 #, elixir-autogen, elixir-format
 msgid "Posts deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3356
+#: lib/abuuba_web/live/admin_live.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Posts marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1340
+#: lib/abuuba_web/live/admin_live.ex:1353
 #, elixir-autogen, elixir-format
 msgid "Somebody who was warned, silenced or suspended saying it was a mistake. Upholding an appeal undoes the action where it can be undone; where it cannot, the appeal is still recorded as upheld. Either way the account's owner is told."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3070
+#: lib/abuuba_web/live/admin_live.ex:3085
 #, elixir-autogen, elixir-format
 msgid "That appeal is no longer waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1374
+#: lib/abuuba_web/live/admin_live.ex:1387
 #, elixir-autogen, elixir-format
 msgid "Turn down"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1366
+#: lib/abuuba_web/live/admin_live.ex:1379
 #, elixir-autogen, elixir-format
 msgid "Uphold and undo"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3354
+#: lib/abuuba_web/live/admin_live.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Warned"
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2237
+#, elixir-autogen, elixir-format
+msgid "%{size} MB"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -49,7 +49,7 @@ msgid "Change"
 msgstr ""
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:736
+#: lib/abuuba_web/live/compose_component.ex:723
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -401,13 +401,13 @@ msgstr ""
 msgid "This is the only time they are shown. Each one works once, and they are how you get back in if you lose your phone."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/admin_live.ex:549
 #: lib/abuuba_web/live/two_factor_settings_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Turn it off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/admin_live.ex:549
 #: lib/abuuba_web/live/two_factor_settings_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Turn it on"
@@ -453,7 +453,7 @@ msgstr ""
 msgid "Act as a moderator (%{scope})"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1051
+#: lib/abuuba_web/live/admin_live.ex:1064
 #: lib/abuuba_web/live/authorize_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Allow"
@@ -464,10 +464,10 @@ msgstr ""
 msgid "Authorize %{app}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1741
+#: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
+#: lib/abuuba_web/live/compose_component.ex:397
 #: lib/abuuba_web/live/compose_component.ex:410
-#: lib/abuuba_web/live/compose_component.ex:423
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -662,7 +662,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
 #: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2310
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -689,7 +689,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
@@ -761,7 +761,7 @@ msgid "Follow some people and their posts will appear here."
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:267
-#: lib/abuuba_web/live/compose_component.ex:616
+#: lib/abuuba_web/live/compose_component.ex:603
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
@@ -791,303 +791,303 @@ msgstr ""
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1679
+#: lib/abuuba_web/live/compose_component.ex:1666
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1664
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1680
+#: lib/abuuba_web/live/compose_component.ex:1667
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/compose_component.ex:1663
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/compose_component.ex:1662
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1678
+#: lib/abuuba_web/live/compose_component.ex:1665
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1681
+#: lib/abuuba_web/live/compose_component.ex:1668
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1156
+#: lib/abuuba_web/live/compose_component.ex:1141
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:651
+#: lib/abuuba_web/live/compose_component.ex:638
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:722
+#: lib/abuuba_web/live/compose_component.ex:709
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:663
+#: lib/abuuba_web/live/compose_component.ex:650
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1696
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/settings_live.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1687
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/compose_component.ex:1674
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1688
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:627
+#: lib/abuuba_web/live/compose_component.ex:614
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:451
-#: lib/abuuba_web/live/compose_component.ex:712
+#: lib/abuuba_web/live/compose_component.ex:438
+#: lib/abuuba_web/live/compose_component.ex:699
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:813
+#: lib/abuuba_web/live/compose_component.ex:800
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:446
+#: lib/abuuba_web/live/compose_component.ex:433
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:432
-#: lib/abuuba_web/live/admin_live.ex:1761
+#: lib/abuuba_web/live/admin_live.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:416
+#: lib/abuuba_web/live/compose_component.ex:403
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:667
+#: lib/abuuba_web/live/compose_component.ex:654
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1689
+#: lib/abuuba_web/live/compose_component.ex:1676
 #: lib/abuuba_web/live/profile_live.ex:837
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1677
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3413
-#: lib/abuuba_web/live/compose_component.ex:1698
-#: lib/abuuba_web/live/settings_live.ex:2295
+#: lib/abuuba_web/live/admin_live.ex:3428
+#: lib/abuuba_web/live/compose_component.ex:1685
+#: lib/abuuba_web/live/settings_live.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1689
-#: lib/abuuba_web/live/settings_live.ex:2290
+#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1690
+#: lib/abuuba_web/live/compose_component.ex:1677
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1697
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/compose_component.ex:1684
+#: lib/abuuba_web/live/settings_live.ex:2306
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1456
+#: lib/abuuba_web/live/compose_component.ex:1441
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:696
+#: lib/abuuba_web/live/compose_component.ex:683
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1687
-#: lib/abuuba_web/live/compose_component.ex:1705
+#: lib/abuuba_web/live/compose_component.ex:1674
+#: lib/abuuba_web/live/compose_component.ex:1692
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1688
+#: lib/abuuba_web/live/compose_component.ex:1675
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:732
+#: lib/abuuba_web/live/compose_component.ex:719
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:639
+#: lib/abuuba_web/live/compose_component.ex:626
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:403
+#: lib/abuuba_web/live/compose_component.ex:390
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1454
+#: lib/abuuba_web/live/compose_component.ex:1439
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3374
-#: lib/abuuba_web/live/compose_component.ex:478
+#: lib/abuuba_web/live/admin_live.ex:3389
+#: lib/abuuba_web/live/compose_component.ex:465
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1118
+#: lib/abuuba_web/live/compose_component.ex:1103
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1180
-#: lib/abuuba_web/live/compose_component.ex:1215
-#: lib/abuuba_web/live/compose_component.ex:1410
+#: lib/abuuba_web/live/compose_component.ex:1165
+#: lib/abuuba_web/live/compose_component.ex:1200
+#: lib/abuuba_web/live/compose_component.ex:1395
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:462
-#: lib/abuuba_web/live/compose_component.ex:468
+#: lib/abuuba_web/live/compose_component.ex:449
+#: lib/abuuba_web/live/compose_component.ex:455
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:456
+#: lib/abuuba_web/live/compose_component.ex:443
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:772
+#: lib/abuuba_web/live/compose_component.ex:759
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:752
+#: lib/abuuba_web/live/compose_component.ex:739
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1114
+#: lib/abuuba_web/live/compose_component.ex:1099
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1212
+#: lib/abuuba_web/live/compose_component.ex:1197
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1652
+#: lib/abuuba_web/live/compose_component.ex:1635
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:819
+#: lib/abuuba_web/live/compose_component.ex:806
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:851
+#: lib/abuuba_web/live/compose_component.ex:838
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:1160
+#: lib/abuuba_web/live/compose_component.ex:1145
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:882
+#: lib/abuuba_web/live/compose_component.ex:869
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:843
+#: lib/abuuba_web/live/compose_component.ex:830
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:682
+#: lib/abuuba_web/live/compose_component.ex:669
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:833
-#: lib/abuuba_web/live/compose_component.ex:872
+#: lib/abuuba_web/live/compose_component.ex:820
+#: lib/abuuba_web/live/compose_component.ex:859
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1131
-#: lib/abuuba_web/live/compose_component.ex:1401
+#: lib/abuuba_web/live/compose_component.ex:1116
+#: lib/abuuba_web/live/compose_component.ex:1386
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:804
+#: lib/abuuba_web/live/compose_component.ex:791
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1455
+#: lib/abuuba_web/live/compose_component.ex:1440
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:317
+#: lib/abuuba_web/live/compose_component.ex:304
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That draft could not be saved."
 msgstr ""
@@ -1097,104 +1097,104 @@ msgstr ""
 msgid "That post is scheduled."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1165
+#: lib/abuuba_web/live/compose_component.ex:1150
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:313
+#: lib/abuuba_web/live/compose_component.ex:300
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1449
+#: lib/abuuba_web/live/compose_component.ex:1434
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:689
+#: lib/abuuba_web/live/compose_component.ex:676
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1128
+#: lib/abuuba_web/live/compose_component.ex:1113
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:497
+#: lib/abuuba_web/live/compose_component.ex:484
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:592
+#: lib/abuuba_web/live/compose_component.ex:579
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:542
+#: lib/abuuba_web/live/compose_component.ex:529
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:559
-#: lib/abuuba_web/live/compose_component.ex:567
+#: lib/abuuba_web/live/compose_component.ex:546
+#: lib/abuuba_web/live/compose_component.ex:554
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:581
+#: lib/abuuba_web/live/compose_component.ex:568
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:596
+#: lib/abuuba_web/live/compose_component.ex:583
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:554
+#: lib/abuuba_web/live/compose_component.ex:541
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:522
+#: lib/abuuba_web/live/compose_component.ex:509
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:607
+#: lib/abuuba_web/live/compose_component.ex:594
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:252
-#: lib/abuuba_web/live/compose_component.ex:1445
+#: lib/abuuba_web/live/compose_component.ex:239
+#: lib/abuuba_web/live/compose_component.ex:1430
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1442
+#: lib/abuuba_web/live/compose_component.ex:1427
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:239
+#: lib/abuuba_web/live/compose_component.ex:226
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1443
+#: lib/abuuba_web/live/compose_component.ex:1428
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1444
+#: lib/abuuba_web/live/compose_component.ex:1429
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:501
+#: lib/abuuba_web/live/compose_component.ex:488
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr ""
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "Posts and replies"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:931
+#: lib/abuuba_web/live/admin_live.ex:944
 #: lib/abuuba_web/live/profile_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Save the note"
@@ -1504,7 +1504,7 @@ msgstr ""
 #: lib/abuuba_web/live/notifications_live.ex:440
 #: lib/abuuba_web/live/profile_live.ex:838
 #: lib/abuuba_web/live/settings_live.ex:2103
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2241
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows"
 msgstr ""
@@ -1565,11 +1565,11 @@ msgstr ""
 msgid "Private mentions out of nowhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1010
-#: lib/abuuba_web/live/admin_live.ex:1018
-#: lib/abuuba_web/live/admin_live.ex:1121
-#: lib/abuuba_web/live/admin_live.ex:1574
-#: lib/abuuba_web/live/admin_live.ex:2150
+#: lib/abuuba_web/live/admin_live.ex:1023
+#: lib/abuuba_web/live/admin_live.ex:1031
+#: lib/abuuba_web/live/admin_live.ex:1134
+#: lib/abuuba_web/live/admin_live.ex:1587
+#: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
 #: lib/abuuba_web/live/profile_live.ex:255
 #: lib/abuuba_web/live/settings_live.ex:294
@@ -1584,7 +1584,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:238
+#: lib/abuuba_web/live/admin_live.ex:245
 #: lib/abuuba_web/live/notification_settings_live.ex:54
 #: lib/abuuba_web/live/settings_live.ex:136
 #, elixir-autogen, elixir-format
@@ -1638,8 +1638,8 @@ msgstr ""
 msgid "A name, a #tag, or some words"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2263
-#: lib/abuuba_web/live/admin_live.ex:3572
+#: lib/abuuba_web/live/admin_live.ex:2277
+#: lib/abuuba_web/live/admin_live.ex:3587
 #: lib/abuuba_web/live/search_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Everything"
@@ -1765,7 +1765,7 @@ msgstr ""
 msgid "About you"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3364
+#: lib/abuuba_web/live/admin_live.ex:3379
 #: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Account"
@@ -1786,7 +1786,7 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
@@ -1806,7 +1806,7 @@ msgstr ""
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
@@ -1816,7 +1816,7 @@ msgstr ""
 msgid "Change the password"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:985
+#: lib/abuuba_web/live/admin_live.ex:998
 #: lib/abuuba_web/live/settings_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Delete"
@@ -1827,7 +1827,7 @@ msgstr ""
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
@@ -1837,7 +1837,7 @@ msgstr ""
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
@@ -1858,27 +1858,27 @@ msgid "Fields"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:2102
-#: lib/abuuba_web/live/settings_live.ex:2235
+#: lib/abuuba_web/live/settings_live.ex:2247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2317
+#: lib/abuuba_web/live/settings_live.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2318
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2266
+#: lib/abuuba_web/live/settings_live.ex:2278
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
@@ -1893,17 +1893,17 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2269
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
@@ -1933,7 +1933,7 @@ msgstr ""
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
@@ -1958,26 +1958,26 @@ msgstr ""
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2302
+#: lib/abuuba_web/live/settings_live.ex:2314
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2285
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:546
-#: lib/abuuba_web/live/admin_live.ex:1656
-#: lib/abuuba_web/live/admin_live.ex:1772
-#: lib/abuuba_web/live/admin_live.ex:1864
-#: lib/abuuba_web/live/admin_live.ex:2188
+#: lib/abuuba_web/live/admin_live.ex:559
+#: lib/abuuba_web/live/admin_live.ex:1669
+#: lib/abuuba_web/live/admin_live.ex:1786
+#: lib/abuuba_web/live/admin_live.ex:1878
+#: lib/abuuba_web/live/admin_live.ex:2202
 #: lib/abuuba_web/live/conversations_live.ex:112
 #: lib/abuuba_web/live/settings_live.ex:280
 #: lib/abuuba_web/live/settings_live.ex:315
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2284
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
@@ -2010,7 +2010,7 @@ msgstr ""
 msgid "Take it back out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3735
+#: lib/abuuba_web/live/admin_live.ex:3750
 #: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved. Check what you typed."
@@ -2026,17 +2026,17 @@ msgstr ""
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2267
+#: lib/abuuba_web/live/settings_live.ex:2279
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2268
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
@@ -2056,7 +2056,7 @@ msgstr ""
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
@@ -2066,7 +2066,7 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2277
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
@@ -2081,7 +2081,7 @@ msgstr ""
 msgid "What the compose box starts with."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2164
+#: lib/abuuba_web/live/admin_live.ex:2178
 #: lib/abuuba_web/live/settings_live.ex:761
 #, elixir-autogen, elixir-format
 msgid "What to call it"
@@ -2117,7 +2117,7 @@ msgstr ""
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
@@ -2153,7 +2153,7 @@ msgid "A server on the fediverse, running %{software}."
 msgstr ""
 
 #: lib/abuuba_web/live/about_live.ex:24
-#: lib/abuuba_web/live/admin_live.ex:621
+#: lib/abuuba_web/live/admin_live.ex:634
 #: lib/abuuba_web/live/document_live.ex:134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "About"
@@ -2185,7 +2185,7 @@ msgid "No password is asked for and nothing is done on your behalf: you are simp
 msgstr ""
 
 #: lib/abuuba_web/live/about_live.ex:93
-#: lib/abuuba_web/live/admin_live.ex:1946
+#: lib/abuuba_web/live/admin_live.ex:1960
 #: lib/abuuba_web/live/document_live.ex:133
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Privacy policy"
@@ -2222,7 +2222,7 @@ msgid "Take me to my server"
 msgstr ""
 
 #: lib/abuuba_web/live/about_live.ex:92
-#: lib/abuuba_web/live/admin_live.ex:2193
+#: lib/abuuba_web/live/admin_live.ex:2207
 #: lib/abuuba_web/live/document_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
@@ -2401,427 +2401,427 @@ msgstr ""
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2248
+#: lib/abuuba_web/live/admin_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "A new rule"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2833
+#: lib/abuuba_web/live/admin_live.ex:2847
 #, elixir-autogen, elixir-format
 msgid "A rule needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3363
+#: lib/abuuba_web/live/admin_live.ex:3378
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1603
-#: lib/abuuba_web/live/admin_live.ex:1821
-#: lib/abuuba_web/live/admin_live.ex:2251
+#: lib/abuuba_web/live/admin_live.ex:1616
+#: lib/abuuba_web/live/admin_live.ex:1835
+#: lib/abuuba_web/live/admin_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1991
+#: lib/abuuba_web/live/admin_live.ex:2005
 #, elixir-autogen, elixir-format
 msgid "Address people can write to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:221
-#: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/admin_live.ex:228
+#: lib/abuuba_web/live/admin_live.ex:3396
 #, elixir-autogen, elixir-format
 msgid "Administration"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3718
+#: lib/abuuba_web/live/admin_live.ex:3733
 #, elixir-autogen, elixir-format
 msgid "An open server left unattended fills with spam registrations within days. Put sign-ups behind approval unless somebody is watching."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:739
+#: lib/abuuba_web/live/admin_live.ex:752
 #, elixir-autogen, elixir-format
 msgid "Any state"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3703
+#: lib/abuuba_web/live/admin_live.ex:3718
 #, elixir-autogen, elixir-format
 msgid "Anybody may sign up without being checked"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3412
+#: lib/abuuba_web/live/admin_live.ex:3427
 #, elixir-autogen, elixir-format
 msgid "Anybody, after somebody here says yes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3411
+#: lib/abuuba_web/live/admin_live.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Anybody, straight away"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:732
+#: lib/abuuba_web/live/admin_live.ex:745
 #, elixir-autogen, elixir-format
 msgid "Anywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:377
-#: lib/abuuba_web/live/admin_live.ex:381
+#: lib/abuuba_web/live/admin_live.ex:390
+#: lib/abuuba_web/live/admin_live.ex:394
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Appeals waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3380
+#: lib/abuuba_web/live/admin_live.ex:3395
 #, elixir-autogen, elixir-format
 msgid "Audit log"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1021
+#: lib/abuuba_web/live/admin_live.ex:1034
 #, elixir-autogen, elixir-format
 msgid "Change an address only when somebody cannot reach their own."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3362
+#: lib/abuuba_web/live/admin_live.ex:3377
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2867
+#: lib/abuuba_web/live/admin_live.ex:2881
 #, elixir-autogen, elixir-format
 msgid "Deleting posts needs the posts named, which this page cannot do yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3422
+#: lib/abuuba_web/live/admin_live.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Disable: they cannot sign in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:874
+#: lib/abuuba_web/live/admin_live.ex:887
 #, elixir-autogen, elixir-format
 msgid "Do it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:735
+#: lib/abuuba_web/live/admin_live.ex:748
 #, elixir-autogen, elixir-format
 msgid "Elsewhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1015
+#: lib/abuuba_web/live/admin_live.ex:1028
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3708
+#: lib/abuuba_web/live/admin_live.ex:3723
 #, elixir-autogen, elixir-format
 msgid "Everything else on this page is guesswork until that is fixed."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:748
-#: lib/abuuba_web/live/admin_live.ex:1472
+#: lib/abuuba_web/live/admin_live.ex:761
+#: lib/abuuba_web/live/admin_live.ex:1485
 #, elixir-autogen, elixir-format
 msgid "Find"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:733
+#: lib/abuuba_web/live/admin_live.ex:746
 #, elixir-autogen, elixir-format
 msgid "Here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:811
+#: lib/abuuba_web/live/admin_live.ex:824
 #, elixir-autogen, elixir-format
 msgid "Let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:895
-#: lib/abuuba_web/live/admin_live.ex:1193
-#: lib/abuuba_web/live/admin_live.ex:1220
-#: lib/abuuba_web/live/admin_live.ex:1248
-#: lib/abuuba_web/live/admin_live.ex:1272
+#: lib/abuuba_web/live/admin_live.ex:908
+#: lib/abuuba_web/live/admin_live.ex:1206
+#: lib/abuuba_web/live/admin_live.ex:1233
+#: lib/abuuba_web/live/admin_live.ex:1261
+#: lib/abuuba_web/live/admin_live.ex:1285
 #, elixir-autogen, elixir-format
 msgid "Lift it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3404
+#: lib/abuuba_web/live/admin_live.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3423
+#: lib/abuuba_web/live/admin_live.ex:3438
 #, elixir-autogen, elixir-format
 msgid "Mark everything they post sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:728
+#: lib/abuuba_web/live/admin_live.ex:741
 #, elixir-autogen, elixir-format
 msgid "Name or name@server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3724
+#: lib/abuuba_web/live/admin_live.ex:3739
 #, elixir-autogen, elixir-format
 msgid "Nobody can grant roles or change settings that need it. Give somebody a role holding the administrator permission."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3704
+#: lib/abuuba_web/live/admin_live.ex:3719
 #, elixir-autogen, elixir-format
 msgid "Nobody here is an administrator"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:829
+#: lib/abuuba_web/live/admin_live.ex:842
 #, elixir-autogen, elixir-format
 msgid "Nobody here matches that."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1000
+#: lib/abuuba_web/live/admin_live.ex:1013
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2283
+#: lib/abuuba_web/live/admin_live.ex:2297
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing has been done yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:418
-#: lib/abuuba_web/live/admin_live.ex:443
-#: lib/abuuba_web/live/admin_live.ex:701
-#: lib/abuuba_web/live/admin_live.ex:900
+#: lib/abuuba_web/live/admin_live.ex:431
+#: lib/abuuba_web/live/admin_live.ex:456
+#: lib/abuuba_web/live/admin_live.ex:714
+#: lib/abuuba_web/live/admin_live.ex:913
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:457
+#: lib/abuuba_web/live/admin_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Nothing. Every check this server knows how to make came back fine."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:385
+#: lib/abuuba_web/live/admin_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "People waiting to be let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:369
+#: lib/abuuba_web/live/admin_live.ex:382
 #, elixir-autogen, elixir-format
 msgid "Reports waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2241
+#: lib/abuuba_web/live/admin_live.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Retire it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:998
+#: lib/abuuba_web/live/admin_live.ex:1011
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2227
+#: lib/abuuba_web/live/admin_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Rules people agree to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3419
+#: lib/abuuba_web/live/admin_live.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Send a warning and nothing else"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1469
-#: lib/abuuba_web/live/admin_live.ex:1909
+#: lib/abuuba_web/live/admin_live.ex:1482
+#: lib/abuuba_web/live/admin_live.ex:1923
 #, elixir-autogen, elixir-format
 msgid "Server name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3379
+#: lib/abuuba_web/live/admin_live.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Server settings"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3712
+#: lib/abuuba_web/live/admin_live.ex:3727
 #, elixir-autogen, elixir-format
 msgid "Servers running authorized fetch will refuse this one. It is created on first use, so this usually means something went wrong writing it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2266
+#: lib/abuuba_web/live/admin_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2229
+#: lib/abuuba_web/live/admin_live.ex:2243
 #, elixir-autogen, elixir-format
 msgid "Shown when somebody signs up and when they file a report."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3420
+#: lib/abuuba_web/live/admin_live.ex:3435
 #, elixir-autogen, elixir-format
 msgid "Silence: out of everywhere nobody asked for them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3421
+#: lib/abuuba_web/live/admin_live.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Suspend: hidden, and deleted after the grace window"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3405
+#: lib/abuuba_web/live/admin_live.ex:3420
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2059
+#: lib/abuuba_web/live/admin_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Talk only to servers on the allowlist"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3330
+#: lib/abuuba_web/live/admin_live.ex:3345
 #, elixir-autogen, elixir-format
 msgid "That account outranks yours, so there is nothing here you can do to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2871
-#: lib/abuuba_web/live/admin_live.ex:2883
+#: lib/abuuba_web/live/admin_live.ex:2885
+#: lib/abuuba_web/live/admin_live.ex:2897
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be done."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2460
+#: lib/abuuba_web/live/admin_live.ex:2474
 #, elixir-autogen, elixir-format
 msgid "That is not a role you can hand out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2475
+#: lib/abuuba_web/live/admin_live.ex:2489
 #, elixir-autogen, elixir-format
 msgid "That is not an address."
 msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
-#: lib/abuuba_web/live/admin_live.ex:3325
+#: lib/abuuba_web/live/admin_live.ex:3340
 #: lib/abuuba_web/live/settings_live.ex:1628
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3701
+#: lib/abuuba_web/live/admin_live.ex:3716
 #, elixir-autogen, elixir-format
 msgid "The database is not answering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:848
+#: lib/abuuba_web/live/admin_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "This account outranks yours, so there is nothing here you can do to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:819
+#: lib/abuuba_web/live/admin_live.ex:832
 #, elixir-autogen, elixir-format
 msgid "This deletes the account as well. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3702
+#: lib/abuuba_web/live/admin_live.ex:3717
 #, elixir-autogen, elixir-format
 msgid "This server has no actor of its own"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:821
+#: lib/abuuba_web/live/admin_live.ex:834
 #, elixir-autogen, elixir-format
 msgid "Turn away"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3403
+#: lib/abuuba_web/live/admin_live.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Waiting to be let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:877
+#: lib/abuuba_web/live/admin_live.ex:890
 #, elixir-autogen, elixir-format
 msgid "What has been decided about them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:446
+#: lib/abuuba_web/live/admin_live.ex:459
 #, elixir-autogen, elixir-format
 msgid "What needs attention"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1914
+#: lib/abuuba_web/live/admin_live.ex:1928
 #, elixir-autogen, elixir-format
 msgid "What this server is for"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:863
+#: lib/abuuba_web/live/admin_live.ex:876
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What to do"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2014
+#: lib/abuuba_web/live/admin_live.ex:2028
 #, elixir-autogen, elixir-format
 msgid "What to say when nobody may sign up"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:870
+#: lib/abuuba_web/live/admin_live.ex:883
 #, elixir-autogen, elixir-format
 msgid "What to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2001
+#: lib/abuuba_web/live/admin_live.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Who may sign up"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:886
+#: lib/abuuba_web/live/admin_live.ex:899
 #, elixir-autogen, elixir-format
 msgid "lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:801
+#: lib/abuuba_web/live/admin_live.ex:814
 #, elixir-autogen, elixir-format
 msgid "limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:800
+#: lib/abuuba_web/live/admin_live.ex:813
 #, elixir-autogen, elixir-format
 msgid "suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2272
+#: lib/abuuba_web/live/admin_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "the server"
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:307
-#: lib/abuuba_web/live/admin_live.ex:1077
+#: lib/abuuba_web/live/admin_live.ex:1090
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} person"
 msgid_plural "%{count} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1033
+#: lib/abuuba_web/live/admin_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Nothing appears in the trending lists until somebody here has looked at it. This is what is waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1092
+#: lib/abuuba_web/live/admin_live.ex:1105
 #, elixir-autogen, elixir-format
 msgid "Nothing is trending. That is what a quiet day looks like."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1067
+#: lib/abuuba_web/live/admin_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting to be looked at."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1060
+#: lib/abuuba_web/live/admin_live.ex:1073
 #, elixir-autogen, elixir-format
 msgid "Refuse"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1086
-#: lib/abuuba_web/live/admin_live.ex:1144
+#: lib/abuuba_web/live/admin_live.ex:1099
+#: lib/abuuba_web/live/admin_live.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Take it down"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3369
+#: lib/abuuba_web/live/admin_live.ex:3384
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Trends"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1070
+#: lib/abuuba_web/live/admin_live.ex:1083
 #, elixir-autogen, elixir-format
 msgid "What is trending now"
 msgstr ""
@@ -2841,12 +2841,12 @@ msgstr ""
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2515
+#: lib/abuuba_web/live/admin_live.ex:2529
 #, elixir-autogen, elixir-format
 msgid "An announcement needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3370
+#: lib/abuuba_web/live/admin_live.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Announcements"
 msgstr ""
@@ -2856,7 +2856,7 @@ msgstr ""
 msgid "Codes that let somebody you know sign up."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2195
+#: lib/abuuba_web/live/admin_live.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Each version is kept with the day it takes effect, so somebody can still read what they agreed to."
 msgstr ""
@@ -2866,12 +2866,12 @@ msgstr ""
 msgid "Earlier versions"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3781
+#: lib/abuuba_web/live/admin_live.ex:3796
 #, elixir-autogen, elixir-format
 msgid "Everybody has already been told about that one."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1132
+#: lib/abuuba_web/live/admin_live.ex:1145
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Goes up"
 msgstr ""
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "How many people"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2203
+#: lib/abuuba_web/live/admin_live.ex:2217
 #, elixir-autogen, elixir-format
 msgid "In effect from"
 msgstr ""
@@ -2901,7 +2901,7 @@ msgstr ""
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1117
+#: lib/abuuba_web/live/admin_live.ex:1130
 #, elixir-autogen, elixir-format
 msgid "Leave this empty to publish it now."
 msgstr ""
@@ -2911,27 +2911,27 @@ msgstr ""
 msgid "Make one"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1135
+#: lib/abuuba_web/live/admin_live.ex:1148
 #, elixir-autogen, elixir-format
 msgid "Not published"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1150
+#: lib/abuuba_web/live/admin_live.ex:1163
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing has been announced."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2206
+#: lib/abuuba_web/live/admin_live.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1129
+#: lib/abuuba_web/live/admin_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Published"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1102
+#: lib/abuuba_web/live/admin_live.ex:1115
 #, elixir-autogen, elixir-format
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
@@ -2941,12 +2941,12 @@ msgstr ""
 msgid "Take it back"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2222
+#: lib/abuuba_web/live/admin_live.ex:2236
 #, elixir-autogen, elixir-format
 msgid "Tell everybody"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2541
+#: lib/abuuba_web/live/admin_live.ex:2555
 #, elixir-autogen, elixir-format
 msgid "Terms need some text and a day they take effect."
 msgstr ""
@@ -2961,13 +2961,13 @@ msgstr ""
 msgid "What it is for"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1109
-#: lib/abuuba_web/live/admin_live.ex:2087
+#: lib/abuuba_web/live/admin_live.ex:1122
+#: lib/abuuba_web/live/admin_live.ex:2101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What to say"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1114
+#: lib/abuuba_web/live/admin_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "When to publish it"
 msgstr ""
@@ -2982,7 +2982,7 @@ msgstr ""
 msgid "You have not made any."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2213
+#: lib/abuuba_web/live/admin_live.ex:2227
 #, elixir-autogen, elixir-format
 msgid "everybody was told"
 msgstr ""
@@ -2994,59 +2994,59 @@ msgid_plural "used %{count} times"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1200
+#: lib/abuuba_web/live/admin_live.ex:1213
 #, elixir-autogen, elixir-format
 msgid "Addresses"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1232
+#: lib/abuuba_web/live/admin_live.ex:1245
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Anywhere in a name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3763
+#: lib/abuuba_web/live/admin_live.ex:3778
 #, elixir-autogen, elixir-format
 msgid "Ask for approval"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1177
-#: lib/abuuba_web/live/admin_live.ex:1206
-#: lib/abuuba_web/live/admin_live.ex:1234
+#: lib/abuuba_web/live/admin_live.ex:1190
+#: lib/abuuba_web/live/admin_live.ex:1219
+#: lib/abuuba_web/live/admin_live.ex:1247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Block it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1255
+#: lib/abuuba_web/live/admin_live.ex:1268
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email addresses"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1257
+#: lib/abuuba_web/live/admin_live.ex:1270
 #, elixir-autogen, elixir-format
 msgid "Kept as hashes rather than addresses. The list has to recognise somebody coming back, not be readable."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1166
+#: lib/abuuba_web/live/admin_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "Mail domains"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3765
+#: lib/abuuba_web/live/admin_live.ex:3780
 #, elixir-autogen, elixir-format
 msgid "No access at all"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3764
+#: lib/abuuba_web/live/admin_live.ex:3779
 #, elixir-autogen, elixir-format
 msgid "No sign-ups"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1278
+#: lib/abuuba_web/live/admin_live.ex:1291
 #, elixir-autogen, elixir-format
 msgid "None. One is added when an account is suspended and you ask for it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1175
+#: lib/abuuba_web/live/admin_live.ex:1188
 #, elixir-autogen, elixir-format
 msgid "Only ask for approval"
 msgstr ""
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "Please complete the puzzle so we know you are a person."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3371
+#: lib/abuuba_web/live/admin_live.ex:3386
 #, elixir-autogen, elixir-format
 msgid "Sign-up blocks"
 msgstr ""
@@ -3076,22 +3076,22 @@ msgstr ""
 msgid "This server asks new accounts to solve a puzzle first."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1227
+#: lib/abuuba_web/live/admin_live.ex:1240
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Usernames"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1160
+#: lib/abuuba_web/live/admin_live.ex:1173
 #, elixir-autogen, elixir-format
 msgid "What this server refuses at the door. Most of these have a middle setting that asks somebody to look rather than shutting the door."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1240
+#: lib/abuuba_web/live/admin_live.ex:1253
 #, elixir-autogen, elixir-format, fuzzy
 msgid "anywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1184
+#: lib/abuuba_web/live/admin_live.ex:1197
 #, elixir-autogen, elixir-format
 msgid "approval only"
 msgstr ""
@@ -3304,7 +3304,7 @@ msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:1064
 #: lib/abuuba_web/live/settings_live.ex:1913
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:2244
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
@@ -3399,7 +3399,7 @@ msgstr ""
 msgid "A filter needs at least one word to look for."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:798
+#: lib/abuuba_web/live/admin_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "Why they want to join:"
 msgstr ""
@@ -3456,27 +3456,27 @@ msgstr ""
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:917
+#: lib/abuuba_web/live/admin_live.ex:930
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mark as a memorial"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:904
+#: lib/abuuba_web/live/admin_live.ex:917
 #, elixir-autogen, elixir-format
 msgid "Marking an account as a memorial stops it being signed in to and marks the profile as one. Nothing is hidden and nothing is deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2306
+#: lib/abuuba_web/live/admin_live.ex:2320
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:912
+#: lib/abuuba_web/live/admin_live.ex:925
 #, elixir-autogen, elixir-format
 msgid "This also disables their login. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:916
+#: lib/abuuba_web/live/admin_live.ex:929
 #, elixir-autogen, elixir-format
 msgid "This is not a memorial"
 msgstr ""
@@ -3563,17 +3563,17 @@ msgstr ""
 msgid "Wrote things other people replied to."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2100
+#: lib/abuuba_web/live/admin_live.ex:2114
 #, elixir-autogen, elixir-format
 msgid "An http or https address. Anything else is refused and nothing is shown."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2079
+#: lib/abuuba_web/live/admin_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Asking for money"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2081
+#: lib/abuuba_web/live/admin_live.ex:2095
 #, elixir-autogen, elixir-format
 msgid "Clients show this to people signed in here. Leave the message empty to show nothing."
 msgstr ""
@@ -3593,7 +3593,7 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2074
+#: lib/abuuba_web/live/admin_live.ex:2088
 #, elixir-autogen, elixir-format
 msgid "Each person still has to turn it on for themselves, and every address has to confirm before anything is sent to it."
 msgstr ""
@@ -3652,12 +3652,12 @@ msgstr ""
 msgid "This address is getting updates. You can stop them at any time."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2105
+#: lib/abuuba_web/live/admin_live.ex:2119
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What the button says"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2092
+#: lib/abuuba_web/live/admin_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Where the button goes"
 msgstr ""
@@ -3672,7 +3672,7 @@ msgstr ""
 msgid "somebody gave this address to receive updates from %{name} on %{site}. If that was you, confirm it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2071
+#: lib/abuuba_web/live/admin_live.ex:2085
 #, elixir-autogen, elixir-format
 msgid "Let people collect email addresses for updates"
 msgstr ""
@@ -3830,25 +3830,25 @@ msgstr ""
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:810
-#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1303
-#: lib/abuuba_web/live/admin_live.ex:1318
-#: lib/abuuba_web/live/settings_live.ex:2230
+#: lib/abuuba_web/live/admin_live.ex:1316
+#: lib/abuuba_web/live/admin_live.ex:1331
+#: lib/abuuba_web/live/settings_live.ex:2242
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2246
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Bookmarks"
 msgstr ""
@@ -3858,7 +3858,7 @@ msgstr ""
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2241
+#: lib/abuuba_web/live/settings_live.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
@@ -3873,7 +3873,7 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2231
+#: lib/abuuba_web/live/settings_live.ex:2243
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mutes"
 msgstr ""
@@ -3893,7 +3893,7 @@ msgstr ""
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2240
+#: lib/abuuba_web/live/settings_live.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3913,7 +3913,7 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2250
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waiting to start"
 msgstr ""
@@ -4147,7 +4147,7 @@ msgstr ""
 msgid "Mail about your own account — password resets and the like — still comes."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2143
+#: lib/abuuba_web/live/admin_live.ex:2157
 #, elixir-autogen, elixir-format
 msgid "Served from this server and linked from every page. It goes out exactly as typed."
 msgstr ""
@@ -4173,7 +4173,7 @@ msgstr ""
 msgid "You will not get that kind of email from us again."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2141
+#: lib/abuuba_web/live/admin_live.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Your own CSS"
 msgstr ""
@@ -4193,649 +4193,649 @@ msgstr ""
 msgid "the occasional summary of what you missed"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1590
+#: lib/abuuba_web/live/admin_live.ex:1603
 #, elixir-autogen, elixir-format
 msgid "A relay forwards every public post it is sent on to everybody subscribed to it. On a young server it is the quickest way to have a federated timeline with anything in it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1513
-#: lib/abuuba_web/live/admin_live.ex:1625
+#: lib/abuuba_web/live/admin_live.ex:1526
+#: lib/abuuba_web/live/admin_live.ex:1638
 #, elixir-autogen, elixir-format
 msgid "Last error:"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1662
+#: lib/abuuba_web/live/admin_live.ex:1675
 #, elixir-autogen, elixir-format
 msgid "No relays yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3666
+#: lib/abuuba_web/live/admin_live.ex:3681
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3668
+#: lib/abuuba_web/live/admin_live.ex:3683
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3372
+#: lib/abuuba_web/live/admin_live.ex:3387
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Relays"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1654
+#: lib/abuuba_web/live/admin_live.ex:1667
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this relay?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2813
+#: lib/abuuba_web/live/admin_live.ex:2827
 #, elixir-autogen, elixir-format
 msgid "That is not an https inbox address, or it is already here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3669
+#: lib/abuuba_web/live/admin_live.ex:3684
 #, elixir-autogen, elixir-format
 msgid "The relay refused"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1607
+#: lib/abuuba_web/live/admin_live.ex:1620
 #, elixir-autogen, elixir-format
 msgid "The relay's inbox address, which its operator publishes. Adding and turning on are separate steps, so a mistyped address can be corrected before anything is sent to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1646
-#: lib/abuuba_web/live/admin_live.ex:1844
+#: lib/abuuba_web/live/admin_live.ex:1659
+#: lib/abuuba_web/live/admin_live.ex:1858
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Turn off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1636
-#: lib/abuuba_web/live/admin_live.ex:1844
+#: lib/abuuba_web/live/admin_live.ex:1649
+#: lib/abuuba_web/live/admin_live.ex:1858
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Turn on"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3667
+#: lib/abuuba_web/live/admin_live.ex:3682
 #, elixir-autogen, elixir-format
 msgid "Waiting for the relay to answer"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1619
+#: lib/abuuba_web/live/admin_live.ex:1632
 #, elixir-autogen, elixir-format
 msgid "last sent %{when}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1825
+#: lib/abuuba_web/live/admin_live.ex:1839
 #, elixir-autogen, elixir-format
 msgid "Added turned off, so a URL typed wrong can be corrected before anything goes to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1800
+#: lib/abuuba_web/live/admin_live.ex:1814
 #, elixir-autogen, elixir-format
 msgid "Copy it now. It is not shown again."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1854
+#: lib/abuuba_web/live/admin_live.ex:1868
 #, elixir-autogen, elixir-format
 msgid "New secret"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1896
+#: lib/abuuba_web/live/admin_live.ex:1910
 #, elixir-autogen, elixir-format
 msgid "No webhooks yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1891
+#: lib/abuuba_web/live/admin_live.ex:1905
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing sent yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1862
+#: lib/abuuba_web/live/admin_live.ex:1876
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this webhook?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3094
-#: lib/abuuba_web/live/admin_live.ex:3662
+#: lib/abuuba_web/live/admin_live.ex:3109
+#: lib/abuuba_web/live/admin_live.ex:3677
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That did not work."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3659
+#: lib/abuuba_web/live/admin_live.ex:3674
 #, elixir-autogen, elixir-format
 msgid "That is not an event this server sends."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3656
+#: lib/abuuba_web/live/admin_live.ex:3671
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not an https address, or it is already here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1852
+#: lib/abuuba_web/live/admin_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "The old secret stops working immediately. Continue?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1798
+#: lib/abuuba_web/live/admin_live.ex:1812
 #, elixir-autogen, elixir-format
 msgid "The signing secret"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1792
+#: lib/abuuba_web/live/admin_live.ex:1806
 #, elixir-autogen, elixir-format
 msgid "This server posts to a webhook when something happens that a moderator would want to know about."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/admin_live.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Webhooks"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1877
+#: lib/abuuba_web/live/admin_live.ex:1891
 #, elixir-autogen, elixir-format
 msgid "no answer"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1674
+#: lib/abuuba_web/live/admin_live.ex:1688
 #, elixir-autogen, elixir-format
 msgid "A role is a set of permissions and a position. Position is what decides who may act on whom: nobody may edit a role at or above their own, and nobody may grant a permission they do not hold themselves."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1776
+#: lib/abuuba_web/live/admin_live.ex:1790
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Above yours"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3575
+#: lib/abuuba_web/live/admin_live.ex:3590
 #, elixir-autogen, elixir-format
 msgid "Act on accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3579
+#: lib/abuuba_web/live/admin_live.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Answer appeals"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3605
+#: lib/abuuba_web/live/admin_live.ex:3620
 #, elixir-autogen, elixir-format
 msgid "Approve registrations, and turn two-factor off for somebody locked out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3583
+#: lib/abuuba_web/live/admin_live.ex:3598
 #, elixir-autogen, elixir-format
 msgid "Approve what trends"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3613
+#: lib/abuuba_web/live/admin_live.ex:3628
 #, elixir-autogen, elixir-format
 msgid "Block and unblock other servers, and set up relays."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3581
+#: lib/abuuba_web/live/admin_live.ex:3596
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Block sign-ups"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3582
+#: lib/abuuba_web/live/admin_live.ex:3597
 #, elixir-autogen, elixir-format
 msgid "Change the server's settings"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1699
+#: lib/abuuba_web/live/admin_live.ex:1713
 #, elixir-autogen, elixir-format
 msgid "Colour"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1738
+#: lib/abuuba_web/live/admin_live.ex:1752
 #, elixir-autogen, elixir-format
 msgid "Create the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3580
+#: lib/abuuba_web/live/admin_live.ex:3595
 #, elixir-autogen, elixir-format
 msgid "Decide about other servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3619
+#: lib/abuuba_web/live/admin_live.ex:3634
 #, elixir-autogen, elixir-format
 msgid "Decide which hashtags, links and posts may appear in what is trending."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3577
+#: lib/abuuba_web/live/admin_live.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Delete an account's data"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3608
+#: lib/abuuba_web/live/admin_live.ex:3623
 #, elixir-autogen, elixir-format
 msgid "Delete somebody's posts and files. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3594
+#: lib/abuuba_web/live/admin_live.ex:3609
 #, elixir-autogen, elixir-format
 msgid "Every permission below, including ones added later. Give it to very few people."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3578
+#: lib/abuuba_web/live/admin_live.ex:3593
 #, elixir-autogen, elixir-format
 msgid "Handle reports"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3576
+#: lib/abuuba_web/live/admin_live.ex:3591
 #, elixir-autogen, elixir-format
 msgid "Let people in and out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3623
+#: lib/abuuba_web/live/admin_live.ex:3638
 #, elixir-autogen, elixir-format
 msgid "Make and change roles, never above their own and never granting more than they hold."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3588
+#: lib/abuuba_web/live/admin_live.ex:3603
 #, elixir-autogen, elixir-format
 msgid "Manage custom emoji"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3584
+#: lib/abuuba_web/live/admin_live.ex:3599
 #, elixir-autogen, elixir-format
 msgid "Manage everybody's invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3590
+#: lib/abuuba_web/live/admin_live.ex:3605
 #, elixir-autogen, elixir-format
 msgid "Manage roles"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3589
+#: lib/abuuba_web/live/admin_live.ex:3604
 #, elixir-autogen, elixir-format
 msgid "Manage webhooks"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1684
+#: lib/abuuba_web/live/admin_live.ex:1698
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1781
+#: lib/abuuba_web/live/admin_live.ex:1795
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No roles yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1689
+#: lib/abuuba_web/live/admin_live.ex:1703
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Position"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1752
+#: lib/abuuba_web/live/admin_live.ex:1766
 #, elixir-autogen, elixir-format
 msgid "Position %{position}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3574
+#: lib/abuuba_web/live/admin_live.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Read the audit log"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3610
+#: lib/abuuba_web/live/admin_live.ex:3625
 #, elixir-autogen, elixir-format
 msgid "Read the queue, resolve and reopen."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1770
+#: lib/abuuba_web/live/admin_live.ex:1784
 #, elixir-autogen, elixir-format
 msgid "Remove this role? Anybody holding it keeps their account."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3377
+#: lib/abuuba_web/live/admin_live.ex:3392
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Roles"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1738
+#: lib/abuuba_web/live/admin_live.ex:1752
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3573
+#: lib/abuuba_web/live/admin_live.ex:3588
 #, elixir-autogen, elixir-format
 msgid "See the admin area"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3602
+#: lib/abuuba_web/live/admin_live.ex:3617
 #, elixir-autogen, elixir-format
 msgid "Silence, suspend, approve and reject accounts on this server."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3487
-#: lib/abuuba_web/live/admin_live.ex:3513
+#: lib/abuuba_web/live/admin_live.ex:3502
+#: lib/abuuba_web/live/admin_live.ex:3528
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That role could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3599
+#: lib/abuuba_web/live/admin_live.ex:3614
 #, elixir-autogen, elixir-format
 msgid "What every moderator has done, including this person's own actions."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1711
+#: lib/abuuba_web/live/admin_live.ex:1725
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What this role may do"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3616
+#: lib/abuuba_web/live/admin_live.ex:3631
 #, elixir-autogen, elixir-format
 msgid "Who may sign up, the server's name and description, and the rest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3596
+#: lib/abuuba_web/live/admin_live.ex:3611
 #, elixir-autogen, elixir-format
 msgid "Without this the admin area is closed."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3587
+#: lib/abuuba_web/live/admin_live.ex:3602
 #, elixir-autogen, elixir-format
 msgid "Write announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3585
+#: lib/abuuba_web/live/admin_live.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Write invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3586
+#: lib/abuuba_web/live/admin_live.ex:3601
 #, elixir-autogen, elixir-format
 msgid "Write the server rules"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3566
+#: lib/abuuba_web/live/admin_live.ex:3581
 #, elixir-autogen, elixir-format
 msgid "You cannot make a role at or above your own position, or grant a permission you do not hold."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1731
+#: lib/abuuba_web/live/admin_live.ex:1745
 #, elixir-autogen, elixir-format
 msgid "You do not hold this yourself, so you cannot grant it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3636
+#: lib/abuuba_web/live/admin_live.ex:3651
 #, elixir-autogen, elixir-format
 msgid "nothing in particular"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:922
-#: lib/abuuba_web/live/admin_live.ex:1571
+#: lib/abuuba_web/live/admin_live.ex:935
+#: lib/abuuba_web/live/admin_live.ex:1584
 #, elixir-autogen, elixir-format
 msgid "A note for the other moderators"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1548
+#: lib/abuuba_web/live/admin_live.ex:1561
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Blocked: %{severity}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1506
+#: lib/abuuba_web/live/admin_live.ex:1519
 #, elixir-autogen, elixir-format
 msgid "Delivering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1492
+#: lib/abuuba_web/live/admin_live.ex:1505
 #, elixir-autogen, elixir-format
 msgid "Delivery stopped by a moderator"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1459
+#: lib/abuuba_web/live/admin_live.ex:1472
 #, elixir-autogen, elixir-format
 msgid "Every server this one has heard from, busiest first. A peer that has quietly stopped accepting deliveries looks exactly like a peer whose people have gone quiet, and this is where the two are told apart."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1544
+#: lib/abuuba_web/live/admin_live.ex:1557
 #, elixir-autogen, elixir-format
 msgid "Forget the failures"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1580
+#: lib/abuuba_web/live/admin_live.ex:1593
 #, elixir-autogen, elixir-format
 msgid "No other servers yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1484
+#: lib/abuuba_web/live/admin_live.ex:1497
 #, elixir-autogen, elixir-format
 msgid "One account"
 msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3376
+#: lib/abuuba_web/live/admin_live.ex:3391
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Other servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1561
+#: lib/abuuba_web/live/admin_live.ex:1574
 #, elixir-autogen, elixir-format
 msgid "Silence this server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1558
+#: lib/abuuba_web/live/admin_live.ex:1571
 #, elixir-autogen, elixir-format
 msgid "Silence this server? Its posts stop appearing in public timelines."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1534
+#: lib/abuuba_web/live/admin_live.ex:1547
 #, elixir-autogen, elixir-format
 msgid "Start again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1524
+#: lib/abuuba_web/live/admin_live.ex:1537
 #, elixir-autogen, elixir-format
 msgid "Stop delivering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2670
+#: lib/abuuba_web/live/admin_live.ex:2684
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That server could not be blocked."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1498
+#: lib/abuuba_web/live/admin_live.ex:1511
 #, elixir-autogen, elixir-format
 msgid "Treated as down since %{when}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1509
+#: lib/abuuba_web/live/admin_live.ex:1522
 #, elixir-autogen, elixir-format
 msgid "one bad day"
 msgid_plural "%{count} bad days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1484
+#: lib/abuuba_web/live/admin_live.ex:1497
 #, elixir-autogen, elixir-format, fuzzy
 msgid "one post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:955
+#: lib/abuuba_web/live/admin_live.ex:968
 #, elixir-autogen, elixir-format
 msgid "Ask their server for it again. Worth doing when the name or picture here is out of date and waiting for their next post is waiting for something that may not come."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:982
+#: lib/abuuba_web/live/admin_live.ex:995
 #, elixir-autogen, elixir-format
 msgid "Delete this post? Other servers are told to delete it too."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:967
+#: lib/abuuba_web/live/admin_live.ex:980
 #, elixir-autogen, elixir-format
 msgid "Deleting one from here is the same delete they would do themselves."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:960
+#: lib/abuuba_web/live/admin_live.ex:973
 #, elixir-autogen, elixir-format
 msgid "Fetch it again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:948
+#: lib/abuuba_web/live/admin_live.ex:961
 #, elixir-autogen, elixir-format
 msgid "Force a password reset"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:936
+#: lib/abuuba_web/live/admin_live.ex:949
 #, elixir-autogen, elixir-format
 msgid "Locked out, or somebody else is in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:924
+#: lib/abuuba_web/live/admin_live.ex:937
 #, elixir-autogen, elixir-format
 msgid "Nobody is told and nothing is applied. This is for the context that otherwise lives in one person's head: that this is the third report about the same joke, or that somebody spoke to them and they understood."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:991
+#: lib/abuuba_web/live/admin_live.ex:1004
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing posted."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:945
+#: lib/abuuba_web/live/admin_live.ex:958
 #, elixir-autogen, elixir-format
 msgid "Sign them out everywhere and send a reset link?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2688
+#: lib/abuuba_web/live/admin_live.ex:2702
 #, elixir-autogen, elixir-format
 msgid "That account has nobody to sign in as."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:965
+#: lib/abuuba_web/live/admin_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "Their most recent posts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:953
+#: lib/abuuba_web/live/admin_live.ex:966
 #, elixir-autogen, elixir-format
 msgid "Their profile here is a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2701
+#: lib/abuuba_web/live/admin_live.ex:2715
 #, elixir-autogen, elixir-format
 msgid "Their server did not answer."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:938
+#: lib/abuuba_web/live/admin_live.ex:951
 #, elixir-autogen, elixir-format
 msgid "This ends every session and every app, and emails them a link to set a new password. It does not choose one for them: a password a moderator picked is a password a moderator knows."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2137
+#: lib/abuuba_web/live/admin_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "%{latest} is out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1289
+#: lib/abuuba_web/live/admin_live.ex:1302
 #, elixir-autogen, elixir-format
 msgid "A server that has decided about four hundred domains has made four hundred decisions, and the way those get shared is a list somebody publishes. This reads and writes those lists."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2757
+#: lib/abuuba_web/live/admin_live.ex:2771
 #, elixir-autogen, elixir-format
 msgid "Added %{added}. %{skipped} were already decided about."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1431
+#: lib/abuuba_web/live/admin_live.ex:1444
 #, elixir-autogen, elixir-format
 msgid "Addresses that asked one account here to write to them. Only the confirmed ones are counted: an unconfirmed address is a claim somebody typed, not a subscriber."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1304
-#: lib/abuuba_web/live/admin_live.ex:1319
+#: lib/abuuba_web/live/admin_live.ex:1317
+#: lib/abuuba_web/live/admin_live.ex:1332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allows"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2114
+#: lib/abuuba_web/live/admin_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Checking for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3375
+#: lib/abuuba_web/live/admin_live.ex:3390
 #, elixir-autogen, elixir-format
 msgid "Domain lists"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1309
+#: lib/abuuba_web/live/admin_live.ex:1322
 #, elixir-autogen, elixir-format
 msgid "Domains this server has already decided about are left exactly as they are. An import adds and never removes: one paste should not be able to undo every decision made here, silently and unrecoverably."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3373
+#: lib/abuuba_web/live/admin_live.ex:3388
 #, elixir-autogen, elixir-format
 msgid "Email subscriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1448
+#: lib/abuuba_web/live/admin_live.ex:1461
 #, elixir-autogen, elixir-format
 msgid "Nobody here has any subscribers."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1421
+#: lib/abuuba_web/live/admin_live.ex:1434
 #, elixir-autogen, elixir-format
 msgid "Nobody is being suggested yet. It needs a few follows to work from."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1403
+#: lib/abuuba_web/live/admin_live.ex:1416
 #, elixir-autogen, elixir-format
 msgid "Not suggested"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2116
+#: lib/abuuba_web/live/admin_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. It asks %{url} whether there is a newer abuuba. What that tells them is what any web request tells anybody: this server's address, a user agent, and that somebody asked. Nothing about the accounts here, their number or their posts is sent, and there is nowhere in the request for it to go."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1442
+#: lib/abuuba_web/live/admin_live.ex:1455
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One address"
 msgid_plural "%{count} addresses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1296
+#: lib/abuuba_web/live/admin_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "One blocked domain"
 msgid_plural "%{count} blocked domains"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1330
+#: lib/abuuba_web/live/admin_live.ex:1343
 #, elixir-autogen, elixir-format
 msgid "Read it in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1307
+#: lib/abuuba_web/live/admin_live.ex:1320
 #, elixir-autogen, elixir-format
 msgid "Read one in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2135
+#: lib/abuuba_web/live/admin_live.ex:2149
 #, elixir-autogen, elixir-format
 msgid "Running %{version}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1415
+#: lib/abuuba_web/live/admin_live.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Stop suggesting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1414
+#: lib/abuuba_web/live/admin_live.ex:1427
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Suggest again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1294
+#: lib/abuuba_web/live/admin_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Take a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2131
+#: lib/abuuba_web/live/admin_live.ex:2145
 #, elixir-autogen, elixir-format
 msgid "Tell me when there is a newer version"
 msgstr ""
@@ -4845,104 +4845,104 @@ msgstr ""
 msgid "There is no list of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1316
+#: lib/abuuba_web/live/admin_live.ex:1329
 #, elixir-autogen, elixir-format
 msgid "Which list"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1391
+#: lib/abuuba_web/live/admin_live.ex:1404
 #, elixir-autogen, elixir-format
 msgid "Who this server puts in front of a newcomer. Taking somebody out is not a block and not a silence: their account carries on exactly as before and nobody is told."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1296
+#: lib/abuuba_web/live/admin_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "one allowed domain"
 msgid_plural "%{count} allowed domains"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:344
+#: lib/abuuba_web/live/admin_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "%{label}, highest %{top}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3690
+#: lib/abuuba_web/live/admin_live.ex:3705
 #, elixir-autogen, elixir-format
 msgid "Favourites, boosts and replies"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3695
+#: lib/abuuba_web/live/admin_live.ex:3710
 #, elixir-autogen, elixir-format
 msgid "Languages people write in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3688
+#: lib/abuuba_web/live/admin_live.ex:3703
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:425
+#: lib/abuuba_web/live/admin_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Of the people who signed up in a given week, how many were still posting in the weeks after. A number that only means something once the server has been running a while."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3687
+#: lib/abuuba_web/live/admin_live.ex:3702
 #, elixir-autogen, elixir-format
 msgid "People who posted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3689
+#: lib/abuuba_web/live/admin_live.ex:3704
 #, elixir-autogen, elixir-format
 msgid "Posts written here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3691
+#: lib/abuuba_web/live/admin_live.ex:3706
 #, elixir-autogen, elixir-format
 msgid "Reports opened"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3692
+#: lib/abuuba_web/live/admin_live.ex:3707
 #, elixir-autogen, elixir-format
 msgid "Reports resolved"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3697
+#: lib/abuuba_web/live/admin_live.ex:3712
 #, elixir-autogen, elixir-format
 msgid "Servers we hear most from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:389
+#: lib/abuuba_web/live/admin_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "The last thirty days"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:391
+#: lib/abuuba_web/live/admin_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "The same numbers a moderation client draws from the API, so what you see here and what it shows are the same figures rather than two answers to one question."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3698
+#: lib/abuuba_web/live/admin_live.ex:3713
 #, elixir-autogen, elixir-format
 msgid "What those servers run"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3696
+#: lib/abuuba_web/live/admin_live.ex:3711
 #, elixir-autogen, elixir-format
 msgid "Where accounts signed up from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:404
+#: lib/abuuba_web/live/admin_live.ex:417
 #, elixir-autogen, elixir-format
 msgid "Where things come from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:423
+#: lib/abuuba_web/live/admin_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Who stayed"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:434
+#: lib/abuuba_web/live/admin_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "one signed up"
 msgid_plural "%{count} signed up"
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:552
+#: lib/abuuba_web/live/admin_live.ex:565
 #: lib/abuuba_web/live/settings_live.ex:364
 #, elixir-autogen, elixir-format, fuzzy
 msgid "None yet."
@@ -5116,222 +5116,222 @@ msgstr ""
 msgid "On its way."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2423
+#: lib/abuuba_web/live/admin_live.ex:2437
 #, elixir-autogen, elixir-format
 msgid "A preset needs both."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:494
-#: lib/abuuba_web/live/admin_live.ex:710
+#: lib/abuuba_web/live/admin_live.ex:507
+#: lib/abuuba_web/live/admin_live.ex:723
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:570
+#: lib/abuuba_web/live/admin_live.ex:583
 #, elixir-autogen, elixir-format
 msgid "All of them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:568
+#: lib/abuuba_web/live/admin_live.ex:581
 #, elixir-autogen, elixir-format
 msgid "Dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:777
+#: lib/abuuba_web/live/admin_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "Do it to all of them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:629
+#: lib/abuuba_web/live/admin_live.ex:642
 #, elixir-autogen, elixir-format
 msgid "Filed as %{category} on %{date}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:687
+#: lib/abuuba_web/live/admin_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "For whoever picks this up next. The person reported never sees any of it, and neither does whoever filed it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:663
+#: lib/abuuba_web/live/admin_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "I am on this"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2173
+#: lib/abuuba_web/live/admin_live.ex:2187
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3295
+#: lib/abuuba_web/live/admin_live.ex:3310
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Limit them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:672
+#: lib/abuuba_web/live/admin_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "Mark it dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:601
+#: lib/abuuba_web/live/admin_live.ex:614
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:855
+#: lib/abuuba_web/live/admin_live.ex:868
 #, elixir-autogen, elixir-format
 msgid "Nothing, I will write it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:757
+#: lib/abuuba_web/live/admin_live.ex:770
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One account ticked."
 msgid_plural "%{count} accounts ticked."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:681
+#: lib/abuuba_web/live/admin_live.ex:694
 #, elixir-autogen, elixir-format
 msgid "Put it back in the queue"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2155
+#: lib/abuuba_web/live/admin_live.ex:2169
 #, elixir-autogen, elixir-format
 msgid "Ready-made texts a moderator picks instead of retyping. Kept for the server rather than for one moderator, so two people writing about the same thing say the same thing."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3367
+#: lib/abuuba_web/live/admin_live.ex:3382
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:578
+#: lib/abuuba_web/live/admin_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "Report %{id}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3365
+#: lib/abuuba_web/live/admin_live.ex:3380
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reports"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:853
+#: lib/abuuba_web/live/admin_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "Start from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:566
+#: lib/abuuba_web/live/admin_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Still open"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3297
+#: lib/abuuba_web/live/admin_live.ex:3312
 #, elixir-autogen, elixir-format
 msgid "Stop them signing in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3296
+#: lib/abuuba_web/live/admin_live.ex:3311
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Suspend them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:639
+#: lib/abuuba_web/live/admin_live.ex:652
 #, elixir-autogen, elixir-format
 msgid "The posts it names"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:770
+#: lib/abuuba_web/live/admin_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "This does the same thing to one account and tells them. Go ahead?"
 msgid_plural "This does the same thing to all %{count} accounts and tells each of them. Go ahead?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:788
+#: lib/abuuba_web/live/admin_live.ex:801
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Tick %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:755
+#: lib/abuuba_web/live/admin_live.ex:768
 #, elixir-autogen, elixir-format
 msgid "Tick some accounts to do one thing to all of them."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2153
+#: lib/abuuba_web/live/admin_live.ex:2167
 #, elixir-autogen, elixir-format
 msgid "Warning presets"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2170
+#: lib/abuuba_web/live/admin_live.ex:2184
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What it says"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:685
+#: lib/abuuba_web/live/admin_live.ex:698
 #, elixir-autogen, elixir-format
 msgid "What moderators have written here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:707
+#: lib/abuuba_web/live/admin_live.ex:720
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What you found"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:564
+#: lib/abuuba_web/live/admin_live.ex:577
 #, elixir-autogen, elixir-format
 msgid "Which ones"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:582
+#: lib/abuuba_web/live/admin_live.ex:595
 #, elixir-autogen, elixir-format, fuzzy
 msgid "about"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:589
+#: lib/abuuba_web/live/admin_live.ex:602
 #, elixir-autogen, elixir-format
 msgid "dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:582
-#: lib/abuuba_web/live/admin_live.ex:624
+#: lib/abuuba_web/live/admin_live.ex:595
+#: lib/abuuba_web/live/admin_live.ex:637
 #, elixir-autogen, elixir-format
 msgid "from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3313
+#: lib/abuuba_web/live/admin_live.ex:3328
 #, elixir-autogen, elixir-format
 msgid "somebody who is gone"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:591
+#: lib/abuuba_web/live/admin_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "taken"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3272
+#: lib/abuuba_web/live/admin_live.ex:3287
 #, elixir-autogen, elixir-format
 msgid "One account could not be changed."
 msgid_plural "%{count} accounts could not be changed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3265
+#: lib/abuuba_web/live/admin_live.ex:3280
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One account was left alone because it outranks yours."
 msgid_plural "%{count} accounts were left alone because they outrank yours."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:605
+#: lib/abuuba_web/live/admin_live.ex:618
 #, elixir-autogen, elixir-format
 msgid "Showing the newest %{count}. Deal with some to see the ones that have waited longest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3230
+#: lib/abuuba_web/live/admin_live.ex:3245
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not something this list can do."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:644
+#: lib/abuuba_web/live/admin_live.ex:657
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Warning:"
 msgstr ""
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Your account may not do that."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:650
+#: lib/abuuba_web/live/admin_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "has pictures or video"
 msgstr ""
@@ -5452,95 +5452,95 @@ msgstr ""
 msgid "Show anyway"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:490
+#: lib/abuuba_web/live/admin_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "A PNG or a GIF, at most %{size}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3197
+#: lib/abuuba_web/live/admin_live.ex:3212
 #, elixir-autogen, elixir-format
 msgid "A shortcode is letters, numbers and underscores, and nothing else."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3133
-#: lib/abuuba_web/live/admin_live.ex:3179
+#: lib/abuuba_web/live/admin_live.ex:3148
+#: lib/abuuba_web/live/admin_live.ex:3194
 #, elixir-autogen, elixir-format
 msgid "An emoji has to be a PNG or a GIF."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3123
-#: lib/abuuba_web/live/admin_live.ex:3157
+#: lib/abuuba_web/live/admin_live.ex:3138
+#: lib/abuuba_web/live/admin_live.ex:3172
 #, elixir-autogen, elixir-format
 msgid "Choose a picture for it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3366
+#: lib/abuuba_web/live/admin_live.ex:3381
 #, elixir-autogen, elixir-format
 msgid "Custom emoji"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:543
+#: lib/abuuba_web/live/admin_live.ex:556
 #, elixir-autogen, elixir-format
 msgid "Every post that used it loses its picture. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:481
+#: lib/abuuba_web/live/admin_live.ex:494
 #, elixir-autogen, elixir-format
 msgid "Group it under"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:518
+#: lib/abuuba_web/live/admin_live.ex:531
 #, elixir-autogen, elixir-format
 msgid "Offer it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:468
+#: lib/abuuba_web/live/admin_live.ex:481
 #, elixir-autogen, elixir-format
 msgid "Pictures people here can type into a post by name. One uploaded here is held on this server, so it outlives whoever made it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:476
+#: lib/abuuba_web/live/admin_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Shortcode"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:517
+#: lib/abuuba_web/live/admin_live.ex:530
 #, elixir-autogen, elixir-format
 msgid "Stop offering it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3199
+#: lib/abuuba_web/live/admin_live.ex:3214
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That emoji could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3185
+#: lib/abuuba_web/live/admin_live.ex:3200
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That picture could not be stored."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3139
+#: lib/abuuba_web/live/admin_live.ex:3154
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That picture could not be used."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3136
-#: lib/abuuba_web/live/admin_live.ex:3182
+#: lib/abuuba_web/live/admin_live.ex:3151
+#: lib/abuuba_web/live/admin_live.ex:3197
 #, elixir-autogen, elixir-format
 msgid "That picture is too large for an emoji."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:487
+#: lib/abuuba_web/live/admin_live.ex:500
 #, elixir-autogen, elixir-format
 msgid "The picture"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3120
+#: lib/abuuba_web/live/admin_live.ex:3135
 #, elixir-autogen, elixir-format
 msgid "The picture is still uploading. Try again in a moment."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:505
+#: lib/abuuba_web/live/admin_live.ex:518
 #, elixir-autogen, elixir-format
 msgid "not offered"
 msgstr ""
@@ -5630,22 +5630,22 @@ msgstr ""
 msgid "Quotes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2019
+#: lib/abuuba_web/live/admin_live.ex:2033
 #, elixir-autogen, elixir-format
 msgid "Days to keep other servers' files"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2028
+#: lib/abuuba_web/live/admin_live.ex:2042
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them indefinitely. Anything older goes off this server's disk each night. The posts stay, and a file is fetched again if somebody opens it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:530
+#: lib/abuuba_web/live/admin_live.ex:543
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Every post that used it loses its picture until you turn it back on. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:503
+#: lib/abuuba_web/live/admin_live.ex:516
 #, elixir-autogen, elixir-format, fuzzy
 msgid "turned off"
 msgstr ""
@@ -5682,69 +5682,69 @@ msgstr ""
 msgid "This takes it out of your inbox only. Nobody else loses anything, and a later message brings it back. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2035
+#: lib/abuuba_web/live/admin_live.ex:2049
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Days to keep other servers' posts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2044
+#: lib/abuuba_web/live/admin_live.ex:2058
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them for ever. Anything older is deleted each night, except a post somebody here favourited, bookmarked, pinned, boosted, quoted, replied to or was mentioned in."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1919
+#: lib/abuuba_web/live/admin_live.ex:1933
 #, elixir-autogen, elixir-format
 msgid "The longer version, for the about page"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1970
-#: lib/abuuba_web/live/admin_live.ex:1979
+#: lib/abuuba_web/live/admin_live.ex:1984
+#: lib/abuuba_web/live/admin_live.ex:1993
 #, elixir-autogen, elixir-format
 msgid "Anybody, including people with no account"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1985
+#: lib/abuuba_web/live/admin_live.ex:1999
 #, elixir-autogen, elixir-format
 msgid "Nobody: turn them off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1967
-#: lib/abuuba_web/live/admin_live.ex:1982
+#: lib/abuuba_web/live/admin_live.ex:1981
+#: lib/abuuba_web/live/admin_live.ex:1996
 #, elixir-autogen, elixir-format
 msgid "Only people signed in here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1976
+#: lib/abuuba_web/live/admin_live.ex:1990
 #, elixir-autogen, elixir-format
 msgid "Who may read the public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1951
+#: lib/abuuba_web/live/admin_live.ex:1965
 #, elixir-autogen, elixir-format
 msgid "The privacy policy takes effect on"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1935
+#: lib/abuuba_web/live/admin_live.ex:1949
 #, elixir-autogen, elixir-format
 msgid "The account to write to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1940
+#: lib/abuuba_web/live/admin_live.ex:1954
 #, elixir-autogen, elixir-format
 msgid "a username on this server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1924
+#: lib/abuuba_web/live/admin_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "Status page"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1964
+#: lib/abuuba_web/live/admin_live.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Nobody: the server does not say"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1961
+#: lib/abuuba_web/live/admin_live.ex:1975
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Who may read the blocklist"
 msgstr ""
@@ -5780,62 +5780,68 @@ msgstr ""
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3355
+#: lib/abuuba_web/live/admin_live.ex:3370
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3358
+#: lib/abuuba_web/live/admin_live.ex:3373
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3359
+#: lib/abuuba_web/live/admin_live.ex:3374
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3368
+#: lib/abuuba_web/live/admin_live.ex:3383
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Appeals"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1381
+#: lib/abuuba_web/live/admin_live.ex:1394
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting. Appeals against a strike show up here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3357
+#: lib/abuuba_web/live/admin_live.ex:3372
 #, elixir-autogen, elixir-format
 msgid "Posts deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3356
+#: lib/abuuba_web/live/admin_live.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Posts marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1340
+#: lib/abuuba_web/live/admin_live.ex:1353
 #, elixir-autogen, elixir-format
 msgid "Somebody who was warned, silenced or suspended saying it was a mistake. Upholding an appeal undoes the action where it can be undone; where it cannot, the appeal is still recorded as upheld. Either way the account's owner is told."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3070
+#: lib/abuuba_web/live/admin_live.ex:3085
 #, elixir-autogen, elixir-format
 msgid "That appeal is no longer waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1374
+#: lib/abuuba_web/live/admin_live.ex:1387
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Turn down"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1366
+#: lib/abuuba_web/live/admin_live.ex:1379
 #, elixir-autogen, elixir-format
 msgid "Uphold and undo"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3354
+#: lib/abuuba_web/live/admin_live.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Warned"
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2237
+#, elixir-autogen, elixir-format
+msgid "%{size} MB"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -124,7 +124,7 @@ msgstr ""
 msgid "Create account"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:80
+#: lib/abuuba_web/live/landing_live.ex:81
 #: lib/abuuba_web/live/registration_live.ex:37
 #: lib/abuuba_web/live/registration_live.ex:207
 #, elixir-autogen, elixir-format
@@ -330,12 +330,12 @@ msgstr ""
 msgid "you can now sign in to %{site}:"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:96
+#: lib/abuuba_web/live/two_factor_settings_live.ex:95
 #, elixir-autogen, elixir-format
 msgid "A second factor means somebody who learns your password still cannot sign in as you."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:116
+#: lib/abuuba_web/live/two_factor_settings_live.ex:115
 #, elixir-autogen, elixir-format
 msgid "Cannot scan it? Type this in instead:"
 msgstr ""
@@ -346,7 +346,7 @@ msgid "Checking…"
 msgstr ""
 
 #: lib/abuuba_web/live/two_factor_live.ex:40
-#: lib/abuuba_web/live/two_factor_settings_live.ex:124
+#: lib/abuuba_web/live/two_factor_settings_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Code"
 msgstr ""
@@ -361,7 +361,7 @@ msgstr ""
 msgid "Enter the code from your authenticator app, or one of your recovery codes."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:146
+#: lib/abuuba_web/live/two_factor_settings_live.ex:145
 #, elixir-autogen, elixir-format
 msgid "Make new recovery codes"
 msgstr ""
@@ -371,22 +371,22 @@ msgstr ""
 msgid "One more step"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:83
+#: lib/abuuba_web/live/two_factor_settings_live.ex:82
 #, elixir-autogen, elixir-format
 msgid "Save these recovery codes now"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:110
+#: lib/abuuba_web/live/two_factor_settings_live.ex:109
 #, elixir-autogen, elixir-format
 msgid "Scan this with your authenticator app, then type the code it shows."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:104
+#: lib/abuuba_web/live/two_factor_settings_live.ex:103
 #, elixir-autogen, elixir-format
 msgid "Set up an authenticator app"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:50
+#: lib/abuuba_web/live/two_factor_settings_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "That code is not right. Try again."
 msgstr ""
@@ -396,54 +396,54 @@ msgstr ""
 msgid "That code is not right. Try the next one."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:85
+#: lib/abuuba_web/live/two_factor_settings_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "This is the only time they are shown. Each one works once, and they are how you get back in if you lose your phone."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:534
-#: lib/abuuba_web/live/two_factor_settings_live.ex:154
+#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/two_factor_settings_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Turn it off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:534
-#: lib/abuuba_web/live/two_factor_settings_live.ex:131
+#: lib/abuuba_web/live/admin_live.ex:536
+#: lib/abuuba_web/live/two_factor_settings_live.ex:130
 #, elixir-autogen, elixir-format
 msgid "Turn it on"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:151
+#: lib/abuuba_web/live/two_factor_settings_live.ex:150
 #, elixir-autogen, elixir-format
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:899
+#: lib/abuuba_web/live/settings_live.ex:900
 #: lib/abuuba_web/live/two_factor_live.ex:16
-#: lib/abuuba_web/live/two_factor_settings_live.ex:21
-#: lib/abuuba_web/live/two_factor_settings_live.ex:80
+#: lib/abuuba_web/live/two_factor_settings_live.ex:20
+#: lib/abuuba_web/live/two_factor_settings_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication"
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:72
+#: lib/abuuba_web/live/two_factor_settings_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication is off."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:47
+#: lib/abuuba_web/live/two_factor_settings_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication is on."
 msgstr ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:138
+#: lib/abuuba_web/live/two_factor_settings_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Two-factor authentication is on. You have 1 recovery code left."
 msgid_plural "Two-factor authentication is on. You have %{count} recovery codes left."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/two_factor_settings_live.ex:61
+#: lib/abuuba_web/live/two_factor_settings_live.ex:60
 #, elixir-autogen, elixir-format
 msgid "Your old recovery codes no longer work."
 msgstr ""
@@ -453,7 +453,7 @@ msgstr ""
 msgid "Act as a moderator (%{scope})"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1049
+#: lib/abuuba_web/live/admin_live.ex:1051
 #: lib/abuuba_web/live/authorize_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "Allow"
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Authorize %{app}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1739
+#: lib/abuuba_web/live/admin_live.ex:1741
 #: lib/abuuba_web/live/authorize_live.ex:123
 #: lib/abuuba_web/live/compose_component.ex:410
 #: lib/abuuba_web/live/compose_component.ex:423
@@ -662,7 +662,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
 #: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -675,7 +675,7 @@ msgid "Keyboard shortcuts"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:254
-#: lib/abuuba_web/live/landing_live.ex:82
+#: lib/abuuba_web/live/landing_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
@@ -689,14 +689,14 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:118
-#: lib/abuuba_web/live/settings_live.ex:2112
+#: lib/abuuba_web/live/settings_live.ex:119
+#: lib/abuuba_web/live/settings_live.ex:2119
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -791,37 +791,37 @@ msgstr ""
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1682
+#: lib/abuuba_web/live/compose_component.ex:1679
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1680
+#: lib/abuuba_web/live/compose_component.ex:1677
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/compose_component.ex:1680
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1679
+#: lib/abuuba_web/live/compose_component.ex:1676
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1678
+#: lib/abuuba_web/live/compose_component.ex:1675
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1681
+#: lib/abuuba_web/live/compose_component.ex:1678
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1684
+#: lib/abuuba_web/live/compose_component.ex:1681
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
@@ -846,20 +846,20 @@ msgstr ""
 msgid "Allow more than one choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1699
-#: lib/abuuba_web/live/settings_live.ex:2292
+#: lib/abuuba_web/live/compose_component.ex:1696
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1690
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/compose_component.ex:1687
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1691
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/compose_component.ex:1688
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
@@ -886,7 +886,7 @@ msgid "Do not reply to this person"
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:432
-#: lib/abuuba_web/live/admin_live.ex:1759
+#: lib/abuuba_web/live/admin_live.ex:1761
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
@@ -901,37 +901,37 @@ msgstr ""
 msgid "Ends after"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1692
-#: lib/abuuba_web/live/profile_live.ex:866
+#: lib/abuuba_web/live/compose_component.ex:1689
+#: lib/abuuba_web/live/profile_live.ex:837
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1693
+#: lib/abuuba_web/live/compose_component.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3419
-#: lib/abuuba_web/live/compose_component.ex:1701
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/admin_live.ex:3413
+#: lib/abuuba_web/live/compose_component.ex:1698
+#: lib/abuuba_web/live/settings_live.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1692
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/compose_component.ex:1689
+#: lib/abuuba_web/live/settings_live.ex:2290
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1693
+#: lib/abuuba_web/live/compose_component.ex:1690
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1700
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/compose_component.ex:1697
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
@@ -946,13 +946,13 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1690
-#: lib/abuuba_web/live/compose_component.ex:1708
+#: lib/abuuba_web/live/compose_component.ex:1687
+#: lib/abuuba_web/live/compose_component.ex:1705
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1691
+#: lib/abuuba_web/live/compose_component.ex:1688
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
@@ -977,7 +977,7 @@ msgstr ""
 msgid "Save changes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3380
+#: lib/abuuba_web/live/admin_live.ex:3374
 #: lib/abuuba_web/live/compose_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
@@ -1199,17 +1199,17 @@ msgstr ""
 msgid "or drop one on the box, or paste it"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:278
+#: lib/abuuba_web/live/status_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:301
+#: lib/abuuba_web/live/profile_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:189
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
@@ -1226,34 +1226,34 @@ msgstr ""
 msgid "Go to the new account"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:98
+#: lib/abuuba_web/live/status_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:865
+#: lib/abuuba_web/live/profile_live.ex:836
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:372
+#: lib/abuuba_web/live/profile_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:347
-#: lib/abuuba_web/live/profile_live.ex:348
+#: lib/abuuba_web/live/profile_live.ex:338
+#: lib/abuuba_web/live/profile_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:304
-#: lib/abuuba_web/live/profile_live.ex:863
+#: lib/abuuba_web/live/explore_live.ex:288
+#: lib/abuuba_web/live/profile_live.ex:834
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:122
 #: lib/abuuba_web/live/search_live.ex:264
@@ -1261,18 +1261,18 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:864
+#: lib/abuuba_web/live/profile_live.ex:835
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:929
-#: lib/abuuba_web/live/profile_live.ex:305
+#: lib/abuuba_web/live/admin_live.ex:931
+#: lib/abuuba_web/live/profile_live.ex:296
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:322
+#: lib/abuuba_web/live/status_live.ex:320
 #, elixir-autogen, elixir-format
 msgid "That server could not be reached, so this is all there is."
 msgstr ""
@@ -1282,19 +1282,19 @@ msgstr ""
 msgid "This account has moved to %{handle}."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
-#: lib/abuuba_web/live/settings_live.ex:825
+#: lib/abuuba_web/live/profile_live.ex:189
+#: lib/abuuba_web/live/settings_live.ex:826
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:164
+#: lib/abuuba_web/live/profile_live.ex:155
 #: lib/abuuba_web/live/tag_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:181
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
@@ -1304,7 +1304,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:309
+#: lib/abuuba_web/live/profile_live.ex:300
 #: lib/abuuba_web/live/search_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "What to show"
@@ -1431,7 +1431,7 @@ msgstr ""
 msgid "Accounts made very recently"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:433
+#: lib/abuuba_web/live/notifications_live.ex:430
 #, elixir-autogen, elixir-format, fuzzy
 msgid "All"
 msgstr ""
@@ -1461,7 +1461,7 @@ msgstr ""
 msgid "Automated accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:442
+#: lib/abuuba_web/live/notifications_live.ex:439
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Boosts"
 msgstr ""
@@ -1481,12 +1481,12 @@ msgstr ""
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:447
+#: lib/abuuba_web/live/notifications_live.ex:444
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edits"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:445
+#: lib/abuuba_web/live/notifications_live.ex:442
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Favourites"
 msgstr ""
@@ -1496,15 +1496,15 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:444
+#: lib/abuuba_web/live/notifications_live.ex:441
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:443
-#: lib/abuuba_web/live/profile_live.ex:867
-#: lib/abuuba_web/live/settings_live.ex:2096
-#: lib/abuuba_web/live/settings_live.ex:2228
+#: lib/abuuba_web/live/notifications_live.ex:440
+#: lib/abuuba_web/live/profile_live.ex:838
+#: lib/abuuba_web/live/settings_live.ex:2103
+#: lib/abuuba_web/live/settings_live.ex:2229
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows"
 msgstr ""
@@ -1529,8 +1529,8 @@ msgstr ""
 msgid "Mark as read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:433
-#: lib/abuuba_web/live/notifications_live.ex:441
+#: lib/abuuba_web/live/notifications_live.ex:430
+#: lib/abuuba_web/live/notifications_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr ""
@@ -1555,7 +1555,7 @@ msgstr ""
 msgid "People you do not follow"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:446
+#: lib/abuuba_web/live/notifications_live.ex:443
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Polls"
 msgstr ""
@@ -1565,28 +1565,28 @@ msgstr ""
 msgid "Private mentions out of nowhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1008
-#: lib/abuuba_web/live/admin_live.ex:1016
-#: lib/abuuba_web/live/admin_live.ex:1119
-#: lib/abuuba_web/live/admin_live.ex:1572
-#: lib/abuuba_web/live/admin_live.ex:2148
+#: lib/abuuba_web/live/admin_live.ex:1010
+#: lib/abuuba_web/live/admin_live.ex:1018
+#: lib/abuuba_web/live/admin_live.ex:1121
+#: lib/abuuba_web/live/admin_live.ex:1574
+#: lib/abuuba_web/live/admin_live.ex:2150
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:264
-#: lib/abuuba_web/live/settings_live.ex:293
-#: lib/abuuba_web/live/settings_live.ex:387
-#: lib/abuuba_web/live/settings_live.ex:424
-#: lib/abuuba_web/live/settings_live.ex:488
-#: lib/abuuba_web/live/settings_live.ex:595
-#: lib/abuuba_web/live/settings_live.ex:640
-#: lib/abuuba_web/live/settings_live.ex:673
-#: lib/abuuba_web/live/settings_live.ex:995
+#: lib/abuuba_web/live/profile_live.ex:255
+#: lib/abuuba_web/live/settings_live.ex:294
+#: lib/abuuba_web/live/settings_live.ex:388
+#: lib/abuuba_web/live/settings_live.ex:425
+#: lib/abuuba_web/live/settings_live.ex:489
+#: lib/abuuba_web/live/settings_live.ex:596
+#: lib/abuuba_web/live/settings_live.ex:641
+#: lib/abuuba_web/live/settings_live.ex:674
+#: lib/abuuba_web/live/settings_live.ex:996
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:237
+#: lib/abuuba_web/live/admin_live.ex:238
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:135
+#: lib/abuuba_web/live/settings_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
@@ -1628,7 +1628,7 @@ msgid "Your settings filed these instead of showing them."
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:186
-#: lib/abuuba_web/live/conversations_live.ex:86
+#: lib/abuuba_web/live/conversations_live.ex:87
 #, elixir-autogen, elixir-format
 msgid "unread"
 msgstr ""
@@ -1638,14 +1638,14 @@ msgstr ""
 msgid "A name, a #tag, or some words"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2261
-#: lib/abuuba_web/live/admin_live.ex:3585
+#: lib/abuuba_web/live/admin_live.ex:2263
+#: lib/abuuba_web/live/admin_live.ex:3572
 #: lib/abuuba_web/live/search_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:305
+#: lib/abuuba_web/live/explore_live.ex:289
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:113
 #: lib/abuuba_web/live/search_live.ex:263
@@ -1653,12 +1653,12 @@ msgstr ""
 msgid "Hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:69
+#: lib/abuuba_web/live/landing_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "It runs %{software}, which is free software anybody may run."
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:83
+#: lib/abuuba_web/live/landing_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Look around first"
 msgstr ""
@@ -1668,7 +1668,7 @@ msgstr ""
 msgid "Narrowing a search"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:99
+#: lib/abuuba_web/live/landing_live.ex:100
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted publicly here yet."
 msgstr ""
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:123
+#: lib/abuuba_web/live/explore_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:306
+#: lib/abuuba_web/live/explore_live.ex:290
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:103
 #: lib/abuuba_web/live/search_live.ex:262
@@ -1696,25 +1696,22 @@ msgstr ""
 msgid "People"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:88
+#: lib/abuuba_web/live/landing_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "Recently, from people here"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:116
-#: lib/abuuba_web/live/landing_live.ex:112
+#: lib/abuuba_web/registration_words.ex:29
 #, elixir-autogen, elixir-format
 msgid "Registration is closed here, but any other server on the network will do."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:110
-#: lib/abuuba_web/live/landing_live.ex:106
+#: lib/abuuba_web/registration_words.ex:23
 #, elixir-autogen, elixir-format
 msgid "Registration is open: anybody may sign up."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:113
-#: lib/abuuba_web/live/landing_live.ex:109
+#: lib/abuuba_web/registration_words.ex:26
 #, elixir-autogen, elixir-format
 msgid "Registration needs approval: you sign up and an admin reads your request."
 msgstr ""
@@ -1728,7 +1725,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:63
+#: lib/abuuba_web/live/landing_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr ""
@@ -1758,389 +1755,389 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:890
+#: lib/abuuba_web/live/settings_live.ex:891
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:233
+#: lib/abuuba_web/live/settings_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3370
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/admin_live.ex:3364
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:289
+#: lib/abuuba_web/live/settings_live.ex:290
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a field"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:806
+#: lib/abuuba_web/live/settings_live.ex:807
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:946
+#: lib/abuuba_web/live/settings_live.ex:947
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/settings_live.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:894
+#: lib/abuuba_web/live/settings_live.ex:895
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:983
-#: lib/abuuba_web/live/settings_live.ex:753
+#: lib/abuuba_web/live/admin_live.ex:985
+#: lib/abuuba_web/live/settings_live.ex:754
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:222
+#: lib/abuuba_web/live/settings_live.ex:223
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1599
+#: lib/abuuba_web/live/settings_live.ex:1600
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2121
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:200
+#: lib/abuuba_web/live/settings_live.ex:201
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:238
+#: lib/abuuba_web/live/settings_live.ex:239
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2095
-#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2235
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2316
+#: lib/abuuba_web/live/settings_live.ex:2317
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2317
+#: lib/abuuba_web/live/settings_live.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:253
+#: lib/abuuba_web/live/settings_live.ex:254
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2264
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2268
+#: lib/abuuba_web/live/settings_live.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:271
+#: lib/abuuba_web/live/settings_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:975
+#: lib/abuuba_web/live/settings_live.ex:976
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:989
+#: lib/abuuba_web/live/settings_live.ex:990
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:448
+#: lib/abuuba_web/live/settings_live.ex:449
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2097
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2094
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2272
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:544
-#: lib/abuuba_web/live/admin_live.ex:1654
-#: lib/abuuba_web/live/admin_live.ex:1770
-#: lib/abuuba_web/live/admin_live.ex:1862
-#: lib/abuuba_web/live/admin_live.ex:2186
-#: lib/abuuba_web/live/conversations_live.ex:111
-#: lib/abuuba_web/live/settings_live.ex:279
-#: lib/abuuba_web/live/settings_live.ex:314
+#: lib/abuuba_web/live/admin_live.ex:546
+#: lib/abuuba_web/live/admin_live.ex:1656
+#: lib/abuuba_web/live/admin_live.ex:1772
+#: lib/abuuba_web/live/admin_live.ex:1864
+#: lib/abuuba_web/live/admin_live.ex:2188
+#: lib/abuuba_web/live/conversations_live.ex:112
+#: lib/abuuba_web/live/settings_live.ex:280
+#: lib/abuuba_web/live/settings_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2097
+#: lib/abuuba_web/live/settings_live.ex:2104
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:907
+#: lib/abuuba_web/live/settings_live.ex:908
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:903
+#: lib/abuuba_web/live/settings_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2283
+#: lib/abuuba_web/live/settings_live.ex:2284
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:969
+#: lib/abuuba_web/live/settings_live.ex:970
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3748
-#: lib/abuuba_web/live/settings_live.ex:2086
+#: lib/abuuba_web/live/admin_live.ex:3735
+#: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1574
+#: lib/abuuba_web/live/settings_live.ex:1575
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:467
+#: lib/abuuba_web/live/settings_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2266
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2267
+#: lib/abuuba_web/live/settings_live.ex:2268
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:848
+#: lib/abuuba_web/live/settings_live.ex:849
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:873
+#: lib/abuuba_web/live/settings_live.ex:874
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:240
+#: lib/abuuba_web/live/settings_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:260
+#: lib/abuuba_web/live/settings_live.ex:261
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:798
+#: lib/abuuba_web/live/settings_live.ex:799
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2162
-#: lib/abuuba_web/live/settings_live.ex:760
+#: lib/abuuba_web/live/admin_live.ex:2164
+#: lib/abuuba_web/live/settings_live.ex:761
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:765
+#: lib/abuuba_web/live/settings_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:2126
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:454
+#: lib/abuuba_web/live/settings_live.ex:455
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:435
+#: lib/abuuba_web/live/settings_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2120
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:869
+#: lib/abuuba_web/live/settings_live.ex:870
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:2263
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:885
+#: lib/abuuba_web/live/settings_live.ex:886
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2123
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:986
+#: lib/abuuba_web/live/settings_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2150,13 +2147,13 @@ msgstr ""
 msgid "A handle looks like name@server."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:44
+#: lib/abuuba_web/live/about_live.ex:45
 #, elixir-autogen, elixir-format
 msgid "A server on the fediverse, running %{software}."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:23
-#: lib/abuuba_web/live/admin_live.ex:619
+#: lib/abuuba_web/live/about_live.ex:24
+#: lib/abuuba_web/live/admin_live.ex:621
 #: lib/abuuba_web/live/document_live.ex:134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "About"
@@ -2172,7 +2169,7 @@ msgstr ""
 msgid "Do this from your own server"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:79
+#: lib/abuuba_web/live/about_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Getting in touch"
 msgstr ""
@@ -2187,8 +2184,8 @@ msgstr ""
 msgid "No password is asked for and nothing is done on your behalf: you are simply sent to your own server's search with this address filled in."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:92
-#: lib/abuuba_web/live/admin_live.ex:1944
+#: lib/abuuba_web/live/about_live.ex:93
+#: lib/abuuba_web/live/admin_live.ex:1946
 #: lib/abuuba_web/live/document_live.ex:133
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Privacy policy"
@@ -2204,7 +2201,7 @@ msgstr ""
 msgid "Share"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:62
+#: lib/abuuba_web/live/about_live.ex:63
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signing up"
 msgstr ""
@@ -2224,8 +2221,8 @@ msgstr ""
 msgid "Take me to my server"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:91
-#: lib/abuuba_web/live/admin_live.ex:2191
+#: lib/abuuba_web/live/about_live.ex:92
+#: lib/abuuba_web/live/admin_live.ex:2193
 #: lib/abuuba_web/live/document_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
@@ -2236,17 +2233,17 @@ msgstr ""
 msgid "That is this server. Use the buttons on the post itself once you are signed in."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:52
+#: lib/abuuba_web/live/about_live.ex:53
 #, elixir-autogen, elixir-format
 msgid "The numbers"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:67
+#: lib/abuuba_web/live/about_live.ex:68
 #, elixir-autogen, elixir-format, fuzzy
 msgid "The rules"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:89
+#: lib/abuuba_web/live/about_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "The small print"
 msgstr ""
@@ -2256,7 +2253,7 @@ msgstr ""
 msgid "This has not been written yet. Whoever runs this server can add it in the admin settings."
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:84
+#: lib/abuuba_web/live/about_live.ex:85
 #, elixir-autogen, elixir-format
 msgid "Whoever runs this server has not published an address yet."
 msgstr ""
@@ -2271,560 +2268,560 @@ msgstr ""
 msgid "Your handle"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:102
+#: lib/abuuba_web/live/about_live.ex:103
 #, elixir-autogen, elixir-format, fuzzy
 msgid "people"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:106
+#: lib/abuuba_web/live/about_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "people active this half-year"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:105
+#: lib/abuuba_web/live/about_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "people active this month"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:103
+#: lib/abuuba_web/live/about_live.ex:104
 #, elixir-autogen, elixir-format, fuzzy
 msgid "posts"
 msgstr ""
 
-#: lib/abuuba_web/live/about_live.ex:104
+#: lib/abuuba_web/live/about_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1851
+#: lib/abuuba_web/live/settings_live.ex:1858
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1195
+#: lib/abuuba_web/live/settings_live.ex:1196
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1225
+#: lib/abuuba_web/live/settings_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1835
+#: lib/abuuba_web/live/settings_live.ex:1842
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1192
+#: lib/abuuba_web/live/settings_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1861
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1199
-#: lib/abuuba_web/live/settings_live.ex:1831
+#: lib/abuuba_web/live/settings_live.ex:1200
+#: lib/abuuba_web/live/settings_live.ex:1838
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1170
+#: lib/abuuba_web/live/settings_live.ex:1171
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1846
+#: lib/abuuba_web/live/settings_live.ex:1853
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1845
+#: lib/abuuba_web/live/settings_live.ex:1852
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1847
+#: lib/abuuba_web/live/settings_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1852
+#: lib/abuuba_web/live/settings_live.ex:1859
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1855
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1856
+#: lib/abuuba_web/live/settings_live.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1178
+#: lib/abuuba_web/live/settings_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1216
+#: lib/abuuba_web/live/settings_live.ex:1217
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1205
+#: lib/abuuba_web/live/settings_live.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1207
+#: lib/abuuba_web/live/settings_live.ex:1208
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2246
+#: lib/abuuba_web/live/admin_live.ex:2248
 #, elixir-autogen, elixir-format
 msgid "A new rule"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2831
+#: lib/abuuba_web/live/admin_live.ex:2833
 #, elixir-autogen, elixir-format
 msgid "A rule needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3369
+#: lib/abuuba_web/live/admin_live.ex:3363
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1601
-#: lib/abuuba_web/live/admin_live.ex:1819
-#: lib/abuuba_web/live/admin_live.ex:2249
+#: lib/abuuba_web/live/admin_live.ex:1603
+#: lib/abuuba_web/live/admin_live.ex:1821
+#: lib/abuuba_web/live/admin_live.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Add"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1989
+#: lib/abuuba_web/live/admin_live.ex:1991
 #, elixir-autogen, elixir-format
 msgid "Address people can write to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:220
-#: lib/abuuba_web/live/admin_live.ex:3387
+#: lib/abuuba_web/live/admin_live.ex:221
+#: lib/abuuba_web/live/admin_live.ex:3381
 #, elixir-autogen, elixir-format
 msgid "Administration"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3731
+#: lib/abuuba_web/live/admin_live.ex:3718
 #, elixir-autogen, elixir-format
 msgid "An open server left unattended fills with spam registrations within days. Put sign-ups behind approval unless somebody is watching."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:737
+#: lib/abuuba_web/live/admin_live.ex:739
 #, elixir-autogen, elixir-format
 msgid "Any state"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3716
+#: lib/abuuba_web/live/admin_live.ex:3703
 #, elixir-autogen, elixir-format
 msgid "Anybody may sign up without being checked"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3418
+#: lib/abuuba_web/live/admin_live.ex:3412
 #, elixir-autogen, elixir-format
 msgid "Anybody, after somebody here says yes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3417
+#: lib/abuuba_web/live/admin_live.ex:3411
 #, elixir-autogen, elixir-format
 msgid "Anybody, straight away"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:730
+#: lib/abuuba_web/live/admin_live.ex:732
 #, elixir-autogen, elixir-format
 msgid "Anywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:375
-#: lib/abuuba_web/live/admin_live.ex:379
+#: lib/abuuba_web/live/admin_live.ex:377
+#: lib/abuuba_web/live/admin_live.ex:381
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Appeals waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3386
+#: lib/abuuba_web/live/admin_live.ex:3380
 #, elixir-autogen, elixir-format
 msgid "Audit log"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1019
+#: lib/abuuba_web/live/admin_live.ex:1021
 #, elixir-autogen, elixir-format
 msgid "Change an address only when somebody cannot reach their own."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3368
+#: lib/abuuba_web/live/admin_live.ex:3362
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2865
+#: lib/abuuba_web/live/admin_live.ex:2867
 #, elixir-autogen, elixir-format
 msgid "Deleting posts needs the posts named, which this page cannot do yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3428
+#: lib/abuuba_web/live/admin_live.ex:3422
 #, elixir-autogen, elixir-format
 msgid "Disable: they cannot sign in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:872
+#: lib/abuuba_web/live/admin_live.ex:874
 #, elixir-autogen, elixir-format
 msgid "Do it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:733
+#: lib/abuuba_web/live/admin_live.ex:735
 #, elixir-autogen, elixir-format
 msgid "Elsewhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1013
+#: lib/abuuba_web/live/admin_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "Email address"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3721
+#: lib/abuuba_web/live/admin_live.ex:3708
 #, elixir-autogen, elixir-format
 msgid "Everything else on this page is guesswork until that is fixed."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:746
-#: lib/abuuba_web/live/admin_live.ex:1470
+#: lib/abuuba_web/live/admin_live.ex:748
+#: lib/abuuba_web/live/admin_live.ex:1472
 #, elixir-autogen, elixir-format
 msgid "Find"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:731
+#: lib/abuuba_web/live/admin_live.ex:733
 #, elixir-autogen, elixir-format
 msgid "Here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:809
+#: lib/abuuba_web/live/admin_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "Let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:893
-#: lib/abuuba_web/live/admin_live.ex:1191
-#: lib/abuuba_web/live/admin_live.ex:1218
-#: lib/abuuba_web/live/admin_live.ex:1246
-#: lib/abuuba_web/live/admin_live.ex:1270
+#: lib/abuuba_web/live/admin_live.ex:895
+#: lib/abuuba_web/live/admin_live.ex:1193
+#: lib/abuuba_web/live/admin_live.ex:1220
+#: lib/abuuba_web/live/admin_live.ex:1248
+#: lib/abuuba_web/live/admin_live.ex:1272
 #, elixir-autogen, elixir-format
 msgid "Lift it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3410
+#: lib/abuuba_web/live/admin_live.ex:3404
 #, elixir-autogen, elixir-format
 msgid "Limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3429
+#: lib/abuuba_web/live/admin_live.ex:3423
 #, elixir-autogen, elixir-format
 msgid "Mark everything they post sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:726
+#: lib/abuuba_web/live/admin_live.ex:728
 #, elixir-autogen, elixir-format
 msgid "Name or name@server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3737
+#: lib/abuuba_web/live/admin_live.ex:3724
 #, elixir-autogen, elixir-format
 msgid "Nobody can grant roles or change settings that need it. Give somebody a role holding the administrator permission."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3717
+#: lib/abuuba_web/live/admin_live.ex:3704
 #, elixir-autogen, elixir-format
 msgid "Nobody here is an administrator"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:827
+#: lib/abuuba_web/live/admin_live.ex:829
 #, elixir-autogen, elixir-format
 msgid "Nobody here matches that."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:998
+#: lib/abuuba_web/live/admin_live.ex:1000
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2281
+#: lib/abuuba_web/live/admin_live.ex:2283
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing has been done yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:416
-#: lib/abuuba_web/live/admin_live.ex:441
-#: lib/abuuba_web/live/admin_live.ex:699
-#: lib/abuuba_web/live/admin_live.ex:898
+#: lib/abuuba_web/live/admin_live.ex:418
+#: lib/abuuba_web/live/admin_live.ex:443
+#: lib/abuuba_web/live/admin_live.ex:701
+#: lib/abuuba_web/live/admin_live.ex:900
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:455
+#: lib/abuuba_web/live/admin_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "Nothing. Every check this server knows how to make came back fine."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:383
+#: lib/abuuba_web/live/admin_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "People waiting to be let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:367
+#: lib/abuuba_web/live/admin_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Reports waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2239
+#: lib/abuuba_web/live/admin_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Retire it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:996
+#: lib/abuuba_web/live/admin_live.ex:998
 #, elixir-autogen, elixir-format
 msgid "Role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2225
+#: lib/abuuba_web/live/admin_live.ex:2227
 #, elixir-autogen, elixir-format
 msgid "Rules people agree to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3425
+#: lib/abuuba_web/live/admin_live.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Send a warning and nothing else"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1467
-#: lib/abuuba_web/live/admin_live.ex:1907
+#: lib/abuuba_web/live/admin_live.ex:1469
+#: lib/abuuba_web/live/admin_live.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Server name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3385
+#: lib/abuuba_web/live/admin_live.ex:3379
 #, elixir-autogen, elixir-format
 msgid "Server settings"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3725
+#: lib/abuuba_web/live/admin_live.ex:3712
 #, elixir-autogen, elixir-format
 msgid "Servers running authorized fetch will refuse this one. It is created on first use, so this usually means something went wrong writing it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2264
+#: lib/abuuba_web/live/admin_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "Show"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2227
+#: lib/abuuba_web/live/admin_live.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Shown when somebody signs up and when they file a report."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3426
+#: lib/abuuba_web/live/admin_live.ex:3420
 #, elixir-autogen, elixir-format
 msgid "Silence: out of everywhere nobody asked for them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3427
+#: lib/abuuba_web/live/admin_live.ex:3421
 #, elixir-autogen, elixir-format
 msgid "Suspend: hidden, and deleted after the grace window"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3411
+#: lib/abuuba_web/live/admin_live.ex:3405
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2057
+#: lib/abuuba_web/live/admin_live.ex:2059
 #, elixir-autogen, elixir-format
 msgid "Talk only to servers on the allowlist"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3333
+#: lib/abuuba_web/live/admin_live.ex:3330
 #, elixir-autogen, elixir-format
 msgid "That account outranks yours, so there is nothing here you can do to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2869
-#: lib/abuuba_web/live/admin_live.ex:2881
+#: lib/abuuba_web/live/admin_live.ex:2871
+#: lib/abuuba_web/live/admin_live.ex:2883
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be done."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2458
+#: lib/abuuba_web/live/admin_live.ex:2460
 #, elixir-autogen, elixir-format
 msgid "That is not a role you can hand out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2473
+#: lib/abuuba_web/live/admin_live.ex:2475
 #, elixir-autogen, elixir-format
 msgid "That is not an address."
 msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
-#: lib/abuuba_web/live/admin_live.ex:3328
-#: lib/abuuba_web/live/settings_live.ex:1627
+#: lib/abuuba_web/live/admin_live.ex:3325
+#: lib/abuuba_web/live/settings_live.ex:1628
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3714
+#: lib/abuuba_web/live/admin_live.ex:3701
 #, elixir-autogen, elixir-format
 msgid "The database is not answering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:846
+#: lib/abuuba_web/live/admin_live.ex:848
 #, elixir-autogen, elixir-format
 msgid "This account outranks yours, so there is nothing here you can do to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:817
+#: lib/abuuba_web/live/admin_live.ex:819
 #, elixir-autogen, elixir-format
 msgid "This deletes the account as well. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3715
+#: lib/abuuba_web/live/admin_live.ex:3702
 #, elixir-autogen, elixir-format
 msgid "This server has no actor of its own"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:819
+#: lib/abuuba_web/live/admin_live.ex:821
 #, elixir-autogen, elixir-format
 msgid "Turn away"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3409
+#: lib/abuuba_web/live/admin_live.ex:3403
 #, elixir-autogen, elixir-format
 msgid "Waiting to be let in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:875
+#: lib/abuuba_web/live/admin_live.ex:877
 #, elixir-autogen, elixir-format
 msgid "What has been decided about them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:444
+#: lib/abuuba_web/live/admin_live.ex:446
 #, elixir-autogen, elixir-format
 msgid "What needs attention"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1912
+#: lib/abuuba_web/live/admin_live.ex:1914
 #, elixir-autogen, elixir-format
 msgid "What this server is for"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:861
+#: lib/abuuba_web/live/admin_live.ex:863
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What to do"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2012
+#: lib/abuuba_web/live/admin_live.ex:2014
 #, elixir-autogen, elixir-format
 msgid "What to say when nobody may sign up"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:868
+#: lib/abuuba_web/live/admin_live.ex:870
 #, elixir-autogen, elixir-format
 msgid "What to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1999
+#: lib/abuuba_web/live/admin_live.ex:2001
 #, elixir-autogen, elixir-format
 msgid "Who may sign up"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:884
+#: lib/abuuba_web/live/admin_live.ex:886
 #, elixir-autogen, elixir-format
 msgid "lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:799
+#: lib/abuuba_web/live/admin_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:798
+#: lib/abuuba_web/live/admin_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2270
+#: lib/abuuba_web/live/admin_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "the server"
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:307
-#: lib/abuuba_web/live/admin_live.ex:1075
+#: lib/abuuba_web/live/admin_live.ex:1077
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} person"
 msgid_plural "%{count} people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1031
+#: lib/abuuba_web/live/admin_live.ex:1033
 #, elixir-autogen, elixir-format
 msgid "Nothing appears in the trending lists until somebody here has looked at it. This is what is waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1090
+#: lib/abuuba_web/live/admin_live.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Nothing is trending. That is what a quiet day looks like."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1065
+#: lib/abuuba_web/live/admin_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting to be looked at."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1058
+#: lib/abuuba_web/live/admin_live.ex:1060
 #, elixir-autogen, elixir-format
 msgid "Refuse"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1084
-#: lib/abuuba_web/live/admin_live.ex:1142
+#: lib/abuuba_web/live/admin_live.ex:1086
+#: lib/abuuba_web/live/admin_live.ex:1144
 #, elixir-autogen, elixir-format
 msgid "Take it down"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3375
+#: lib/abuuba_web/live/admin_live.ex:3369
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Trends"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1068
+#: lib/abuuba_web/live/admin_live.ex:1070
 #, elixir-autogen, elixir-format
 msgid "What is trending now"
 msgstr ""
@@ -2834,32 +2831,32 @@ msgstr ""
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1241
+#: lib/abuuba_web/live/settings_live.ex:1242
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2513
+#: lib/abuuba_web/live/admin_live.ex:2515
 #, elixir-autogen, elixir-format
 msgid "An announcement needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3376
+#: lib/abuuba_web/live/admin_live.ex:3370
 #, elixir-autogen, elixir-format
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2136
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2193
+#: lib/abuuba_web/live/admin_live.ex:2195
 #, elixir-autogen, elixir-format
 msgid "Each version is kept with the day it takes effect, so somebody can still read what they agreed to."
 msgstr ""
@@ -2869,22 +2866,22 @@ msgstr ""
 msgid "Earlier versions"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3794
+#: lib/abuuba_web/live/admin_live.ex:3781
 #, elixir-autogen, elixir-format
 msgid "Everybody has already been told about that one."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1130
+#: lib/abuuba_web/live/admin_live.ex:1132
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1252
+#: lib/abuuba_web/live/settings_live.ex:1253
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2201
+#: lib/abuuba_web/live/admin_live.ex:2203
 #, elixir-autogen, elixir-format
 msgid "In effect from"
 msgstr ""
@@ -2894,83 +2891,83 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1236
+#: lib/abuuba_web/live/settings_live.ex:1237
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1115
+#: lib/abuuba_web/live/admin_live.ex:1117
 #, elixir-autogen, elixir-format
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1259
+#: lib/abuuba_web/live/settings_live.ex:1260
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1133
+#: lib/abuuba_web/live/admin_live.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Not published"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1148
+#: lib/abuuba_web/live/admin_live.ex:1150
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing has been announced."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2204
+#: lib/abuuba_web/live/admin_live.ex:2206
 #, elixir-autogen, elixir-format
 msgid "Publish a new version"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1127
+#: lib/abuuba_web/live/admin_live.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Published"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1100
+#: lib/abuuba_web/live/admin_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1273
+#: lib/abuuba_web/live/settings_live.ex:1274
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take it back"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2220
+#: lib/abuuba_web/live/admin_live.ex:2222
 #, elixir-autogen, elixir-format
 msgid "Tell everybody"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2539
+#: lib/abuuba_web/live/admin_live.ex:2541
 #, elixir-autogen, elixir-format
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1257
+#: lib/abuuba_web/live/settings_live.ex:1258
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1248
+#: lib/abuuba_web/live/settings_live.ex:1249
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What it is for"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1107
-#: lib/abuuba_web/live/admin_live.ex:2085
+#: lib/abuuba_web/live/admin_live.ex:1109
+#: lib/abuuba_web/live/admin_live.ex:2087
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What to say"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1112
+#: lib/abuuba_web/live/admin_live.ex:1114
 #, elixir-autogen, elixir-format
 msgid "When to publish it"
 msgstr ""
@@ -2980,76 +2977,76 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1279
+#: lib/abuuba_web/live/settings_live.ex:1280
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2211
+#: lib/abuuba_web/live/admin_live.ex:2213
 #, elixir-autogen, elixir-format
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2088
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1198
+#: lib/abuuba_web/live/admin_live.ex:1200
 #, elixir-autogen, elixir-format
 msgid "Addresses"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1230
+#: lib/abuuba_web/live/admin_live.ex:1232
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Anywhere in a name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3776
+#: lib/abuuba_web/live/admin_live.ex:3763
 #, elixir-autogen, elixir-format
 msgid "Ask for approval"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1175
-#: lib/abuuba_web/live/admin_live.ex:1204
-#: lib/abuuba_web/live/admin_live.ex:1232
+#: lib/abuuba_web/live/admin_live.ex:1177
+#: lib/abuuba_web/live/admin_live.ex:1206
+#: lib/abuuba_web/live/admin_live.ex:1234
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Block it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1253
+#: lib/abuuba_web/live/admin_live.ex:1255
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email addresses"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1255
+#: lib/abuuba_web/live/admin_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "Kept as hashes rather than addresses. The list has to recognise somebody coming back, not be readable."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1164
+#: lib/abuuba_web/live/admin_live.ex:1166
 #, elixir-autogen, elixir-format
 msgid "Mail domains"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3778
+#: lib/abuuba_web/live/admin_live.ex:3765
 #, elixir-autogen, elixir-format
 msgid "No access at all"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3777
+#: lib/abuuba_web/live/admin_live.ex:3764
 #, elixir-autogen, elixir-format
 msgid "No sign-ups"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1276
+#: lib/abuuba_web/live/admin_live.ex:1278
 #, elixir-autogen, elixir-format
 msgid "None. One is added when an account is suspended and you ask for it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1173
+#: lib/abuuba_web/live/admin_live.ex:1175
 #, elixir-autogen, elixir-format
 msgid "Only ask for approval"
 msgstr ""
@@ -3059,7 +3056,7 @@ msgstr ""
 msgid "Please complete the puzzle so we know you are a person."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3377
+#: lib/abuuba_web/live/admin_live.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Sign-up blocks"
 msgstr ""
@@ -3079,22 +3076,22 @@ msgstr ""
 msgid "This server asks new accounts to solve a puzzle first."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1225
+#: lib/abuuba_web/live/admin_live.ex:1227
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Usernames"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1158
+#: lib/abuuba_web/live/admin_live.ex:1160
 #, elixir-autogen, elixir-format
 msgid "What this server refuses at the door. Most of these have a middle setting that asks somebody to look rather than shutting the door."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1238
+#: lib/abuuba_web/live/admin_live.ex:1240
 #, elixir-autogen, elixir-format, fuzzy
 msgid "anywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1182
+#: lib/abuuba_web/live/admin_live.ex:1184
 #, elixir-autogen, elixir-format
 msgid "approval only"
 msgstr ""
@@ -3104,11 +3101,11 @@ msgstr ""
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:208
+#: lib/abuuba_web/live/explore_live.ex:204
 #: lib/abuuba_web/live/home_live.ex:337
-#: lib/abuuba_web/live/profile_live.ex:529
+#: lib/abuuba_web/live/profile_live.ex:518
 #: lib/abuuba_web/live/search_live.ex:195
-#: lib/abuuba_web/live/status_live.ex:184
+#: lib/abuuba_web/live/status_live.ex:185
 #: lib/abuuba_web/live/tag_live.ex:153
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be translated just now."
@@ -3129,245 +3126,245 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr "This account has been disabled. Contact the moderators."
 
-#: lib/abuuba_web/live/settings_live.ex:1980
+#: lib/abuuba_web/live/settings_live.ex:1987
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1971
+#: lib/abuuba_web/live/settings_live.ex:1978
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1887
+#: lib/abuuba_web/live/settings_live.ex:1894
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2044
+#: lib/abuuba_web/live/settings_live.ex:2051
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1868
+#: lib/abuuba_web/live/settings_live.ex:1875
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2109
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1893
+#: lib/abuuba_web/live/settings_live.ex:1900
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2066
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2132
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2068
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2040
+#: lib/abuuba_web/live/settings_live.ex:2047
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2055
-#: lib/abuuba_web/live/settings_live.ex:2060
+#: lib/abuuba_web/live/settings_live.ex:2062
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2057
+#: lib/abuuba_web/live/settings_live.ex:2064
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2058
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1877
+#: lib/abuuba_web/live/settings_live.ex:1884
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2072
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1874
+#: lib/abuuba_web/live/settings_live.ex:1881
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1882
+#: lib/abuuba_web/live/settings_live.ex:1889
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2071
+#: lib/abuuba_web/live/settings_live.ex:2078
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2080
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2077
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2082
 #, elixir-autogen, elixir-format, fuzzy
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2076
+#: lib/abuuba_web/live/settings_live.ex:2083
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1044
+#: lib/abuuba_web/live/settings_live.ex:1045
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1926
+#: lib/abuuba_web/live/settings_live.ex:1933
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1039
+#: lib/abuuba_web/live/settings_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1944
+#: lib/abuuba_web/live/settings_live.ex:1951
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1049
+#: lib/abuuba_web/live/settings_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1037
+#: lib/abuuba_web/live/settings_live.ex:1038
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1006
+#: lib/abuuba_web/live/settings_live.ex:1007
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1957
+#: lib/abuuba_web/live/settings_live.ex:1964
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1934
+#: lib/abuuba_web/live/settings_live.ex:1941
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1063
-#: lib/abuuba_web/live/settings_live.ex:1906
-#: lib/abuuba_web/live/settings_live.ex:2231
+#: lib/abuuba_web/live/settings_live.ex:1064
+#: lib/abuuba_web/live/settings_live.ex:1913
+#: lib/abuuba_web/live/settings_live.ex:2232
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1033
+#: lib/abuuba_web/live/settings_live.ex:1034
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1017
+#: lib/abuuba_web/live/settings_live.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2030
+#: lib/abuuba_web/live/settings_live.ex:2037
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1001
+#: lib/abuuba_web/live/settings_live.ex:1002
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1930
+#: lib/abuuba_web/live/settings_live.ex:1937
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2020
+#: lib/abuuba_web/live/settings_live.ex:2027
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2031
+#: lib/abuuba_web/live/settings_live.ex:2038
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1908
+#: lib/abuuba_web/live/settings_live.ex:1915
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1027
+#: lib/abuuba_web/live/settings_live.ex:1028
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:999
+#: lib/abuuba_web/live/settings_live.ex:1000
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1923
+#: lib/abuuba_web/live/settings_live.ex:1930
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2026
+#: lib/abuuba_web/live/settings_live.ex:2033
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
@@ -3377,109 +3374,109 @@ msgstr ""
 msgid "No such post here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:243
+#: lib/abuuba_web/live/settings_live.ex:244
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:781
+#: lib/abuuba_web/live/settings_live.ex:782
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:794
+#: lib/abuuba_web/live/settings_live.ex:795
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:778
+#: lib/abuuba_web/live/settings_live.ex:779
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1513
+#: lib/abuuba_web/live/settings_live.ex:1514
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:796
+#: lib/abuuba_web/live/admin_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "Why they want to join:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:306
+#: lib/abuuba_web/live/settings_live.ex:307
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:323
+#: lib/abuuba_web/live/settings_live.ex:324
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:326
+#: lib/abuuba_web/live/settings_live.ex:327
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feature it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:297
+#: lib/abuuba_web/live/settings_live.ex:298
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:299
+#: lib/abuuba_web/live/settings_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1496
+#: lib/abuuba_web/live/settings_live.ex:1497
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:330
+#: lib/abuuba_web/live/settings_live.ex:331
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1490
+#: lib/abuuba_web/live/settings_live.ex:1491
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:481
+#: lib/abuuba_web/live/settings_live.ex:482
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:483
+#: lib/abuuba_web/live/settings_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:915
+#: lib/abuuba_web/live/admin_live.ex:917
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mark as a memorial"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:902
+#: lib/abuuba_web/live/admin_live.ex:904
 #, elixir-autogen, elixir-format
 msgid "Marking an account as a memorial stops it being signed in to and marks the profile as one. Nothing is hidden and nothing is deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2304
+#: lib/abuuba_web/live/admin_live.ex:2306
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:910
+#: lib/abuuba_web/live/admin_live.ex:912
 #, elixir-autogen, elixir-format
 msgid "This also disables their login. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:914
+#: lib/abuuba_web/live/admin_live.ex:916
 #, elixir-autogen, elixir-format
 msgid "This is not a memorial"
 msgstr ""
@@ -3491,7 +3488,7 @@ msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/collection_live.ex:115
+#: lib/abuuba_web/live/collection_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "A collection by %{name}"
 msgstr ""
@@ -3511,7 +3508,7 @@ msgstr ""
 msgid "Nobody is on this list yet."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:117
+#: lib/abuuba_web/live/annual_report_live.ex:114
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} posts in %{year}"
 msgstr ""
@@ -3521,7 +3518,7 @@ msgstr ""
 msgid "%{name}'s year"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:109
+#: lib/abuuba_web/live/annual_report_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "Asked a lot of questions."
 msgstr ""
@@ -3531,7 +3528,7 @@ msgstr ""
 msgid "Counted from public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:108
+#: lib/abuuba_web/live/annual_report_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Mostly here to pass on what other people said."
 msgstr ""
@@ -3546,12 +3543,12 @@ msgstr ""
 msgid "Posts this year"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:107
+#: lib/abuuba_web/live/annual_report_live.ex:104
 #, elixir-autogen, elixir-format
 msgid "Read a lot more than they wrote."
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:110
+#: lib/abuuba_web/live/annual_report_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Spent the year in other people's threads."
 msgstr ""
@@ -3561,22 +3558,22 @@ msgstr ""
 msgid "Written about most"
 msgstr ""
 
-#: lib/abuuba_web/live/annual_report_live.ex:111
+#: lib/abuuba_web/live/annual_report_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Wrote things other people replied to."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2098
+#: lib/abuuba_web/live/admin_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "An http or https address. Anything else is refused and nothing is shown."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2077
+#: lib/abuuba_web/live/admin_live.ex:2079
 #, elixir-autogen, elixir-format
 msgid "Asking for money"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2079
+#: lib/abuuba_web/live/admin_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Clients show this to people signed in here. Leave the message empty to show nothing."
 msgstr ""
@@ -3596,13 +3593,13 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2072
+#: lib/abuuba_web/live/admin_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "Each person still has to turn it on for themselves, and every address has to confirm before anything is sent to it."
 msgstr ""
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:644
+#: lib/abuuba_web/live/settings_live.ex:645
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email updates"
 msgstr ""
@@ -3617,7 +3614,7 @@ msgstr ""
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:662
+#: lib/abuuba_web/live/settings_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr ""
@@ -3627,7 +3624,7 @@ msgstr ""
 msgid "No, remove my address"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:664
+#: lib/abuuba_web/live/settings_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3655,12 +3652,12 @@ msgstr ""
 msgid "This address is getting updates. You can stop them at any time."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2103
+#: lib/abuuba_web/live/admin_live.ex:2105
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What the button says"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2090
+#: lib/abuuba_web/live/admin_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Where the button goes"
 msgstr ""
@@ -3675,12 +3672,12 @@ msgstr ""
 msgid "somebody gave this address to receive updates from %{name} on %{site}. If that was you, confirm it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2069
+#: lib/abuuba_web/live/admin_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "Let people collect email addresses for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:646
+#: lib/abuuba_web/live/settings_live.ex:647
 #, elixir-autogen, elixir-format, fuzzy
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr ""
@@ -3828,75 +3825,75 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1076
+#: lib/abuuba_web/live/settings_live.ex:1077
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2239
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:809
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:810
+#: lib/abuuba_web/live/settings_live.ex:2233
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1301
-#: lib/abuuba_web/live/admin_live.ex:1316
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/admin_live.ex:1303
+#: lib/abuuba_web/live/admin_live.ex:1318
+#: lib/abuuba_web/live/settings_live.ex:2230
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2234
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1118
+#: lib/abuuba_web/live/settings_live.ex:1119
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2240
+#: lib/abuuba_web/live/settings_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1101
+#: lib/abuuba_web/live/settings_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2103
+#: lib/abuuba_web/live/settings_live.ex:2110
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2230
+#: lib/abuuba_web/live/settings_live.ex:2231
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1065
+#: lib/abuuba_web/live/settings_live.ex:1066
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1386
+#: lib/abuuba_web/live/settings_live.ex:1387
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1083
+#: lib/abuuba_web/live/settings_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3916,13 +3913,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2237
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1107
-#: lib/abuuba_web/live/settings_live.ex:1392
+#: lib/abuuba_web/live/settings_live.ex:1108
+#: lib/abuuba_web/live/settings_live.ex:1393
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3932,7 +3929,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1078
+#: lib/abuuba_web/live/settings_live.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3942,87 +3939,87 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1157
+#: lib/abuuba_web/live/settings_live.ex:1158
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1155
+#: lib/abuuba_web/live/settings_live.ex:1156
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1121
+#: lib/abuuba_web/live/settings_live.ex:1122
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1060
+#: lib/abuuba_web/live/settings_live.ex:1061
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2135
+#: lib/abuuba_web/live/settings_live.ex:2142
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1138
+#: lib/abuuba_web/live/settings_live.ex:1139
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1419
+#: lib/abuuba_web/live/settings_live.ex:1420
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1416
+#: lib/abuuba_web/live/settings_live.ex:1417
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1128
+#: lib/abuuba_web/live/settings_live.ex:1129
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1412
+#: lib/abuuba_web/live/settings_live.ex:1413
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1143
+#: lib/abuuba_web/live/settings_live.ex:1144
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1123
+#: lib/abuuba_web/live/settings_live.ex:1124
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1133
+#: lib/abuuba_web/live/settings_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
 
-#: lib/abuuba_web/controllers/feed_controller.ex:131
+#: lib/abuuba_web/controllers/feed_controller.ex:132
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A post"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:399
+#: lib/abuuba_web/live/profile_live.ex:390
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nobody yet."
 msgstr ""
 
-#: lib/abuuba_web/controllers/feed_controller.ex:76
+#: lib/abuuba_web/controllers/feed_controller.ex:77
 #, elixir-autogen, elixir-format
 msgid "Public posts tagged #%{tag}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:376
+#: lib/abuuba_web/live/profile_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr ""
@@ -4048,99 +4045,99 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1448
+#: lib/abuuba_web/live/settings_live.ex:1449
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:913
+#: lib/abuuba_web/live/settings_live.ex:914
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:522
+#: lib/abuuba_web/live/settings_live.ex:523
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:531
+#: lib/abuuba_web/live/settings_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:550
+#: lib/abuuba_web/live/settings_live.ex:551
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:577
+#: lib/abuuba_web/live/settings_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:566
+#: lib/abuuba_web/live/settings_live.ex:567
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:562
+#: lib/abuuba_web/live/settings_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:936
+#: lib/abuuba_web/live/settings_live.ex:937
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:519
+#: lib/abuuba_web/live/settings_live.ex:520
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:932
+#: lib/abuuba_web/live/settings_live.ex:933
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:524
+#: lib/abuuba_web/live/settings_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:588
+#: lib/abuuba_web/live/settings_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:499
+#: lib/abuuba_web/live/settings_live.ex:500
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:911
+#: lib/abuuba_web/live/settings_live.ex:912
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:921
+#: lib/abuuba_web/live/settings_live.ex:922
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:921
+#: lib/abuuba_web/live/settings_live.ex:922
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signed in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:513
+#: lib/abuuba_web/live/settings_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:501
+#: lib/abuuba_web/live/settings_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr ""
@@ -4150,7 +4147,7 @@ msgstr ""
 msgid "Mail about your own account — password resets and the like — still comes."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2141
+#: lib/abuuba_web/live/admin_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Served from this server and linked from every page. It goes out exactly as typed."
 msgstr ""
@@ -4176,7 +4173,7 @@ msgstr ""
 msgid "You will not get that kind of email from us again."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2139
+#: lib/abuuba_web/live/admin_live.ex:2141
 #, elixir-autogen, elixir-format
 msgid "Your own CSS"
 msgstr ""
@@ -4196,649 +4193,649 @@ msgstr ""
 msgid "the occasional summary of what you missed"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1588
+#: lib/abuuba_web/live/admin_live.ex:1590
 #, elixir-autogen, elixir-format
 msgid "A relay forwards every public post it is sent on to everybody subscribed to it. On a young server it is the quickest way to have a federated timeline with anything in it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1511
-#: lib/abuuba_web/live/admin_live.ex:1623
+#: lib/abuuba_web/live/admin_live.ex:1513
+#: lib/abuuba_web/live/admin_live.ex:1625
 #, elixir-autogen, elixir-format
 msgid "Last error:"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1660
+#: lib/abuuba_web/live/admin_live.ex:1662
 #, elixir-autogen, elixir-format
 msgid "No relays yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3679
+#: lib/abuuba_web/live/admin_live.ex:3666
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3681
+#: lib/abuuba_web/live/admin_live.ex:3668
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/admin_live.ex:3372
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Relays"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1652
+#: lib/abuuba_web/live/admin_live.ex:1654
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this relay?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2811
+#: lib/abuuba_web/live/admin_live.ex:2813
 #, elixir-autogen, elixir-format
 msgid "That is not an https inbox address, or it is already here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3682
+#: lib/abuuba_web/live/admin_live.ex:3669
 #, elixir-autogen, elixir-format
 msgid "The relay refused"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1605
+#: lib/abuuba_web/live/admin_live.ex:1607
 #, elixir-autogen, elixir-format
 msgid "The relay's inbox address, which its operator publishes. Adding and turning on are separate steps, so a mistyped address can be corrected before anything is sent to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1644
-#: lib/abuuba_web/live/admin_live.ex:1842
+#: lib/abuuba_web/live/admin_live.ex:1646
+#: lib/abuuba_web/live/admin_live.ex:1844
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Turn off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1634
-#: lib/abuuba_web/live/admin_live.ex:1842
+#: lib/abuuba_web/live/admin_live.ex:1636
+#: lib/abuuba_web/live/admin_live.ex:1844
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Turn on"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3680
+#: lib/abuuba_web/live/admin_live.ex:3667
 #, elixir-autogen, elixir-format
 msgid "Waiting for the relay to answer"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1617
+#: lib/abuuba_web/live/admin_live.ex:1619
 #, elixir-autogen, elixir-format
 msgid "last sent %{when}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1823
+#: lib/abuuba_web/live/admin_live.ex:1825
 #, elixir-autogen, elixir-format
 msgid "Added turned off, so a URL typed wrong can be corrected before anything goes to it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1798
+#: lib/abuuba_web/live/admin_live.ex:1800
 #, elixir-autogen, elixir-format
 msgid "Copy it now. It is not shown again."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1852
+#: lib/abuuba_web/live/admin_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "New secret"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1894
+#: lib/abuuba_web/live/admin_live.ex:1896
 #, elixir-autogen, elixir-format
 msgid "No webhooks yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1889
+#: lib/abuuba_web/live/admin_live.ex:1891
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing sent yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1860
+#: lib/abuuba_web/live/admin_live.ex:1862
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Remove this webhook?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3097
-#: lib/abuuba_web/live/admin_live.ex:3675
+#: lib/abuuba_web/live/admin_live.ex:3094
+#: lib/abuuba_web/live/admin_live.ex:3662
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That did not work."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3672
+#: lib/abuuba_web/live/admin_live.ex:3659
 #, elixir-autogen, elixir-format
 msgid "That is not an event this server sends."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3669
+#: lib/abuuba_web/live/admin_live.ex:3656
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not an https address, or it is already here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1850
+#: lib/abuuba_web/live/admin_live.ex:1852
 #, elixir-autogen, elixir-format
 msgid "The old secret stops working immediately. Continue?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1796
+#: lib/abuuba_web/live/admin_live.ex:1798
 #, elixir-autogen, elixir-format
 msgid "The signing secret"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1790
+#: lib/abuuba_web/live/admin_live.ex:1792
 #, elixir-autogen, elixir-format
 msgid "This server posts to a webhook when something happens that a moderator would want to know about."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3384
+#: lib/abuuba_web/live/admin_live.ex:3378
 #, elixir-autogen, elixir-format
 msgid "Webhooks"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1875
+#: lib/abuuba_web/live/admin_live.ex:1877
 #, elixir-autogen, elixir-format
 msgid "no answer"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1672
+#: lib/abuuba_web/live/admin_live.ex:1674
 #, elixir-autogen, elixir-format
 msgid "A role is a set of permissions and a position. Position is what decides who may act on whom: nobody may edit a role at or above their own, and nobody may grant a permission they do not hold themselves."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1774
+#: lib/abuuba_web/live/admin_live.ex:1776
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Above yours"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3588
+#: lib/abuuba_web/live/admin_live.ex:3575
 #, elixir-autogen, elixir-format
 msgid "Act on accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3592
+#: lib/abuuba_web/live/admin_live.ex:3579
 #, elixir-autogen, elixir-format
 msgid "Answer appeals"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3618
+#: lib/abuuba_web/live/admin_live.ex:3605
 #, elixir-autogen, elixir-format
 msgid "Approve registrations, and turn two-factor off for somebody locked out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3596
+#: lib/abuuba_web/live/admin_live.ex:3583
 #, elixir-autogen, elixir-format
 msgid "Approve what trends"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3626
+#: lib/abuuba_web/live/admin_live.ex:3613
 #, elixir-autogen, elixir-format
 msgid "Block and unblock other servers, and set up relays."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3594
+#: lib/abuuba_web/live/admin_live.ex:3581
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Block sign-ups"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3595
+#: lib/abuuba_web/live/admin_live.ex:3582
 #, elixir-autogen, elixir-format
 msgid "Change the server's settings"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1697
+#: lib/abuuba_web/live/admin_live.ex:1699
 #, elixir-autogen, elixir-format
 msgid "Colour"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1736
+#: lib/abuuba_web/live/admin_live.ex:1738
 #, elixir-autogen, elixir-format
 msgid "Create the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3593
+#: lib/abuuba_web/live/admin_live.ex:3580
 #, elixir-autogen, elixir-format
 msgid "Decide about other servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3632
+#: lib/abuuba_web/live/admin_live.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Decide which hashtags, links and posts may appear in what is trending."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3590
+#: lib/abuuba_web/live/admin_live.ex:3577
 #, elixir-autogen, elixir-format
 msgid "Delete an account's data"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3621
+#: lib/abuuba_web/live/admin_live.ex:3608
 #, elixir-autogen, elixir-format
 msgid "Delete somebody's posts and files. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3607
+#: lib/abuuba_web/live/admin_live.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Every permission below, including ones added later. Give it to very few people."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3591
+#: lib/abuuba_web/live/admin_live.ex:3578
 #, elixir-autogen, elixir-format
 msgid "Handle reports"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3589
+#: lib/abuuba_web/live/admin_live.ex:3576
 #, elixir-autogen, elixir-format
 msgid "Let people in and out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3636
+#: lib/abuuba_web/live/admin_live.ex:3623
 #, elixir-autogen, elixir-format
 msgid "Make and change roles, never above their own and never granting more than they hold."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3601
+#: lib/abuuba_web/live/admin_live.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Manage custom emoji"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3597
+#: lib/abuuba_web/live/admin_live.ex:3584
 #, elixir-autogen, elixir-format
 msgid "Manage everybody's invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3603
+#: lib/abuuba_web/live/admin_live.ex:3590
 #, elixir-autogen, elixir-format
 msgid "Manage roles"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3602
+#: lib/abuuba_web/live/admin_live.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Manage webhooks"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1682
+#: lib/abuuba_web/live/admin_live.ex:1684
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1779
+#: lib/abuuba_web/live/admin_live.ex:1781
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No roles yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1687
+#: lib/abuuba_web/live/admin_live.ex:1689
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Position"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1750
+#: lib/abuuba_web/live/admin_live.ex:1752
 #, elixir-autogen, elixir-format
 msgid "Position %{position}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3587
+#: lib/abuuba_web/live/admin_live.ex:3574
 #, elixir-autogen, elixir-format
 msgid "Read the audit log"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3623
+#: lib/abuuba_web/live/admin_live.ex:3610
 #, elixir-autogen, elixir-format
 msgid "Read the queue, resolve and reopen."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1768
+#: lib/abuuba_web/live/admin_live.ex:1770
 #, elixir-autogen, elixir-format
 msgid "Remove this role? Anybody holding it keeps their account."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3383
+#: lib/abuuba_web/live/admin_live.ex:3377
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Roles"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1736
+#: lib/abuuba_web/live/admin_live.ex:1738
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3586
+#: lib/abuuba_web/live/admin_live.ex:3573
 #, elixir-autogen, elixir-format
 msgid "See the admin area"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3615
+#: lib/abuuba_web/live/admin_live.ex:3602
 #, elixir-autogen, elixir-format
 msgid "Silence, suspend, approve and reject accounts on this server."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3500
-#: lib/abuuba_web/live/admin_live.ex:3526
+#: lib/abuuba_web/live/admin_live.ex:3487
+#: lib/abuuba_web/live/admin_live.ex:3513
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That role could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3612
+#: lib/abuuba_web/live/admin_live.ex:3599
 #, elixir-autogen, elixir-format
 msgid "What every moderator has done, including this person's own actions."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1709
+#: lib/abuuba_web/live/admin_live.ex:1711
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What this role may do"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3629
+#: lib/abuuba_web/live/admin_live.ex:3616
 #, elixir-autogen, elixir-format
 msgid "Who may sign up, the server's name and description, and the rest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3609
+#: lib/abuuba_web/live/admin_live.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Without this the admin area is closed."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3600
+#: lib/abuuba_web/live/admin_live.ex:3587
 #, elixir-autogen, elixir-format
 msgid "Write announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3598
+#: lib/abuuba_web/live/admin_live.ex:3585
 #, elixir-autogen, elixir-format
 msgid "Write invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3599
+#: lib/abuuba_web/live/admin_live.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Write the server rules"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3579
+#: lib/abuuba_web/live/admin_live.ex:3566
 #, elixir-autogen, elixir-format
 msgid "You cannot make a role at or above your own position, or grant a permission you do not hold."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1729
+#: lib/abuuba_web/live/admin_live.ex:1731
 #, elixir-autogen, elixir-format
 msgid "You do not hold this yourself, so you cannot grant it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3649
+#: lib/abuuba_web/live/admin_live.ex:3636
 #, elixir-autogen, elixir-format
 msgid "nothing in particular"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:920
-#: lib/abuuba_web/live/admin_live.ex:1569
+#: lib/abuuba_web/live/admin_live.ex:922
+#: lib/abuuba_web/live/admin_live.ex:1571
 #, elixir-autogen, elixir-format
 msgid "A note for the other moderators"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1546
+#: lib/abuuba_web/live/admin_live.ex:1548
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Blocked: %{severity}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1504
+#: lib/abuuba_web/live/admin_live.ex:1506
 #, elixir-autogen, elixir-format
 msgid "Delivering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1490
+#: lib/abuuba_web/live/admin_live.ex:1492
 #, elixir-autogen, elixir-format
 msgid "Delivery stopped by a moderator"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1457
+#: lib/abuuba_web/live/admin_live.ex:1459
 #, elixir-autogen, elixir-format
 msgid "Every server this one has heard from, busiest first. A peer that has quietly stopped accepting deliveries looks exactly like a peer whose people have gone quiet, and this is where the two are told apart."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1542
+#: lib/abuuba_web/live/admin_live.ex:1544
 #, elixir-autogen, elixir-format
 msgid "Forget the failures"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1578
+#: lib/abuuba_web/live/admin_live.ex:1580
 #, elixir-autogen, elixir-format
 msgid "No other servers yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1482
+#: lib/abuuba_web/live/admin_live.ex:1484
 #, elixir-autogen, elixir-format
 msgid "One account"
 msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3382
+#: lib/abuuba_web/live/admin_live.ex:3376
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Other servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1559
+#: lib/abuuba_web/live/admin_live.ex:1561
 #, elixir-autogen, elixir-format
 msgid "Silence this server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1556
+#: lib/abuuba_web/live/admin_live.ex:1558
 #, elixir-autogen, elixir-format
 msgid "Silence this server? Its posts stop appearing in public timelines."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1532
+#: lib/abuuba_web/live/admin_live.ex:1534
 #, elixir-autogen, elixir-format
 msgid "Start again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1522
+#: lib/abuuba_web/live/admin_live.ex:1524
 #, elixir-autogen, elixir-format
 msgid "Stop delivering"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2668
+#: lib/abuuba_web/live/admin_live.ex:2670
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That server could not be blocked."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1496
+#: lib/abuuba_web/live/admin_live.ex:1498
 #, elixir-autogen, elixir-format
 msgid "Treated as down since %{when}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1507
+#: lib/abuuba_web/live/admin_live.ex:1509
 #, elixir-autogen, elixir-format
 msgid "one bad day"
 msgid_plural "%{count} bad days"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1482
+#: lib/abuuba_web/live/admin_live.ex:1484
 #, elixir-autogen, elixir-format, fuzzy
 msgid "one post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:953
+#: lib/abuuba_web/live/admin_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Ask their server for it again. Worth doing when the name or picture here is out of date and waiting for their next post is waiting for something that may not come."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:980
+#: lib/abuuba_web/live/admin_live.ex:982
 #, elixir-autogen, elixir-format
 msgid "Delete this post? Other servers are told to delete it too."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:965
+#: lib/abuuba_web/live/admin_live.ex:967
 #, elixir-autogen, elixir-format
 msgid "Deleting one from here is the same delete they would do themselves."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:958
+#: lib/abuuba_web/live/admin_live.ex:960
 #, elixir-autogen, elixir-format
 msgid "Fetch it again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:946
+#: lib/abuuba_web/live/admin_live.ex:948
 #, elixir-autogen, elixir-format
 msgid "Force a password reset"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:934
+#: lib/abuuba_web/live/admin_live.ex:936
 #, elixir-autogen, elixir-format
 msgid "Locked out, or somebody else is in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:922
+#: lib/abuuba_web/live/admin_live.ex:924
 #, elixir-autogen, elixir-format
 msgid "Nobody is told and nothing is applied. This is for the context that otherwise lives in one person's head: that this is the third report about the same joke, or that somebody spoke to them and they understood."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:989
+#: lib/abuuba_web/live/admin_live.ex:991
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing posted."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:943
+#: lib/abuuba_web/live/admin_live.ex:945
 #, elixir-autogen, elixir-format
 msgid "Sign them out everywhere and send a reset link?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2686
+#: lib/abuuba_web/live/admin_live.ex:2688
 #, elixir-autogen, elixir-format
 msgid "That account has nobody to sign in as."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:963
+#: lib/abuuba_web/live/admin_live.ex:965
 #, elixir-autogen, elixir-format
 msgid "Their most recent posts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:951
+#: lib/abuuba_web/live/admin_live.ex:953
 #, elixir-autogen, elixir-format
 msgid "Their profile here is a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2699
+#: lib/abuuba_web/live/admin_live.ex:2701
 #, elixir-autogen, elixir-format
 msgid "Their server did not answer."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:936
+#: lib/abuuba_web/live/admin_live.ex:938
 #, elixir-autogen, elixir-format
 msgid "This ends every session and every app, and emails them a link to set a new password. It does not choose one for them: a password a moderator picked is a password a moderator knows."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2135
+#: lib/abuuba_web/live/admin_live.ex:2137
 #, elixir-autogen, elixir-format
 msgid "%{latest} is out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1287
+#: lib/abuuba_web/live/admin_live.ex:1289
 #, elixir-autogen, elixir-format
 msgid "A server that has decided about four hundred domains has made four hundred decisions, and the way those get shared is a list somebody publishes. This reads and writes those lists."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2755
+#: lib/abuuba_web/live/admin_live.ex:2757
 #, elixir-autogen, elixir-format
 msgid "Added %{added}. %{skipped} were already decided about."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1429
+#: lib/abuuba_web/live/admin_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Addresses that asked one account here to write to them. Only the confirmed ones are counted: an unconfirmed address is a claim somebody typed, not a subscriber."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1302
-#: lib/abuuba_web/live/admin_live.ex:1317
+#: lib/abuuba_web/live/admin_live.ex:1304
+#: lib/abuuba_web/live/admin_live.ex:1319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Allows"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2112
+#: lib/abuuba_web/live/admin_live.ex:2114
 #, elixir-autogen, elixir-format
 msgid "Checking for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/admin_live.ex:3375
 #, elixir-autogen, elixir-format
 msgid "Domain lists"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1307
+#: lib/abuuba_web/live/admin_live.ex:1309
 #, elixir-autogen, elixir-format
 msgid "Domains this server has already decided about are left exactly as they are. An import adds and never removes: one paste should not be able to undo every decision made here, silently and unrecoverably."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3379
+#: lib/abuuba_web/live/admin_live.ex:3373
 #, elixir-autogen, elixir-format
 msgid "Email subscriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1446
+#: lib/abuuba_web/live/admin_live.ex:1448
 #, elixir-autogen, elixir-format
 msgid "Nobody here has any subscribers."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1419
+#: lib/abuuba_web/live/admin_live.ex:1421
 #, elixir-autogen, elixir-format
 msgid "Nobody is being suggested yet. It needs a few follows to work from."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1401
+#: lib/abuuba_web/live/admin_live.ex:1403
 #, elixir-autogen, elixir-format
 msgid "Not suggested"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2114
+#: lib/abuuba_web/live/admin_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. It asks %{url} whether there is a newer abuuba. What that tells them is what any web request tells anybody: this server's address, a user agent, and that somebody asked. Nothing about the accounts here, their number or their posts is sent, and there is nowhere in the request for it to go."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1440
+#: lib/abuuba_web/live/admin_live.ex:1442
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One address"
 msgid_plural "%{count} addresses"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1294
+#: lib/abuuba_web/live/admin_live.ex:1296
 #, elixir-autogen, elixir-format
 msgid "One blocked domain"
 msgid_plural "%{count} blocked domains"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:1328
+#: lib/abuuba_web/live/admin_live.ex:1330
 #, elixir-autogen, elixir-format
 msgid "Read it in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1305
+#: lib/abuuba_web/live/admin_live.ex:1307
 #, elixir-autogen, elixir-format
 msgid "Read one in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2133
+#: lib/abuuba_web/live/admin_live.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Running %{version}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1413
+#: lib/abuuba_web/live/admin_live.ex:1415
 #, elixir-autogen, elixir-format
 msgid "Stop suggesting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1412
+#: lib/abuuba_web/live/admin_live.ex:1414
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Suggest again"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1292
+#: lib/abuuba_web/live/admin_live.ex:1294
 #, elixir-autogen, elixir-format
 msgid "Take a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2129
+#: lib/abuuba_web/live/admin_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Tell me when there is a newer version"
 msgstr ""
@@ -4848,228 +4845,228 @@ msgstr ""
 msgid "There is no list of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1314
+#: lib/abuuba_web/live/admin_live.ex:1316
 #, elixir-autogen, elixir-format
 msgid "Which list"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1389
+#: lib/abuuba_web/live/admin_live.ex:1391
 #, elixir-autogen, elixir-format
 msgid "Who this server puts in front of a newcomer. Taking somebody out is not a block and not a silence: their account carries on exactly as before and nobody is told."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1294
+#: lib/abuuba_web/live/admin_live.ex:1296
 #, elixir-autogen, elixir-format
 msgid "one allowed domain"
 msgid_plural "%{count} allowed domains"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:342
+#: lib/abuuba_web/live/admin_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "%{label}, highest %{top}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3703
+#: lib/abuuba_web/live/admin_live.ex:3690
 #, elixir-autogen, elixir-format
 msgid "Favourites, boosts and replies"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3708
+#: lib/abuuba_web/live/admin_live.ex:3695
 #, elixir-autogen, elixir-format
 msgid "Languages people write in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3701
+#: lib/abuuba_web/live/admin_live.ex:3688
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:423
+#: lib/abuuba_web/live/admin_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Of the people who signed up in a given week, how many were still posting in the weeks after. A number that only means something once the server has been running a while."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3700
+#: lib/abuuba_web/live/admin_live.ex:3687
 #, elixir-autogen, elixir-format
 msgid "People who posted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3702
+#: lib/abuuba_web/live/admin_live.ex:3689
 #, elixir-autogen, elixir-format
 msgid "Posts written here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3704
+#: lib/abuuba_web/live/admin_live.ex:3691
 #, elixir-autogen, elixir-format
 msgid "Reports opened"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3705
+#: lib/abuuba_web/live/admin_live.ex:3692
 #, elixir-autogen, elixir-format
 msgid "Reports resolved"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3710
+#: lib/abuuba_web/live/admin_live.ex:3697
 #, elixir-autogen, elixir-format
 msgid "Servers we hear most from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:387
+#: lib/abuuba_web/live/admin_live.ex:389
 #, elixir-autogen, elixir-format
 msgid "The last thirty days"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:389
+#: lib/abuuba_web/live/admin_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "The same numbers a moderation client draws from the API, so what you see here and what it shows are the same figures rather than two answers to one question."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3711
+#: lib/abuuba_web/live/admin_live.ex:3698
 #, elixir-autogen, elixir-format
 msgid "What those servers run"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3709
+#: lib/abuuba_web/live/admin_live.ex:3696
 #, elixir-autogen, elixir-format
 msgid "Where accounts signed up from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:402
+#: lib/abuuba_web/live/admin_live.ex:404
 #, elixir-autogen, elixir-format
 msgid "Where things come from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:421
+#: lib/abuuba_web/live/admin_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "Who stayed"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:432
+#: lib/abuuba_web/live/admin_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "one signed up"
 msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2219
+#: lib/abuuba_web/live/settings_live.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2220
+#: lib/abuuba_web/live/settings_live.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:345
+#: lib/abuuba_web/live/settings_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:550
-#: lib/abuuba_web/live/settings_live.ex:363
+#: lib/abuuba_web/live/admin_live.ex:552
+#: lib/abuuba_web/live/settings_live.ex:364
 #, elixir-autogen, elixir-format, fuzzy
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2054
+#: lib/abuuba_web/live/settings_live.ex:2061
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One picture at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:343
+#: lib/abuuba_web/live/settings_live.ex:344
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:395
+#: lib/abuuba_web/live/settings_live.ex:396
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2052
-#: lib/abuuba_web/live/settings_live.ex:2213
+#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2214
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2208
-#: lib/abuuba_web/live/settings_live.ex:2215
+#: lib/abuuba_web/live/settings_live.ex:2209
+#: lib/abuuba_web/live/settings_live.ex:2216
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2049
+#: lib/abuuba_web/live/settings_live.ex:2056
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:164
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:322
-#: lib/abuuba_web/live/profile_live.ex:326
+#: lib/abuuba_web/live/profile_live.ex:313
+#: lib/abuuba_web/live/profile_live.ex:317
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Featured accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:182
+#: lib/abuuba_web/live/profile_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:555
+#: lib/abuuba_web/live/profile_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:276
+#: lib/abuuba_web/live/profile_live.ex:267
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:679
+#: lib/abuuba_web/live/settings_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:270
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:704
+#: lib/abuuba_web/live/settings_live.ex:705
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send it"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:295
+#: lib/abuuba_web/live/profile_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:713
+#: lib/abuuba_web/live/settings_live.ex:714
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:690
-#: lib/abuuba_web/live/settings_live.ex:1781
+#: lib/abuuba_web/live/settings_live.ex:691
+#: lib/abuuba_web/live/settings_live.ex:1788
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:558
+#: lib/abuuba_web/live/profile_live.ex:547
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1367
+#: lib/abuuba_web/live/settings_live.ex:1368
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5079,17 +5076,17 @@ msgstr ""
 msgid "To stop them, open this link:"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:545
+#: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:697
+#: lib/abuuba_web/live/settings_live.ex:698
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:677
+#: lib/abuuba_web/live/settings_live.ex:678
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr ""
@@ -5099,253 +5096,253 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1372
+#: lib/abuuba_web/live/settings_live.ex:1373
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:288
+#: lib/abuuba_web/live/profile_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1782
+#: lib/abuuba_web/live/settings_live.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:720
+#: lib/abuuba_web/live/settings_live.ex:721
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2421
+#: lib/abuuba_web/live/admin_live.ex:2423
 #, elixir-autogen, elixir-format
 msgid "A preset needs both."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:492
-#: lib/abuuba_web/live/admin_live.ex:708
+#: lib/abuuba_web/live/admin_live.ex:494
+#: lib/abuuba_web/live/admin_live.ex:710
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:568
+#: lib/abuuba_web/live/admin_live.ex:570
 #, elixir-autogen, elixir-format
 msgid "All of them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:566
+#: lib/abuuba_web/live/admin_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:775
+#: lib/abuuba_web/live/admin_live.ex:777
 #, elixir-autogen, elixir-format
 msgid "Do it to all of them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:627
+#: lib/abuuba_web/live/admin_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Filed as %{category} on %{date}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:685
+#: lib/abuuba_web/live/admin_live.ex:687
 #, elixir-autogen, elixir-format
 msgid "For whoever picks this up next. The person reported never sees any of it, and neither does whoever filed it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:661
+#: lib/abuuba_web/live/admin_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "I am on this"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2171
+#: lib/abuuba_web/live/admin_live.ex:2173
 #, elixir-autogen, elixir-format
 msgid "Keep it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3298
+#: lib/abuuba_web/live/admin_live.ex:3295
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Limit them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:670
+#: lib/abuuba_web/live/admin_live.ex:672
 #, elixir-autogen, elixir-format
 msgid "Mark it dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:599
+#: lib/abuuba_web/live/admin_live.ex:601
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:853
+#: lib/abuuba_web/live/admin_live.ex:855
 #, elixir-autogen, elixir-format
 msgid "Nothing, I will write it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:755
+#: lib/abuuba_web/live/admin_live.ex:757
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One account ticked."
 msgid_plural "%{count} accounts ticked."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:679
+#: lib/abuuba_web/live/admin_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Put it back in the queue"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2153
+#: lib/abuuba_web/live/admin_live.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Ready-made texts a moderator picks instead of retyping. Kept for the server rather than for one moderator, so two people writing about the same thing say the same thing."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3373
+#: lib/abuuba_web/live/admin_live.ex:3367
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:576
+#: lib/abuuba_web/live/admin_live.ex:578
 #, elixir-autogen, elixir-format
 msgid "Report %{id}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3371
+#: lib/abuuba_web/live/admin_live.ex:3365
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reports"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:851
+#: lib/abuuba_web/live/admin_live.ex:853
 #, elixir-autogen, elixir-format
 msgid "Start from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:564
+#: lib/abuuba_web/live/admin_live.ex:566
 #, elixir-autogen, elixir-format
 msgid "Still open"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3300
+#: lib/abuuba_web/live/admin_live.ex:3297
 #, elixir-autogen, elixir-format
 msgid "Stop them signing in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3299
+#: lib/abuuba_web/live/admin_live.ex:3296
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Suspend them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:637
+#: lib/abuuba_web/live/admin_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "The posts it names"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:768
+#: lib/abuuba_web/live/admin_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "This does the same thing to one account and tells them. Go ahead?"
 msgid_plural "This does the same thing to all %{count} accounts and tells each of them. Go ahead?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:786
+#: lib/abuuba_web/live/admin_live.ex:788
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Tick %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:753
+#: lib/abuuba_web/live/admin_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Tick some accounts to do one thing to all of them."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2151
+#: lib/abuuba_web/live/admin_live.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Warning presets"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2168
+#: lib/abuuba_web/live/admin_live.ex:2170
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What it says"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:683
+#: lib/abuuba_web/live/admin_live.ex:685
 #, elixir-autogen, elixir-format
 msgid "What moderators have written here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:705
+#: lib/abuuba_web/live/admin_live.ex:707
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What you found"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:562
+#: lib/abuuba_web/live/admin_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Which ones"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:580
+#: lib/abuuba_web/live/admin_live.ex:582
 #, elixir-autogen, elixir-format, fuzzy
 msgid "about"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:587
+#: lib/abuuba_web/live/admin_live.ex:589
 #, elixir-autogen, elixir-format
 msgid "dealt with"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:580
-#: lib/abuuba_web/live/admin_live.ex:622
+#: lib/abuuba_web/live/admin_live.ex:582
+#: lib/abuuba_web/live/admin_live.ex:624
 #, elixir-autogen, elixir-format
 msgid "from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3316
+#: lib/abuuba_web/live/admin_live.ex:3313
 #, elixir-autogen, elixir-format
 msgid "somebody who is gone"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:589
+#: lib/abuuba_web/live/admin_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "taken"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3275
+#: lib/abuuba_web/live/admin_live.ex:3272
 #, elixir-autogen, elixir-format
 msgid "One account could not be changed."
 msgid_plural "%{count} accounts could not be changed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3268
+#: lib/abuuba_web/live/admin_live.ex:3265
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One account was left alone because it outranks yours."
 msgid_plural "%{count} accounts were left alone because they outrank yours."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:603
+#: lib/abuuba_web/live/admin_live.ex:605
 #, elixir-autogen, elixir-format
 msgid "Showing the newest %{count}. Deal with some to see the ones that have waited longest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3233
+#: lib/abuuba_web/live/admin_live.ex:3230
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not something this list can do."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:642
+#: lib/abuuba_web/live/admin_live.ex:644
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Warning:"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:182
-#: lib/abuuba_web/live/admin_live.ex:186
+#: lib/abuuba_web/live/admin_live.ex:183
+#: lib/abuuba_web/live/admin_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Your account may not do that."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:648
+#: lib/abuuba_web/live/admin_live.ex:650
 #, elixir-autogen, elixir-format
 msgid "has pictures or video"
 msgstr ""
@@ -5400,7 +5397,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:959
+#: lib/abuuba_web/live/settings_live.ex:960
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5455,115 +5452,115 @@ msgstr ""
 msgid "Show anyway"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:488
+#: lib/abuuba_web/live/admin_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "A PNG or a GIF, at most %{size}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3200
+#: lib/abuuba_web/live/admin_live.ex:3197
 #, elixir-autogen, elixir-format
 msgid "A shortcode is letters, numbers and underscores, and nothing else."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3133
+#: lib/abuuba_web/live/admin_live.ex:3179
+#, elixir-autogen, elixir-format
+msgid "An emoji has to be a PNG or a GIF."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3123
+#: lib/abuuba_web/live/admin_live.ex:3157
+#, elixir-autogen, elixir-format
+msgid "Choose a picture for it."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3366
+#, elixir-autogen, elixir-format
+msgid "Custom emoji"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:543
+#, elixir-autogen, elixir-format
+msgid "Every post that used it loses its picture. Go ahead?"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:481
+#, elixir-autogen, elixir-format
+msgid "Group it under"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:518
+#, elixir-autogen, elixir-format
+msgid "Offer it"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:468
+#, elixir-autogen, elixir-format
+msgid "Pictures people here can type into a post by name. One uploaded here is held on this server, so it outlives whoever made it."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:476
+#, elixir-autogen, elixir-format
+msgid "Shortcode"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:517
+#, elixir-autogen, elixir-format
+msgid "Stop offering it"
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3199
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That emoji could not be saved."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3185
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That picture could not be stored."
+msgstr ""
+
+#: lib/abuuba_web/live/admin_live.ex:3139
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That picture could not be used."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3136
 #: lib/abuuba_web/live/admin_live.ex:3182
 #, elixir-autogen, elixir-format
-msgid "An emoji has to be a PNG or a GIF."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3126
-#: lib/abuuba_web/live/admin_live.ex:3160
-#, elixir-autogen, elixir-format
-msgid "Choose a picture for it."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3372
-#, elixir-autogen, elixir-format
-msgid "Custom emoji"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:541
-#, elixir-autogen, elixir-format
-msgid "Every post that used it loses its picture. Go ahead?"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:479
-#, elixir-autogen, elixir-format
-msgid "Group it under"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:516
-#, elixir-autogen, elixir-format
-msgid "Offer it"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:466
-#, elixir-autogen, elixir-format
-msgid "Pictures people here can type into a post by name. One uploaded here is held on this server, so it outlives whoever made it."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:474
-#, elixir-autogen, elixir-format
-msgid "Shortcode"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:515
-#, elixir-autogen, elixir-format
-msgid "Stop offering it"
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3202
-#, elixir-autogen, elixir-format, fuzzy
-msgid "That emoji could not be saved."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3188
-#, elixir-autogen, elixir-format, fuzzy
-msgid "That picture could not be stored."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3142
-#, elixir-autogen, elixir-format, fuzzy
-msgid "That picture could not be used."
-msgstr ""
-
-#: lib/abuuba_web/live/admin_live.ex:3139
-#: lib/abuuba_web/live/admin_live.ex:3185
-#, elixir-autogen, elixir-format
 msgid "That picture is too large for an emoji."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:485
+#: lib/abuuba_web/live/admin_live.ex:487
 #, elixir-autogen, elixir-format
 msgid "The picture"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3123
+#: lib/abuuba_web/live/admin_live.ex:3120
 #, elixir-autogen, elixir-format
 msgid "The picture is still uploading. Try again in a moment."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:503
+#: lib/abuuba_web/live/admin_live.ex:505
 #, elixir-autogen, elixir-format
 msgid "not offered"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:245
+#: lib/abuuba_web/live/profile_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:243
+#: lib/abuuba_web/live/profile_live.ex:234
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:222
+#: lib/abuuba_web/live/profile_live.ex:213
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:207
+#: lib/abuuba_web/live/profile_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr ""
@@ -5588,12 +5585,12 @@ msgstr ""
 msgid "Unmute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:453
+#: lib/abuuba_web/live/notifications_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:237
+#: lib/abuuba_web/live/profile_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr ""
@@ -5628,146 +5625,146 @@ msgstr ""
 msgid "Your year on this server is ready to read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:448
+#: lib/abuuba_web/live/notifications_live.ex:445
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quotes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2017
+#: lib/abuuba_web/live/admin_live.ex:2019
 #, elixir-autogen, elixir-format
 msgid "Days to keep other servers' files"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2026
+#: lib/abuuba_web/live/admin_live.ex:2028
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them indefinitely. Anything older goes off this server's disk each night. The posts stay, and a file is fetched again if somebody opens it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:528
+#: lib/abuuba_web/live/admin_live.ex:530
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Every post that used it loses its picture until you turn it back on. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:501
+#: lib/abuuba_web/live/admin_live.ex:503
 #, elixir-autogen, elixir-format, fuzzy
 msgid "turned off"
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:97
+#: lib/abuuba_web/live/conversations_live.ex:98
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mark unread"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:239
-#: lib/abuuba_web/live/conversations_live.ex:44
-#: lib/abuuba_web/live/conversations_live.ex:60
+#: lib/abuuba_web/live/conversations_live.ex:45
+#: lib/abuuba_web/live/conversations_live.ex:61
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Messages"
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:63
+#: lib/abuuba_web/live/conversations_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. A post addressed to only the people you name arrives as a message, and its replies stay with it."
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:82
+#: lib/abuuba_web/live/conversations_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Open the conversation with %{people}"
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:224
+#: lib/abuuba_web/live/conversations_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "The last message has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:105
+#: lib/abuuba_web/live/conversations_live.ex:106
 #, elixir-autogen, elixir-format
 msgid "This takes it out of your inbox only. Nobody else loses anything, and a later message brings it back. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2033
+#: lib/abuuba_web/live/admin_live.ex:2035
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Days to keep other servers' posts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:2042
+#: lib/abuuba_web/live/admin_live.ex:2044
 #, elixir-autogen, elixir-format
 msgid "Zero keeps them for ever. Anything older is deleted each night, except a post somebody here favourited, bookmarked, pinned, boosted, quoted, replied to or was mentioned in."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1917
+#: lib/abuuba_web/live/admin_live.ex:1919
 #, elixir-autogen, elixir-format
 msgid "The longer version, for the about page"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1968
-#: lib/abuuba_web/live/admin_live.ex:1977
+#: lib/abuuba_web/live/admin_live.ex:1970
+#: lib/abuuba_web/live/admin_live.ex:1979
 #, elixir-autogen, elixir-format
 msgid "Anybody, including people with no account"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1983
+#: lib/abuuba_web/live/admin_live.ex:1985
 #, elixir-autogen, elixir-format
 msgid "Nobody: turn them off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1965
-#: lib/abuuba_web/live/admin_live.ex:1980
+#: lib/abuuba_web/live/admin_live.ex:1967
+#: lib/abuuba_web/live/admin_live.ex:1982
 #, elixir-autogen, elixir-format
 msgid "Only people signed in here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1974
+#: lib/abuuba_web/live/admin_live.ex:1976
 #, elixir-autogen, elixir-format
 msgid "Who may read the public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1949
+#: lib/abuuba_web/live/admin_live.ex:1951
 #, elixir-autogen, elixir-format
 msgid "The privacy policy takes effect on"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1933
+#: lib/abuuba_web/live/admin_live.ex:1935
 #, elixir-autogen, elixir-format
 msgid "The account to write to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1938
+#: lib/abuuba_web/live/admin_live.ex:1940
 #, elixir-autogen, elixir-format
 msgid "a username on this server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1922
+#: lib/abuuba_web/live/admin_live.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Status page"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1962
+#: lib/abuuba_web/live/admin_live.ex:1964
 #, elixir-autogen, elixir-format
 msgid "Nobody: the server does not say"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1959
+#: lib/abuuba_web/live/admin_live.ex:1961
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Who may read the blocklist"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:634
+#: lib/abuuba_web/live/settings_live.ex:635
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:626
+#: lib/abuuba_web/live/settings_live.ex:627
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:838
+#: lib/abuuba_web/live/settings_live.ex:839
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Block a server"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:811
+#: lib/abuuba_web/live/settings_live.ex:812
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr ""
@@ -5777,83 +5774,68 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:148
-#: lib/abuuba_web/live/profile_live.ex:596
+#: lib/abuuba_web/live/explore_live.ex:144
+#: lib/abuuba_web/live/profile_live.ex:585
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3361
+#: lib/abuuba_web/live/admin_live.ex:3355
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3364
+#: lib/abuuba_web/live/admin_live.ex:3358
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3365
+#: lib/abuuba_web/live/admin_live.ex:3359
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3374
+#: lib/abuuba_web/live/admin_live.ex:3368
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Appeals"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1379
+#: lib/abuuba_web/live/admin_live.ex:1381
 #, elixir-autogen, elixir-format
 msgid "Nothing is waiting. Appeals against a strike show up here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3363
+#: lib/abuuba_web/live/admin_live.ex:3357
 #, elixir-autogen, elixir-format
 msgid "Posts deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3362
+#: lib/abuuba_web/live/admin_live.ex:3356
 #, elixir-autogen, elixir-format
 msgid "Posts marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1338
+#: lib/abuuba_web/live/admin_live.ex:1340
 #, elixir-autogen, elixir-format
 msgid "Somebody who was warned, silenced or suspended saying it was a mistake. Upholding an appeal undoes the action where it can be undone; where it cannot, the appeal is still recorded as upheld. Either way the account's owner is told."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3073
+#: lib/abuuba_web/live/admin_live.ex:3070
 #, elixir-autogen, elixir-format
 msgid "That appeal is no longer waiting."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1372
+#: lib/abuuba_web/live/admin_live.ex:1374
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Turn down"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:1364
+#: lib/abuuba_web/live/admin_live.ex:1366
 #, elixir-autogen, elixir-format
 msgid "Uphold and undo"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3360
+#: lib/abuuba_web/live/admin_live.ex:3354
 #, elixir-autogen, elixir-format
 msgid "Warned"
-msgstr ""
-
-#: lib/abuuba_web/live/profile_live.ex:155
-#, elixir-autogen, elixir-format
-msgid "Cancel follow request"
-msgstr ""
-
-#: lib/abuuba_web/live/explore_live.ex:117
-#, elixir-autogen, elixir-format
-msgid "Requested"
-msgstr ""
-
-#: lib/abuuba_web/live/profile_live.ex:606
-#, elixir-autogen, elixir-format
-msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -49,7 +49,7 @@ msgid "Change"
 msgstr ""
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:723
+#: lib/abuuba_web/live/compose_component.ex:713
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:900
+#: lib/abuuba_web/live/settings_live.ex:901
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -466,8 +466,8 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:397
-#: lib/abuuba_web/live/compose_component.ex:410
+#: lib/abuuba_web/live/compose_component.ex:387
+#: lib/abuuba_web/live/compose_component.ex:400
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -661,8 +661,8 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:230
 #: lib/abuuba_web/components/layouts.ex:251
-#: lib/abuuba_web/live/home_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:2310
+#: lib/abuuba_web/live/home_live.ex:55
+#: lib/abuuba_web/live/settings_live.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -688,15 +688,15 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
-#: lib/abuuba_web/live/notifications_live.ex:56
-#: lib/abuuba_web/live/settings_live.ex:2311
+#: lib/abuuba_web/live/notifications_live.ex:57
+#: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:119
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:120
+#: lib/abuuba_web/live/settings_live.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Skip to content"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:85
+#: lib/abuuba_web/live/home_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "%{count} new post"
 msgid_plural "%{count} new posts"
@@ -755,13 +755,13 @@ msgstr ""
 msgid "Favourite"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:104
+#: lib/abuuba_web/live/home_live.ex:105
 #, elixir-autogen, elixir-format
 msgid "Follow some people and their posts will appear here."
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:267
-#: lib/abuuba_web/live/compose_component.ex:603
+#: lib/abuuba_web/live/compose_component.ex:593
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:304
+#: lib/abuuba_web/live/home_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "That vote could not be counted."
 msgstr ""
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Vote"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:100
+#: lib/abuuba_web/live/home_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "You have reached the end."
 msgstr ""
@@ -791,96 +791,96 @@ msgstr ""
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/compose_component.ex:1657
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1664
+#: lib/abuuba_web/live/compose_component.ex:1655
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/compose_component.ex:1658
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1663
+#: lib/abuuba_web/live/compose_component.ex:1654
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1662
+#: lib/abuuba_web/live/compose_component.ex:1653
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1665
+#: lib/abuuba_web/live/compose_component.ex:1656
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/compose_component.ex:1659
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1141
+#: lib/abuuba_web/live/compose_component.ex:1131
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:638
+#: lib/abuuba_web/live/compose_component.ex:628
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:709
+#: lib/abuuba_web/live/compose_component.ex:699
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:650
+#: lib/abuuba_web/live/compose_component.ex:640
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1683
-#: lib/abuuba_web/live/settings_live.ex:2305
+#: lib/abuuba_web/live/compose_component.ex:1674
+#: lib/abuuba_web/live/settings_live.ex:2306
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1674
-#: lib/abuuba_web/live/settings_live.ex:2300
+#: lib/abuuba_web/live/compose_component.ex:1665
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:614
+#: lib/abuuba_web/live/compose_component.ex:604
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:438
-#: lib/abuuba_web/live/compose_component.ex:699
+#: lib/abuuba_web/live/compose_component.ex:428
+#: lib/abuuba_web/live/compose_component.ex:689
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:800
+#: lib/abuuba_web/live/compose_component.ex:790
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:433
+#: lib/abuuba_web/live/compose_component.ex:423
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr ""
@@ -891,325 +891,325 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:403
+#: lib/abuuba_web/live/compose_component.ex:393
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:654
+#: lib/abuuba_web/live/compose_component.ex:644
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/profile_live.ex:837
+#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/profile_live.ex:866
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3428
-#: lib/abuuba_web/live/compose_component.ex:1685
-#: lib/abuuba_web/live/settings_live.ex:2307
+#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/settings_live.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2302
+#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/settings_live.ex:2303
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/compose_component.ex:1668
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1684
-#: lib/abuuba_web/live/settings_live.ex:2306
+#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/settings_live.ex:2307
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1441
+#: lib/abuuba_web/live/compose_component.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:683
+#: lib/abuuba_web/live/compose_component.ex:673
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1674
-#: lib/abuuba_web/live/compose_component.ex:1692
+#: lib/abuuba_web/live/compose_component.ex:1665
+#: lib/abuuba_web/live/compose_component.ex:1683
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/compose_component.ex:1666
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:719
+#: lib/abuuba_web/live/compose_component.ex:709
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:626
+#: lib/abuuba_web/live/compose_component.ex:616
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:390
+#: lib/abuuba_web/live/compose_component.ex:380
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1439
+#: lib/abuuba_web/live/compose_component.ex:1430
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3389
-#: lib/abuuba_web/live/compose_component.ex:465
+#: lib/abuuba_web/live/compose_component.ex:455
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1103
+#: lib/abuuba_web/live/compose_component.ex:1093
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1165
-#: lib/abuuba_web/live/compose_component.ex:1200
-#: lib/abuuba_web/live/compose_component.ex:1395
+#: lib/abuuba_web/live/compose_component.ex:1155
+#: lib/abuuba_web/live/compose_component.ex:1190
+#: lib/abuuba_web/live/compose_component.ex:1386
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:449
-#: lib/abuuba_web/live/compose_component.ex:455
+#: lib/abuuba_web/live/compose_component.ex:439
+#: lib/abuuba_web/live/compose_component.ex:445
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:443
+#: lib/abuuba_web/live/compose_component.ex:433
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:759
+#: lib/abuuba_web/live/compose_component.ex:749
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:739
+#: lib/abuuba_web/live/compose_component.ex:729
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1099
+#: lib/abuuba_web/live/compose_component.ex:1089
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1197
+#: lib/abuuba_web/live/compose_component.ex:1187
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1635
+#: lib/abuuba_web/live/compose_component.ex:1626
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:806
+#: lib/abuuba_web/live/compose_component.ex:796
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:838
+#: lib/abuuba_web/live/compose_component.ex:828
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:1145
+#: lib/abuuba_web/live/compose_component.ex:1135
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:869
+#: lib/abuuba_web/live/compose_component.ex:859
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:830
+#: lib/abuuba_web/live/compose_component.ex:820
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:669
+#: lib/abuuba_web/live/compose_component.ex:659
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:820
-#: lib/abuuba_web/live/compose_component.ex:859
+#: lib/abuuba_web/live/compose_component.ex:810
+#: lib/abuuba_web/live/compose_component.ex:849
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1116
-#: lib/abuuba_web/live/compose_component.ex:1386
+#: lib/abuuba_web/live/compose_component.ex:1106
+#: lib/abuuba_web/live/compose_component.ex:1377
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:791
+#: lib/abuuba_web/live/compose_component.ex:781
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1440
+#: lib/abuuba_web/live/compose_component.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:304
+#: lib/abuuba_web/live/compose_component.ex:305
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That draft could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:202
+#: lib/abuuba_web/live/home_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "That post is scheduled."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1150
+#: lib/abuuba_web/live/compose_component.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:300
+#: lib/abuuba_web/live/compose_component.ex:301
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1434
+#: lib/abuuba_web/live/compose_component.ex:1425
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:676
+#: lib/abuuba_web/live/compose_component.ex:666
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1113
+#: lib/abuuba_web/live/compose_component.ex:1103
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:484
+#: lib/abuuba_web/live/compose_component.ex:474
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:579
+#: lib/abuuba_web/live/compose_component.ex:569
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:529
+#: lib/abuuba_web/live/compose_component.ex:519
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:546
-#: lib/abuuba_web/live/compose_component.ex:554
+#: lib/abuuba_web/live/compose_component.ex:536
+#: lib/abuuba_web/live/compose_component.ex:544
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:568
+#: lib/abuuba_web/live/compose_component.ex:558
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:583
+#: lib/abuuba_web/live/compose_component.ex:573
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:541
+#: lib/abuuba_web/live/compose_component.ex:531
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:509
+#: lib/abuuba_web/live/compose_component.ex:499
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:594
+#: lib/abuuba_web/live/compose_component.ex:584
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:239
-#: lib/abuuba_web/live/compose_component.ex:1430
+#: lib/abuuba_web/live/compose_component.ex:240
+#: lib/abuuba_web/live/compose_component.ex:1421
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1427
+#: lib/abuuba_web/live/compose_component.ex:1418
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:226
+#: lib/abuuba_web/live/compose_component.ex:227
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1428
+#: lib/abuuba_web/live/compose_component.ex:1419
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1429
+#: lib/abuuba_web/live/compose_component.ex:1420
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:488
+#: lib/abuuba_web/live/compose_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:279
+#: lib/abuuba_web/live/status_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:292
+#: lib/abuuba_web/live/profile_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:189
+#: lib/abuuba_web/live/profile_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
@@ -1231,29 +1231,29 @@ msgstr ""
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:836
+#: lib/abuuba_web/live/profile_live.ex:865
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:363
+#: lib/abuuba_web/live/profile_live.ex:372
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:338
-#: lib/abuuba_web/live/profile_live.ex:339
+#: lib/abuuba_web/live/profile_live.ex:347
+#: lib/abuuba_web/live/profile_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:288
-#: lib/abuuba_web/live/profile_live.ex:834
+#: lib/abuuba_web/live/explore_live.ex:304
+#: lib/abuuba_web/live/profile_live.ex:863
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:122
 #: lib/abuuba_web/live/search_live.ex:264
@@ -1261,18 +1261,18 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:835
+#: lib/abuuba_web/live/profile_live.ex:864
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:944
-#: lib/abuuba_web/live/profile_live.ex:296
+#: lib/abuuba_web/live/profile_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:320
+#: lib/abuuba_web/live/status_live.ex:318
 #, elixir-autogen, elixir-format
 msgid "That server could not be reached, so this is all there is."
 msgstr ""
@@ -1282,19 +1282,19 @@ msgstr ""
 msgid "This account has moved to %{handle}."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:189
-#: lib/abuuba_web/live/settings_live.ex:826
+#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/settings_live.ex:827
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:155
+#: lib/abuuba_web/live/profile_live.ex:164
 #: lib/abuuba_web/live/tag_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:181
+#: lib/abuuba_web/live/profile_live.ex:190
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
@@ -1304,109 +1304,109 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:300
+#: lib/abuuba_web/live/profile_live.ex:309
 #: lib/abuuba_web/live/search_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "What to show"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:83
+#: lib/abuuba_web/live/notifications_live.ex:84
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:133
+#: lib/abuuba_web/live/notifications_live.ex:134
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:380
+#: lib/abuuba_web/live/notifications_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:384
+#: lib/abuuba_web/live/notifications_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:391
+#: lib/abuuba_web/live/notifications_live.ex:392
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:394
+#: lib/abuuba_web/live/notifications_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:118
+#: lib/abuuba_web/live/notifications_live.ex:119
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:398
+#: lib/abuuba_web/live/notifications_live.ex:399
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:347
+#: lib/abuuba_web/live/notifications_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:345
+#: lib/abuuba_web/live/notifications_live.ex:346
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} boosted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:350
+#: lib/abuuba_web/live/notifications_live.ex:351
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:348
+#: lib/abuuba_web/live/notifications_live.ex:349
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:346
+#: lib/abuuba_web/live/notifications_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:344
+#: lib/abuuba_web/live/notifications_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:351
+#: lib/abuuba_web/live/notifications_live.ex:352
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} posted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:352
+#: lib/abuuba_web/live/notifications_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:349
+#: lib/abuuba_web/live/notifications_live.ex:350
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr ""
@@ -1431,7 +1431,7 @@ msgstr ""
 msgid "Accounts made very recently"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:430
+#: lib/abuuba_web/live/notifications_live.ex:431
 #, elixir-autogen, elixir-format, fuzzy
 msgid "All"
 msgstr ""
@@ -1461,17 +1461,17 @@ msgstr ""
 msgid "Automated accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:439
+#: lib/abuuba_web/live/notifications_live.ex:440
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Boosts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:111
+#: lib/abuuba_web/live/notifications_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:178
+#: lib/abuuba_web/live/notifications_live.ex:179
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -1481,12 +1481,12 @@ msgstr ""
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:444
+#: lib/abuuba_web/live/notifications_live.ex:445
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edits"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:442
+#: lib/abuuba_web/live/notifications_live.ex:443
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Favourites"
 msgstr ""
@@ -1496,15 +1496,15 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:441
+#: lib/abuuba_web/live/notifications_live.ex:442
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:440
-#: lib/abuuba_web/live/profile_live.ex:838
-#: lib/abuuba_web/live/settings_live.ex:2103
-#: lib/abuuba_web/live/settings_live.ex:2241
+#: lib/abuuba_web/live/notifications_live.ex:441
+#: lib/abuuba_web/live/profile_live.ex:867
+#: lib/abuuba_web/live/settings_live.ex:2104
+#: lib/abuuba_web/live/settings_live.ex:2242
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows"
 msgstr ""
@@ -1519,28 +1519,28 @@ msgstr ""
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:147
+#: lib/abuuba_web/live/notifications_live.ex:148
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:107
+#: lib/abuuba_web/live/notifications_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:430
-#: lib/abuuba_web/live/notifications_live.ex:438
+#: lib/abuuba_web/live/notifications_live.ex:431
+#: lib/abuuba_web/live/notifications_live.ex:439
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:156
+#: lib/abuuba_web/live/notifications_live.ex:157
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:192
+#: lib/abuuba_web/live/notifications_live.ex:193
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing has happened yet."
 msgstr ""
@@ -1555,7 +1555,7 @@ msgstr ""
 msgid "People you do not follow"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:443
+#: lib/abuuba_web/live/notifications_live.ex:444
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Polls"
 msgstr ""
@@ -1571,28 +1571,28 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1587
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:255
-#: lib/abuuba_web/live/settings_live.ex:294
-#: lib/abuuba_web/live/settings_live.ex:388
-#: lib/abuuba_web/live/settings_live.ex:425
-#: lib/abuuba_web/live/settings_live.ex:489
-#: lib/abuuba_web/live/settings_live.ex:596
-#: lib/abuuba_web/live/settings_live.ex:641
-#: lib/abuuba_web/live/settings_live.ex:674
-#: lib/abuuba_web/live/settings_live.ex:996
+#: lib/abuuba_web/live/profile_live.ex:264
+#: lib/abuuba_web/live/settings_live.ex:295
+#: lib/abuuba_web/live/settings_live.ex:389
+#: lib/abuuba_web/live/settings_live.ex:426
+#: lib/abuuba_web/live/settings_live.ex:490
+#: lib/abuuba_web/live/settings_live.ex:597
+#: lib/abuuba_web/live/settings_live.ex:642
+#: lib/abuuba_web/live/settings_live.ex:675
+#: lib/abuuba_web/live/settings_live.ex:997
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:245
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:136
+#: lib/abuuba_web/live/settings_live.ex:137
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:342
-#: lib/abuuba_web/live/notifications_live.ex:407
+#: lib/abuuba_web/live/notifications_live.ex:343
+#: lib/abuuba_web/live/notifications_live.ex:408
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Somebody"
 msgstr ""
@@ -1602,7 +1602,7 @@ msgstr ""
 msgid "Somebody a moderator here has already restricted."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:377
+#: lib/abuuba_web/live/notifications_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr ""
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "That could not be saved. Try again."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:72
+#: lib/abuuba_web/live/notifications_live.ex:73
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr ""
@@ -1622,7 +1622,7 @@ msgstr ""
 msgid "Who can reach you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:125
+#: lib/abuuba_web/live/notifications_live.ex:126
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr ""
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:289
+#: lib/abuuba_web/live/explore_live.ex:305
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:113
 #: lib/abuuba_web/live/search_live.ex:263
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:119
+#: lib/abuuba_web/live/explore_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:290
+#: lib/abuuba_web/live/explore_live.ex:306
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:103
 #: lib/abuuba_web/live/search_live.ex:262
@@ -1755,220 +1755,220 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:891
+#: lib/abuuba_web/live/settings_live.ex:892
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:234
+#: lib/abuuba_web/live/settings_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3379
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:290
+#: lib/abuuba_web/live/settings_live.ex:291
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a field"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:807
+#: lib/abuuba_web/live/settings_live.ex:808
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2277
+#: lib/abuuba_web/live/settings_live.ex:2278
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2130
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:947
+#: lib/abuuba_web/live/settings_live.ex:948
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2272
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:895
+#: lib/abuuba_web/live/settings_live.ex:896
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:998
-#: lib/abuuba_web/live/settings_live.ex:754
+#: lib/abuuba_web/live/settings_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:223
+#: lib/abuuba_web/live/settings_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1600
+#: lib/abuuba_web/live/settings_live.ex:1601
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:201
+#: lib/abuuba_web/live/settings_live.ex:202
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:239
+#: lib/abuuba_web/live/settings_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2102
-#: lib/abuuba_web/live/settings_live.ex:2247
+#: lib/abuuba_web/live/settings_live.ex:2103
+#: lib/abuuba_web/live/settings_live.ex:2248
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2329
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2278
+#: lib/abuuba_web/live/settings_live.ex:2279
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2286
+#: lib/abuuba_web/live/settings_live.ex:2287
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:254
+#: lib/abuuba_web/live/settings_live.ex:255
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2282
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:272
+#: lib/abuuba_web/live/settings_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:976
+#: lib/abuuba_web/live/settings_live.ex:977
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:990
+#: lib/abuuba_web/live/settings_live.ex:991
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:449
+#: lib/abuuba_web/live/settings_live.ex:450
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2097
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2315
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2312
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2285
+#: lib/abuuba_web/live/settings_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1979,165 +1979,165 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1878
 #: lib/abuuba_web/live/admin_live.ex:2202
 #: lib/abuuba_web/live/conversations_live.ex:112
-#: lib/abuuba_web/live/settings_live.ex:280
-#: lib/abuuba_web/live/settings_live.ex:315
+#: lib/abuuba_web/live/settings_live.ex:281
+#: lib/abuuba_web/live/settings_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2104
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:908
+#: lib/abuuba_web/live/settings_live.ex:909
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:904
+#: lib/abuuba_web/live/settings_live.ex:905
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:970
+#: lib/abuuba_web/live/settings_live.ex:971
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3750
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2094
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1575
+#: lib/abuuba_web/live/settings_live.ex:1576
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:468
+#: lib/abuuba_web/live/settings_live.ex:469
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2279
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2313
+#: lib/abuuba_web/live/settings_live.ex:2314
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:849
+#: lib/abuuba_web/live/settings_live.ex:850
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:874
+#: lib/abuuba_web/live/settings_live.ex:875
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:241
+#: lib/abuuba_web/live/settings_live.ex:242
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:261
+#: lib/abuuba_web/live/settings_live.ex:262
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/settings_live.ex:2290
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:799
+#: lib/abuuba_web/live/settings_live.ex:800
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2126
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2178
-#: lib/abuuba_web/live/settings_live.ex:761
+#: lib/abuuba_web/live/settings_live.ex:762
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:766
+#: lib/abuuba_web/live/settings_live.ex:767
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:455
+#: lib/abuuba_web/live/settings_live.ex:456
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:436
+#: lib/abuuba_web/live/settings_live.ex:437
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:870
+#: lib/abuuba_web/live/settings_live.ex:871
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:886
+#: lib/abuuba_web/live/settings_live.ex:887
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:987
+#: lib/abuuba_web/live/settings_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2293,110 +2293,110 @@ msgstr ""
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1858
+#: lib/abuuba_web/live/settings_live.ex:1859
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1196
+#: lib/abuuba_web/live/settings_live.ex:1197
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2107
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1226
+#: lib/abuuba_web/live/settings_live.ex:1227
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1842
+#: lib/abuuba_web/live/settings_live.ex:1843
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1193
+#: lib/abuuba_web/live/settings_live.ex:1194
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1861
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1200
-#: lib/abuuba_web/live/settings_live.ex:1838
+#: lib/abuuba_web/live/settings_live.ex:1201
+#: lib/abuuba_web/live/settings_live.ex:1839
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1171
+#: lib/abuuba_web/live/settings_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1854
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1852
+#: lib/abuuba_web/live/settings_live.ex:1853
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1855
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1859
+#: lib/abuuba_web/live/settings_live.ex:1860
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1862
+#: lib/abuuba_web/live/settings_live.ex:1863
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1863
+#: lib/abuuba_web/live/settings_live.ex:1864
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1861
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1179
+#: lib/abuuba_web/live/settings_live.ex:1180
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1217
+#: lib/abuuba_web/live/settings_live.ex:1218
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1206
+#: lib/abuuba_web/live/settings_live.ex:1207
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1208
+#: lib/abuuba_web/live/settings_live.ex:1209
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
@@ -2692,7 +2692,7 @@ msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3340
-#: lib/abuuba_web/live/settings_live.ex:1628
+#: lib/abuuba_web/live/settings_live.ex:1629
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
@@ -2831,12 +2831,12 @@ msgstr ""
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1242
+#: lib/abuuba_web/live/settings_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
@@ -2851,7 +2851,7 @@ msgstr ""
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2136
+#: lib/abuuba_web/live/settings_live.ex:2137
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1253
+#: lib/abuuba_web/live/settings_live.ex:1254
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
@@ -2891,12 +2891,12 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2108
+#: lib/abuuba_web/live/settings_live.ex:2109
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1237
+#: lib/abuuba_web/live/settings_live.ex:1238
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
@@ -2906,7 +2906,7 @@ msgstr ""
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1260
+#: lib/abuuba_web/live/settings_live.ex:1261
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
@@ -2936,7 +2936,7 @@ msgstr ""
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1274
+#: lib/abuuba_web/live/settings_live.ex:1275
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take it back"
 msgstr ""
@@ -2951,12 +2951,12 @@ msgstr ""
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1258
+#: lib/abuuba_web/live/settings_live.ex:1259
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1249
+#: lib/abuuba_web/live/settings_live.ex:1250
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What it is for"
 msgstr ""
@@ -2977,7 +2977,7 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1280
+#: lib/abuuba_web/live/settings_live.ex:1281
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
@@ -2987,7 +2987,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2088
+#: lib/abuuba_web/live/settings_live.ex:2089
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3101,9 +3101,9 @@ msgstr ""
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:204
-#: lib/abuuba_web/live/home_live.ex:337
-#: lib/abuuba_web/live/profile_live.ex:518
+#: lib/abuuba_web/live/explore_live.ex:208
+#: lib/abuuba_web/live/home_live.ex:338
+#: lib/abuuba_web/live/profile_live.ex:529
 #: lib/abuuba_web/live/search_live.ex:195
 #: lib/abuuba_web/live/status_live.ex:185
 #: lib/abuuba_web/live/tag_live.ex:153
@@ -3126,245 +3126,245 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr "This account has been disabled. Contact the moderators."
 
-#: lib/abuuba_web/live/settings_live.ex:1987
+#: lib/abuuba_web/live/settings_live.ex:1988
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1978
+#: lib/abuuba_web/live/settings_live.ex:1979
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1894
+#: lib/abuuba_web/live/settings_live.ex:1895
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2051
+#: lib/abuuba_web/live/settings_live.ex:2052
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1875
+#: lib/abuuba_web/live/settings_live.ex:1876
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2110
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1900
+#: lib/abuuba_web/live/settings_live.ex:1901
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2139
+#: lib/abuuba_web/live/settings_live.ex:2140
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2076
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2047
+#: lib/abuuba_web/live/settings_live.ex:2048
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2062
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2063
+#: lib/abuuba_web/live/settings_live.ex:2068
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2064
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2066
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1884
+#: lib/abuuba_web/live/settings_live.ex:1885
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2072
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1881
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1889
+#: lib/abuuba_web/live/settings_live.ex:1890
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2078
+#: lib/abuuba_web/live/settings_live.ex:2079
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2080
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2082
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2085
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2083
 #, elixir-autogen, elixir-format, fuzzy
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1045
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:1934
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1040
+#: lib/abuuba_web/live/settings_live.ex:1041
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1951
+#: lib/abuuba_web/live/settings_live.ex:1952
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1050
+#: lib/abuuba_web/live/settings_live.ex:1051
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1038
+#: lib/abuuba_web/live/settings_live.ex:1039
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1007
+#: lib/abuuba_web/live/settings_live.ex:1008
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1964
+#: lib/abuuba_web/live/settings_live.ex:1965
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1941
+#: lib/abuuba_web/live/settings_live.ex:1942
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1064
-#: lib/abuuba_web/live/settings_live.ex:1913
-#: lib/abuuba_web/live/settings_live.ex:2244
+#: lib/abuuba_web/live/settings_live.ex:1065
+#: lib/abuuba_web/live/settings_live.ex:1914
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1034
+#: lib/abuuba_web/live/settings_live.ex:1035
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1018
+#: lib/abuuba_web/live/settings_live.ex:1019
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2037
+#: lib/abuuba_web/live/settings_live.ex:2038
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1002
+#: lib/abuuba_web/live/settings_live.ex:1003
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1937
+#: lib/abuuba_web/live/settings_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2027
+#: lib/abuuba_web/live/settings_live.ex:2028
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2038
+#: lib/abuuba_web/live/settings_live.ex:2039
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1915
+#: lib/abuuba_web/live/settings_live.ex:1916
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1028
+#: lib/abuuba_web/live/settings_live.ex:1029
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1000
+#: lib/abuuba_web/live/settings_live.ex:1001
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1930
+#: lib/abuuba_web/live/settings_live.ex:1931
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2033
+#: lib/abuuba_web/live/settings_live.ex:2034
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
@@ -3374,27 +3374,27 @@ msgstr ""
 msgid "No such post here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:244
+#: lib/abuuba_web/live/settings_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:782
+#: lib/abuuba_web/live/settings_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:795
+#: lib/abuuba_web/live/settings_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:779
+#: lib/abuuba_web/live/settings_live.ex:780
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1514
+#: lib/abuuba_web/live/settings_live.ex:1515
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
@@ -3404,54 +3404,54 @@ msgstr ""
 msgid "Why they want to join:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:307
+#: lib/abuuba_web/live/settings_live.ex:308
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:324
+#: lib/abuuba_web/live/settings_live.ex:325
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:327
+#: lib/abuuba_web/live/settings_live.ex:328
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feature it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:298
+#: lib/abuuba_web/live/settings_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:300
+#: lib/abuuba_web/live/settings_live.ex:301
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1497
+#: lib/abuuba_web/live/settings_live.ex:1498
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:331
+#: lib/abuuba_web/live/settings_live.ex:332
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1491
+#: lib/abuuba_web/live/settings_live.ex:1492
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:482
+#: lib/abuuba_web/live/settings_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:484
+#: lib/abuuba_web/live/settings_live.ex:485
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
@@ -3481,29 +3481,29 @@ msgstr ""
 msgid "This is not a memorial"
 msgstr ""
 
-#: lib/abuuba_web/live/collection_live.ex:64
+#: lib/abuuba_web/live/collection_live.ex:63
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} account"
 msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/collection_live.ex:112
+#: lib/abuuba_web/live/collection_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "A collection by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/collection_live.ex:60
+#: lib/abuuba_web/live/collection_live.ex:59
 #, elixir-autogen, elixir-format
 msgid "By"
 msgstr ""
 
-#: lib/abuuba_web/live/collection_live.ex:52
+#: lib/abuuba_web/live/collection_live.ex:51
 #, elixir-autogen, elixir-format
 msgid "Collection"
 msgstr ""
 
-#: lib/abuuba_web/live/collection_live.ex:87
+#: lib/abuuba_web/live/collection_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Nobody is on this list yet."
 msgstr ""
@@ -3599,7 +3599,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr ""
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:645
+#: lib/abuuba_web/live/settings_live.ex:646
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email updates"
 msgstr ""
@@ -3614,7 +3614,7 @@ msgstr ""
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:663
+#: lib/abuuba_web/live/settings_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr ""
@@ -3624,7 +3624,7 @@ msgstr ""
 msgid "No, remove my address"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:665
+#: lib/abuuba_web/live/settings_live.ex:666
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3677,7 +3677,7 @@ msgstr ""
 msgid "Let people collect email addresses for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:647
+#: lib/abuuba_web/live/settings_live.ex:648
 #, elixir-autogen, elixir-format, fuzzy
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr ""
@@ -3825,75 +3825,75 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1077
+#: lib/abuuba_web/live/settings_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2251
+#: lib/abuuba_web/live/settings_live.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:810
-#: lib/abuuba_web/live/settings_live.ex:2245
+#: lib/abuuba_web/live/settings_live.ex:811
+#: lib/abuuba_web/live/settings_live.ex:2246
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2242
+#: lib/abuuba_web/live/settings_live.ex:2243
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2246
+#: lib/abuuba_web/live/settings_live.ex:2247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1119
+#: lib/abuuba_web/live/settings_live.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2253
+#: lib/abuuba_web/live/settings_live.ex:2254
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1102
+#: lib/abuuba_web/live/settings_live.ex:1103
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2110
+#: lib/abuuba_web/live/settings_live.ex:2111
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2243
+#: lib/abuuba_web/live/settings_live.ex:2244
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1066
+#: lib/abuuba_web/live/settings_live.ex:1067
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1387
+#: lib/abuuba_web/live/settings_live.ex:1388
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1084
+#: lib/abuuba_web/live/settings_live.ex:1085
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2252
+#: lib/abuuba_web/live/settings_live.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3913,13 +3913,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2250
+#: lib/abuuba_web/live/settings_live.ex:2251
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1108
-#: lib/abuuba_web/live/settings_live.ex:1393
+#: lib/abuuba_web/live/settings_live.ex:1109
+#: lib/abuuba_web/live/settings_live.ex:1394
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3929,7 +3929,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1079
+#: lib/abuuba_web/live/settings_live.ex:1080
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3939,67 +3939,67 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1158
+#: lib/abuuba_web/live/settings_live.ex:1159
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1156
+#: lib/abuuba_web/live/settings_live.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1122
+#: lib/abuuba_web/live/settings_live.ex:1123
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1061
+#: lib/abuuba_web/live/settings_live.ex:1062
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1139
+#: lib/abuuba_web/live/settings_live.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1420
+#: lib/abuuba_web/live/settings_live.ex:1421
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1417
+#: lib/abuuba_web/live/settings_live.ex:1418
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1129
+#: lib/abuuba_web/live/settings_live.ex:1130
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1413
+#: lib/abuuba_web/live/settings_live.ex:1414
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1144
+#: lib/abuuba_web/live/settings_live.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1124
+#: lib/abuuba_web/live/settings_live.ex:1125
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1134
+#: lib/abuuba_web/live/settings_live.ex:1135
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
@@ -4009,7 +4009,7 @@ msgstr ""
 msgid "A post"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:390
+#: lib/abuuba_web/live/profile_live.ex:399
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nobody yet."
 msgstr ""
@@ -4019,7 +4019,7 @@ msgstr ""
 msgid "Public posts tagged #%{tag}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:367
+#: lib/abuuba_web/live/profile_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr ""
@@ -4045,99 +4045,99 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1449
+#: lib/abuuba_web/live/settings_live.ex:1450
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:914
+#: lib/abuuba_web/live/settings_live.ex:915
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:523
+#: lib/abuuba_web/live/settings_live.ex:524
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:532
+#: lib/abuuba_web/live/settings_live.ex:533
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:551
+#: lib/abuuba_web/live/settings_live.ex:552
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:578
+#: lib/abuuba_web/live/settings_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:567
+#: lib/abuuba_web/live/settings_live.ex:568
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:563
+#: lib/abuuba_web/live/settings_live.ex:564
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:937
+#: lib/abuuba_web/live/settings_live.ex:938
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:520
+#: lib/abuuba_web/live/settings_live.ex:521
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:933
+#: lib/abuuba_web/live/settings_live.ex:934
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:525
+#: lib/abuuba_web/live/settings_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:589
+#: lib/abuuba_web/live/settings_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:500
+#: lib/abuuba_web/live/settings_live.ex:501
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:912
+#: lib/abuuba_web/live/settings_live.ex:913
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:922
+#: lib/abuuba_web/live/settings_live.ex:923
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:922
+#: lib/abuuba_web/live/settings_live.ex:923
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signed in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:514
+#: lib/abuuba_web/live/settings_live.ex:515
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:502
+#: lib/abuuba_web/live/settings_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr ""
@@ -4949,124 +4949,124 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2220
+#: lib/abuuba_web/live/settings_live.ex:2221
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2221
+#: lib/abuuba_web/live/settings_live.ex:2222
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:346
+#: lib/abuuba_web/live/settings_live.ex:347
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:565
-#: lib/abuuba_web/live/settings_live.ex:364
+#: lib/abuuba_web/live/settings_live.ex:365
 #, elixir-autogen, elixir-format, fuzzy
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2061
+#: lib/abuuba_web/live/settings_live.ex:2062
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One picture at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:344
+#: lib/abuuba_web/live/settings_live.ex:345
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:396
+#: lib/abuuba_web/live/settings_live.ex:397
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2059
-#: lib/abuuba_web/live/settings_live.ex:2214
+#: lib/abuuba_web/live/settings_live.ex:2060
+#: lib/abuuba_web/live/settings_live.ex:2215
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2209
-#: lib/abuuba_web/live/settings_live.ex:2216
+#: lib/abuuba_web/live/settings_live.ex:2210
+#: lib/abuuba_web/live/settings_live.ex:2217
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:164
+#: lib/abuuba_web/live/profile_live.ex:173
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:313
-#: lib/abuuba_web/live/profile_live.ex:317
+#: lib/abuuba_web/live/profile_live.ex:322
+#: lib/abuuba_web/live/profile_live.ex:326
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Featured accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:182
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:544
+#: lib/abuuba_web/live/profile_live.ex:555
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:267
+#: lib/abuuba_web/live/profile_live.ex:276
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:680
+#: lib/abuuba_web/live/settings_live.ex:681
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:270
+#: lib/abuuba_web/live/profile_live.ex:279
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:705
+#: lib/abuuba_web/live/settings_live.ex:706
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send it"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:286
+#: lib/abuuba_web/live/profile_live.ex:295
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:714
+#: lib/abuuba_web/live/settings_live.ex:715
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:691
-#: lib/abuuba_web/live/settings_live.ex:1788
+#: lib/abuuba_web/live/settings_live.ex:692
+#: lib/abuuba_web/live/settings_live.ex:1789
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:547
+#: lib/abuuba_web/live/profile_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1368
+#: lib/abuuba_web/live/settings_live.ex:1369
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5076,17 +5076,17 @@ msgstr ""
 msgid "To stop them, open this link:"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:534
+#: lib/abuuba_web/live/profile_live.ex:545
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:698
+#: lib/abuuba_web/live/settings_live.ex:699
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:678
+#: lib/abuuba_web/live/settings_live.ex:679
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr ""
@@ -5096,22 +5096,22 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1373
+#: lib/abuuba_web/live/settings_live.ex:1374
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:288
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1789
+#: lib/abuuba_web/live/settings_live.ex:1790
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:721
+#: lib/abuuba_web/live/settings_live.ex:722
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr ""
@@ -5397,7 +5397,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:960
+#: lib/abuuba_web/live/settings_live.ex:961
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5545,22 +5545,22 @@ msgstr ""
 msgid "not offered"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:236
+#: lib/abuuba_web/live/profile_live.ex:245
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:234
+#: lib/abuuba_web/live/profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:213
+#: lib/abuuba_web/live/profile_live.ex:222
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr ""
@@ -5585,47 +5585,47 @@ msgstr ""
 msgid "Unmute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:450
+#: lib/abuuba_web/live/notifications_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:228
+#: lib/abuuba_web/live/profile_live.ex:237
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:369
+#: lib/abuuba_web/live/notifications_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:373
+#: lib/abuuba_web/live/notifications_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:371
+#: lib/abuuba_web/live/notifications_live.ex:372
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} signed up"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:362
+#: lib/abuuba_web/live/notifications_live.ex:363
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:358
+#: lib/abuuba_web/live/notifications_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:366
+#: lib/abuuba_web/live/notifications_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:445
+#: lib/abuuba_web/live/notifications_live.ex:446
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quotes"
 msgstr ""
@@ -5749,22 +5749,22 @@ msgstr ""
 msgid "Who may read the blocklist"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:635
+#: lib/abuuba_web/live/settings_live.ex:636
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:627
+#: lib/abuuba_web/live/settings_live.ex:628
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:839
+#: lib/abuuba_web/live/settings_live.ex:840
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Block a server"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:812
+#: lib/abuuba_web/live/settings_live.ex:813
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr ""
@@ -5774,8 +5774,8 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:144
-#: lib/abuuba_web/live/profile_live.ex:585
+#: lib/abuuba_web/live/explore_live.ex:148
+#: lib/abuuba_web/live/profile_live.ex:596
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
@@ -5840,8 +5840,23 @@ msgstr ""
 msgid "Warned"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2234
-#: lib/abuuba_web/live/settings_live.ex:2237
+#: lib/abuuba_web/live/settings_live.ex:2235
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
+msgstr ""
+
+#: lib/abuuba_web/live/profile_live.ex:155
+#, elixir-autogen, elixir-format
+msgid "Cancel follow request"
+msgstr ""
+
+#: lib/abuuba_web/live/explore_live.ex:117
+#, elixir-autogen, elixir-format
+msgid "Requested"
+msgstr ""
+
+#: lib/abuuba_web/live/profile_live.ex:606
+#, elixir-autogen, elixir-format
+msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -654,7 +654,7 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:243
 #: lib/abuuba_web/components/layouts.ex:252
-#: lib/abuuba_web/live/explore_live.ex:50
+#: lib/abuuba_web/live/explore_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr ""
@@ -688,7 +688,7 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:233
 #: lib/abuuba_web/live/notification_settings_live.ex:31
-#: lib/abuuba_web/live/notifications_live.ex:57
+#: lib/abuuba_web/live/notifications_live.ex:59
 #: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Notifications"
@@ -902,7 +902,7 @@ msgid "Ends after"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/profile_live.ex:866
+#: lib/abuuba_web/live/profile_live.ex:804
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
@@ -1204,24 +1204,24 @@ msgstr ""
 msgid "%{name} on %{server}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:301
+#: lib/abuuba_web/live/profile_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:113
-#: lib/abuuba_web/live/profile_live.ex:146
-#: lib/abuuba_web/live/tag_live.ex:64
+#: lib/abuuba_web/live/explore_live.ex:112
+#: lib/abuuba_web/live/profile_live.ex:144
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:95
+#: lib/abuuba_web/live/profile_live.ex:93
 #, elixir-autogen, elixir-format
 msgid "Go to the new account"
 msgstr ""
@@ -1231,43 +1231,43 @@ msgstr ""
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:865
+#: lib/abuuba_web/live/profile_live.ex:803
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:372
+#: lib/abuuba_web/live/profile_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:347
-#: lib/abuuba_web/live/profile_live.ex:348
+#: lib/abuuba_web/live/profile_live.ex:345
+#: lib/abuuba_web/live/profile_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:304
-#: lib/abuuba_web/live/profile_live.ex:863
+#: lib/abuuba_web/live/explore_live.ex:248
+#: lib/abuuba_web/live/profile_live.ex:801
+#: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
-#: lib/abuuba_web/live/search_live.ex:122
-#: lib/abuuba_web/live/search_live.ex:264
+#: lib/abuuba_web/live/search_live.ex:208
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:864
+#: lib/abuuba_web/live/profile_live.ex:802
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:944
-#: lib/abuuba_web/live/profile_live.ex:305
+#: lib/abuuba_web/live/profile_live.ex:303
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr ""
@@ -1277,24 +1277,24 @@ msgstr ""
 msgid "That server could not be reached, so this is all there is."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:92
+#: lib/abuuba_web/live/profile_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "This account has moved to %{handle}."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:198
+#: lib/abuuba_web/live/profile_live.ex:196
 #: lib/abuuba_web/live/settings_live.ex:827
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:164
-#: lib/abuuba_web/live/tag_live.ex:64
+#: lib/abuuba_web/live/profile_live.ex:162
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:190
+#: lib/abuuba_web/live/profile_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Unmute"
 msgstr ""
@@ -1304,109 +1304,109 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:309
-#: lib/abuuba_web/live/search_live.ex:90
+#: lib/abuuba_web/live/profile_live.ex:307
+#: lib/abuuba_web/live/search_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "What to show"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:84
+#: lib/abuuba_web/live/notifications_live.ex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:134
+#: lib/abuuba_web/live/notifications_live.ex:151
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:381
+#: lib/abuuba_web/live/notifications_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:385
+#: lib/abuuba_web/live/notifications_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:392
+#: lib/abuuba_web/live/notifications_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:395
+#: lib/abuuba_web/live/notifications_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:119
+#: lib/abuuba_web/live/notifications_live.ex:136
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:399
+#: lib/abuuba_web/live/notifications_live.ex:416
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:348
+#: lib/abuuba_web/live/notifications_live.ex:365
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:346
+#: lib/abuuba_web/live/notifications_live.ex:363
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} boosted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:351
+#: lib/abuuba_web/live/notifications_live.ex:368
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:349
+#: lib/abuuba_web/live/notifications_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:347
+#: lib/abuuba_web/live/notifications_live.ex:364
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:345
+#: lib/abuuba_web/live/notifications_live.ex:362
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:352
+#: lib/abuuba_web/live/notifications_live.ex:369
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} posted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:353
+#: lib/abuuba_web/live/notifications_live.ex:370
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:350
+#: lib/abuuba_web/live/notifications_live.ex:367
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr ""
@@ -1431,7 +1431,7 @@ msgstr ""
 msgid "Accounts made very recently"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:431
+#: lib/abuuba_web/live/notifications_live.ex:448
 #, elixir-autogen, elixir-format, fuzzy
 msgid "All"
 msgstr ""
@@ -1461,17 +1461,17 @@ msgstr ""
 msgid "Automated accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:440
+#: lib/abuuba_web/live/notifications_live.ex:457
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Boosts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:112
+#: lib/abuuba_web/live/notifications_live.ex:129
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:179
+#: lib/abuuba_web/live/notifications_live.ex:196
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -1481,12 +1481,12 @@ msgstr ""
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:445
+#: lib/abuuba_web/live/notifications_live.ex:462
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edits"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:443
+#: lib/abuuba_web/live/notifications_live.ex:460
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Favourites"
 msgstr ""
@@ -1496,13 +1496,13 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:442
+#: lib/abuuba_web/live/notifications_live.ex:459
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:441
-#: lib/abuuba_web/live/profile_live.ex:867
+#: lib/abuuba_web/live/notifications_live.ex:458
+#: lib/abuuba_web/live/profile_live.ex:805
 #: lib/abuuba_web/live/settings_live.ex:2104
 #: lib/abuuba_web/live/settings_live.ex:2242
 #, elixir-autogen, elixir-format, fuzzy
@@ -1519,28 +1519,28 @@ msgstr ""
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:148
+#: lib/abuuba_web/live/notifications_live.ex:165
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:108
+#: lib/abuuba_web/live/notifications_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:431
-#: lib/abuuba_web/live/notifications_live.ex:439
+#: lib/abuuba_web/live/notifications_live.ex:448
+#: lib/abuuba_web/live/notifications_live.ex:456
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:157
+#: lib/abuuba_web/live/notifications_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:193
+#: lib/abuuba_web/live/notifications_live.ex:210
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing has happened yet."
 msgstr ""
@@ -1555,7 +1555,7 @@ msgstr ""
 msgid "People you do not follow"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:444
+#: lib/abuuba_web/live/notifications_live.ex:461
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Polls"
 msgstr ""
@@ -1571,7 +1571,7 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1587
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:264
+#: lib/abuuba_web/live/profile_live.ex:262
 #: lib/abuuba_web/live/settings_live.ex:295
 #: lib/abuuba_web/live/settings_live.ex:389
 #: lib/abuuba_web/live/settings_live.ex:426
@@ -1591,8 +1591,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:343
-#: lib/abuuba_web/live/notifications_live.ex:408
+#: lib/abuuba_web/live/notifications_live.ex:360
+#: lib/abuuba_web/live/notifications_live.ex:425
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Somebody"
 msgstr ""
@@ -1602,7 +1602,7 @@ msgstr ""
 msgid "Somebody a moderator here has already restricted."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:378
+#: lib/abuuba_web/live/notifications_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr ""
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "That could not be saved. Try again."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:73
+#: lib/abuuba_web/live/notifications_live.ex:90
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr ""
@@ -1622,7 +1622,7 @@ msgstr ""
 msgid "Who can reach you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:126
+#: lib/abuuba_web/live/notifications_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr ""
@@ -1633,22 +1633,22 @@ msgstr ""
 msgid "unread"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:67
+#: lib/abuuba_web/live/search_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "A name, a #tag, or some words"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2277
 #: lib/abuuba_web/live/admin_live.ex:3587
-#: lib/abuuba_web/live/search_live.ex:261
+#: lib/abuuba_web/live/search_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:305
+#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
-#: lib/abuuba_web/live/search_live.ex:113
-#: lib/abuuba_web/live/search_live.ex:263
+#: lib/abuuba_web/live/search_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Hashtags"
 msgstr ""
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Look around first"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:76
+#: lib/abuuba_web/live/search_live.ex:75
 #, elixir-autogen, elixir-format
 msgid "Narrowing a search"
 msgstr ""
@@ -1673,25 +1673,25 @@ msgstr ""
 msgid "Nobody has posted publicly here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/tag_live.ex:79
+#: lib/abuuba_web/live/tag_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:123
+#: lib/abuuba_web/live/explore_live.ex:122
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:133
+#: lib/abuuba_web/live/search_live.ex:132
 #, elixir-autogen, elixir-format
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:306
+#: lib/abuuba_web/live/explore_live.ex:250
+#: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
-#: lib/abuuba_web/live/search_live.ex:103
-#: lib/abuuba_web/live/search_live.ex:262
+#: lib/abuuba_web/live/search_live.ex:206
 #, elixir-autogen, elixir-format
 msgid "People"
 msgstr ""
@@ -1718,9 +1718,9 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:244
 #: lib/abuuba_web/components/layouts.ex:253
-#: lib/abuuba_web/live/search_live.ex:40
-#: lib/abuuba_web/live/search_live.ex:62
-#: lib/abuuba_web/live/search_live.ex:71
+#: lib/abuuba_web/live/search_live.ex:38
+#: lib/abuuba_web/live/search_live.ex:61
+#: lib/abuuba_web/live/search_live.ex:70
 #, elixir-autogen, elixir-format
 msgid "Search"
 msgstr ""
@@ -1730,27 +1730,27 @@ msgstr ""
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:65
+#: lib/abuuba_web/live/explore_live.ex:64
 #, elixir-autogen, elixir-format
 msgid "What to explore"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:271
+#: lib/abuuba_web/live/search_live.ex:215
 #, elixir-autogen, elixir-format
 msgid "posts by one person"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:272
+#: lib/abuuba_web/live/search_live.ex:216
 #, elixir-autogen, elixir-format
 msgid "posts carrying a picture or a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:274
+#: lib/abuuba_web/live/search_live.ex:218
 #, elixir-autogen, elixir-format
 msgid "posts newer than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/search_live.ex:273
+#: lib/abuuba_web/live/search_live.ex:217
 #, elixir-autogen, elixir-format
 msgid "posts older than a date"
 msgstr ""
@@ -2826,7 +2826,7 @@ msgstr ""
 msgid "What is trending now"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:77
+#: lib/abuuba_web/live/explore_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
@@ -3101,12 +3101,9 @@ msgstr ""
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:208
 #: lib/abuuba_web/live/home_live.ex:338
-#: lib/abuuba_web/live/profile_live.ex:529
-#: lib/abuuba_web/live/search_live.ex:195
+#: lib/abuuba_web/live/post_actions.ex:297
 #: lib/abuuba_web/live/status_live.ex:185
-#: lib/abuuba_web/live/tag_live.ex:153
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be translated just now."
 msgstr ""
@@ -4009,7 +4006,7 @@ msgstr ""
 msgid "A post"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:399
+#: lib/abuuba_web/live/profile_live.ex:397
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nobody yet."
 msgstr ""
@@ -4019,7 +4016,7 @@ msgstr ""
 msgid "Public posts tagged #%{tag}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:376
+#: lib/abuuba_web/live/profile_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr ""
@@ -5002,28 +4999,28 @@ msgstr ""
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:173
+#: lib/abuuba_web/live/profile_live.ex:171
 #, elixir-autogen, elixir-format
 msgid "Feature on my profile"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:322
-#: lib/abuuba_web/live/profile_live.ex:326
+#: lib/abuuba_web/live/profile_live.ex:320
+#: lib/abuuba_web/live/profile_live.ex:324
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Featured accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:182
+#: lib/abuuba_web/live/profile_live.ex:180
 #, elixir-autogen, elixir-format
 msgid "Stop featuring"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:555
+#: lib/abuuba_web/live/profile_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:276
+#: lib/abuuba_web/live/profile_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr ""
@@ -5033,7 +5030,7 @@ msgstr ""
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:279
+#: lib/abuuba_web/live/profile_live.ex:277
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
@@ -5043,7 +5040,7 @@ msgstr ""
 msgid "Send it"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:295
+#: lib/abuuba_web/live/profile_live.ex:293
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr ""
@@ -5061,7 +5058,7 @@ msgstr[1] ""
 msgid "Subject"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:558
+#: lib/abuuba_web/live/profile_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr ""
@@ -5076,7 +5073,7 @@ msgstr ""
 msgid "To stop them, open this link:"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:545
+#: lib/abuuba_web/live/profile_live.ex:483
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
@@ -5101,7 +5098,7 @@ msgstr ""
 msgid "You have sent as many messages as you can today."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:288
+#: lib/abuuba_web/live/profile_live.ex:286
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr ""
@@ -5545,22 +5542,22 @@ msgstr ""
 msgid "not offered"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:245
+#: lib/abuuba_web/live/profile_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:243
+#: lib/abuuba_web/live/profile_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:222
+#: lib/abuuba_web/live/profile_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:207
+#: lib/abuuba_web/live/profile_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr ""
@@ -5585,47 +5582,47 @@ msgstr ""
 msgid "Unmute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:451
+#: lib/abuuba_web/live/notifications_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:237
+#: lib/abuuba_web/live/profile_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:370
+#: lib/abuuba_web/live/notifications_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:374
+#: lib/abuuba_web/live/notifications_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:372
+#: lib/abuuba_web/live/notifications_live.ex:389
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} signed up"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:363
+#: lib/abuuba_web/live/notifications_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:359
+#: lib/abuuba_web/live/notifications_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:367
+#: lib/abuuba_web/live/notifications_live.ex:384
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:446
+#: lib/abuuba_web/live/notifications_live.ex:463
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quotes"
 msgstr ""
@@ -5774,8 +5771,8 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:148
-#: lib/abuuba_web/live/profile_live.ex:596
+#: lib/abuuba_web/live/explore_live.ex:147
+#: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
@@ -5846,17 +5843,17 @@ msgstr ""
 msgid "%{size} MB"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:155
+#: lib/abuuba_web/live/profile_live.ex:153
 #, elixir-autogen, elixir-format
 msgid "Cancel follow request"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:117
+#: lib/abuuba_web/live/explore_live.ex:116
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:606
+#: lib/abuuba_web/live/profile_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr ""

--- a/test/abuuba_web/post_actions_test.exs
+++ b/test/abuuba_web/post_actions_test.exs
@@ -16,6 +16,7 @@ defmodule AbuubaWeb.PostActionsTest do
   import Abuuba.StatusesFixtures
 
   alias Abuuba.Accounts.Auth
+  alias Abuuba.Notifications
   alias Abuuba.Statuses
 
   setup do
@@ -58,6 +59,17 @@ defmodule AbuubaWeb.PostActionsTest do
     ]
   end
 
+  # Notifications is the sixth screen and was the one nobody had listed: it
+  # drew the whole bar and answered none of it, because the source sweep next
+  # door had a hand-written list of screens and this was not on it. It takes a
+  # notification rather than just a post, so it does not fit `screens/1`.
+  defp notification_path(reader, author) do
+    status = status_fixture(%{account_id: author.id, text: "boosted at you"})
+    {:ok, _notification} = Notifications.notify(reader, author, "reblog", status_id: status.id)
+
+    {status, "/notifications"}
+  end
+
   describe "favouriting a post" do
     test "works on every screen that draws the button", %{
       conn: conn,
@@ -93,6 +105,44 @@ defmodule AbuubaWeb.PostActionsTest do
       |> render_click()
 
       refute Statuses.favourited?(viewer.id, status.id)
+    end
+  end
+
+  describe "the notifications screen" do
+    test "answers the bar it draws", %{conn: conn, user: user, viewer: viewer, author: author} do
+      {status, path} = notification_path(viewer, author)
+
+      {:ok, live, _html} = live(sign_in(conn, user), path)
+
+      live
+      |> element("button[phx-click='favourite'][phx-value-id='#{status.id}']")
+      |> render_click()
+
+      assert Statuses.favourited?(viewer.id, status.id),
+             "favouriting did nothing on the notifications screen"
+    end
+
+    test "and puts the post back where it keeps it", %{
+      conn: conn,
+      user: user,
+      viewer: viewer,
+      author: author
+    } do
+      {status, path} = notification_path(viewer, author)
+
+      {:ok, live, _html} = live(sign_in(conn, user), path)
+
+      html =
+        live
+        |> element("button[phx-click='boost'][phx-value-id='#{status.id}']")
+        |> render_click()
+
+      assert Statuses.boosted?(viewer.id, status.id)
+
+      # The post lives inside its notification group here rather than in a
+      # list, so this is the half that a shared put-back would have got wrong
+      # without saying so: the row has to redraw, not vanish.
+      assert html =~ "boosted at you"
     end
   end
 

--- a/test/abuuba_web/status_component_events_test.exs
+++ b/test/abuuba_web/status_component_events_test.exs
@@ -16,22 +16,19 @@ defmodule AbuubaWeb.StatusComponentEventsTest do
   thing, and the thing worth saying is a list-against-list comparison. It is
   the sweep from `CLAUDE.md` run on every commit instead of when somebody
   remembers.
+
+  ## The screen list is found, not written down
+
+  It used to be a literal list here, and the one screen missing from it was the
+  one with the bug: notifications drew the whole bar and answered none of it,
+  and this file said nothing because nobody had added it. So the screens are
+  now every LiveView that renders the component, and a new one is covered the
+  day it is written.
   """
   use ExUnit.Case, async: true
 
   @component "lib/abuuba_web/components/status_component.ex"
-
-  # The screens that render the component. `landing_live` is deliberately not
-  # here: it draws posts with `interactive: false`, which is the other half of
-  # the same rule -- a control that cannot work on a screen is not drawn on it.
-  @screens ~w(
-    home_live
-    profile_live
-    tag_live
-    search_live
-    explore_live
-    status_live
-  )
+  @live_dir "lib/abuuba_web/live"
 
   defp events_raised do
     @component
@@ -42,10 +39,26 @@ defmodule AbuubaWeb.StatusComponentEventsTest do
     |> Enum.sort()
   end
 
+  # Every LiveView that draws a post, whatever it is called.
+  defp screens do
+    @live_dir
+    |> File.ls!()
+    |> Enum.filter(&String.ends_with?(&1, ".ex"))
+    |> Enum.map(&Path.join(@live_dir, &1))
+    |> Enum.filter(&(&1 |> File.read!() |> String.contains?("<.status")))
+    |> Enum.sort()
+  end
+
+  # Three honest answers, and nothing else counts. Either the screen attaches
+  # the shared wiring, or it answers the event itself, or it does not draw the
+  # controls at all.
   defp answers?(source, event) do
-    String.contains?(source, ~s|handle_event("#{event}"|) or
+    String.contains?(source, "PostActions.attach(") or
+      String.contains?(source, ~s|handle_event("#{event}"|) or
       (event in ~w(favourite boost bookmark) and String.contains?(source, "@post_actions"))
   end
+
+  defp interactive?(source), do: not String.contains?(source, "interactive={false}")
 
   test "the component raises the events this expects" do
     # A canary on the list itself. A new button added to the component makes
@@ -54,16 +67,28 @@ defmodule AbuubaWeb.StatusComponentEventsTest do
     assert events_raised() == ~w(bookmark boost edit favourite reply translate vote)
   end
 
-  for screen <- @screens do
-    test "#{screen} answers all of them" do
-      path = "lib/abuuba_web/live/#{unquote(screen)}.ex"
-      source = File.read!(path)
+  test "every screen that draws a post is one this checked" do
+    # The list is derived, so this is the canary on the derivation: if the
+    # component is ever rendered through a wrapper and `<.status` stops
+    # appearing in the screens, the sweep above would pass by finding nothing.
+    found = Enum.map(screens(), &Path.basename/1)
 
-      missing = Enum.reject(events_raised(), &answers?(source, &1))
+    assert "home_live.ex" in found
+    assert "notifications_live.ex" in found
+    assert length(found) >= 6
+  end
 
-      assert missing == [],
-             "#{path} draws the action bar but never answers #{inspect(missing)}. " <>
-               "Its catch-all handle_event swallows them, so the buttons look live and do nothing."
-    end
+  test "every screen answers every event, or draws none of them" do
+    failures =
+      for path <- screens(),
+          source = File.read!(path),
+          interactive?(source),
+          missing = Enum.reject(events_raised(), &answers?(source, &1)),
+          missing != [],
+          do: "#{path} never answers #{inspect(missing)}"
+
+    assert failures == [],
+           "These screens draw the action bar and swallow the clicks in a catch-all, so the " <>
+             "buttons look live and do nothing:\n" <> Enum.join(failures, "\n")
   end
 end

--- a/test/abuuba_web/status_component_events_test.exs
+++ b/test/abuuba_web/status_component_events_test.exs
@@ -27,6 +27,8 @@ defmodule AbuubaWeb.StatusComponentEventsTest do
   """
   use ExUnit.Case, async: true
 
+  alias AbuubaWeb.PostActions
+
   @component "lib/abuuba_web/components/status_component.ex"
   @live_dir "lib/abuuba_web/live"
 
@@ -50,15 +52,33 @@ defmodule AbuubaWeb.StatusComponentEventsTest do
   end
 
   # Three honest answers, and nothing else counts. Either the screen attaches
-  # the shared wiring, or it answers the event itself, or it does not draw the
-  # controls at all.
+  # the shared wiring — and only for the events that wiring actually answers,
+  # which `PostActions.answers/0` states and the test below holds it to — or it
+  # answers the event itself, or it does not draw the controls at all.
   defp answers?(source, event) do
-    String.contains?(source, "PostActions.attach(") or
+    (String.contains?(source, "PostActions.attach(") and event in PostActions.answers()) or
       String.contains?(source, ~s|handle_event("#{event}"|) or
       (event in ~w(favourite boost bookmark) and String.contains?(source, "@post_actions"))
   end
 
-  defp interactive?(source), do: not String.contains?(source, "interactive={false}")
+  # Scoped to the render it sits on, not to the file. `interactive={false}`
+  # anywhere would otherwise excuse a whole screen from the sweep, which is the
+  # unscoped-exemption shape: the day a screen draws one inert post beside live
+  # ones, it would leave this check silently. A screen is exempt only when
+  # every post it draws is inert.
+  defp interactive?(source) do
+    ~r/<\.status\b[^>]*?\/>/s
+    |> Regex.scan(source)
+    |> Enum.map(fn [tag] -> tag end)
+    |> Enum.any?(&(not String.contains?(&1, "interactive={false}")))
+  end
+
+  test "the shared wiring answers exactly what the component raises" do
+    # The other half of `answers?/2` above. Attaching the hook is only a
+    # truthful answer for as long as the hook answers everything, so the two
+    # lists are compared rather than assumed to match.
+    assert PostActions.answers() == events_raised()
+  end
 
   test "the component raises the events this expects" do
     # A canary on the list itself. A new button added to the component makes


### PR DESCRIPTION
A whole-app `/simplify` pass: eight review agents over `lib/`, findings applied where they were contained enough to belong in a cleanup.

**Bugs it turned up.** Search's translate button raised on every result, writing to an assign that screen never had. Notifications drew the full action bar and answered none of it. Saving privacy settings reloaded the profile section. Eleven modules parsed ids with `Integer.parse`, so an oversized id reached Postgres as an encode error instead of a 404. Web push put raw HTML on the lock screen for posts from other servers.

**The rest is duplication.** ~270 lines of `PostActions` wiring collapsed to one hook, and the source sweep meant to catch that now derives its own screen list — a hand-written one is why notifications was missed.

Deeper findings, mostly around reader-visibility, are recorded but not attempted here: they change what readers see and want issues and tests.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01VHhyg2m8KLtTaru8JvnQQS
