### PR TITLE
Say on the homepage that agents wrote it

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -174,6 +174,21 @@ bin/abuuba eval 'Abuuba.Release.import_mastodon()'</pre>
 
   <section class="band">
     <div class="wrap reveal">
+      <h2>Written with <em>agents</em>.</h2>
+      <p>One person built this, and that sentence is only honest with the next one: it was written with AI coding agents, every day, at a volume I could not have typed. Better said plainly than left for somebody to work out.</p>
+      <p>The speed is the least interesting part of it. What changed is that the tedious correct thing now happens every time, including on the days I would have talked myself out of it.</p>
+      <ul class="nots">
+        <li><b>4,387 tests</b>, written before the code rather than after it. "Test first" is a rule an agent keeps and a tired human negotiates with.</li>
+        <li><b>32 federation scenarios</b> driven against real Mastodon and GoToSocial containers every night. Nobody enjoys writing the twenty-ninth one.</li>
+        <li><b>Ten user-guide pages and ten German translations of them.</b> A page changes in the same commit as the behaviour it describes, or the commit does not land.</li>
+      </ul>
+      <p>What it still needs me for: deciding what to build, what to refuse, and which of two working designs is the one to keep. An agent will do the wrong thing thoroughly and cheerfully. Every architectural call here is mine, and so is every mistake.</p>
+      <p>And it says so. Text an agent wrote in my name carries a line telling you it did, in commit messages, issues and pull requests. I would rather that be visible than tasteful.</p>
+    </div>
+  </section>
+
+  <section class="band">
+    <div class="wrap reveal">
       <h2>Not here to kill Mastodon. <em>To push it.</em></h2>
       <blockquote class="quote">
         <p>This is the <a href="https://nginx.org">nginx</a> and <a href="https://httpd.apache.org">Apache</a> story. Apache was good software and still is; nginx turned up because a different shape of load arrived and an architecture built for the older one could not bend that far. The part worth remembering is what happened next: nginx did not kill Apache, it made Apache faster and better.</p>

--- a/site/press.html
+++ b/site/press.html
@@ -84,7 +84,7 @@
           <dt>Client API</dt><dd>All 289 endpoints Mastodon 4.6 declares under <code>/api/v1</code> and <code>/api/v2</code></dd>
           <dt>Federation</dt><dd>Tested against Mastodon 4.4.7 and GoToSocial 0.19.1 in Docker, 32 scenarios</dd>
           <dt>Migration</dt><dd>Takes over a Mastodon instance in place, on the same domain, with one command against the old database</dd>
-          <dt>Size</dt><dd>About 84,000 lines of application code, 4,347 tests, 364 lines of JavaScript, no npm dependencies</dd>
+          <dt>Size</dt><dd>About 84,000 lines of application code, 4,387 tests, 364 lines of JavaScript, no npm dependencies</dd>
           <dt>Author</dt><dd>Stefan Wintermeyer, Koblenz, Germany</dd>
           <dt>Source</dt><dd><a href="https://github.com/wintermeyer/abuuba">github.com/wintermeyer/abuuba</a></dd>
           <dt>Website</dt><dd><a href="https://abuuba.com/">abuuba.com</a></dd>


### PR DESCRIPTION
**TL;DR** The homepage says nothing about how the code got written. This adds a section between "Why abuuba exists" and "Not here to kill Mastodon", so the *how* follows the *why*.

**Where:** `site/index.html`, one new `band` section.

The argument is that the speed is the least interesting part, and that what changed is the tedious correct thing happening every time. Its three numbers were counted, not quoted: 4,387 tests (`mix precommit`), 32 scenarios (`test/interop/scenarios`), ten `docs/user/` pages against ten in `docs/de/user/`. It also says where a human is still needed, and why agent-written text here carries a line saying so.

`site/press.html` said 4,347 tests, which was stale by forty; both pages now agree.

Checked in Chrome, no console errors.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014Q5hWq8iFZRhXnaHAQK3Yi
