### PR TITLE
Call abuuba a drop-in replacement in the hero lede

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -37,7 +37,7 @@
       <div class="hero-grid">
         <div>
           <h1>The cheetah that outran the mastodon.</h1>
-          <p class="lede">abuuba is a fediverse server written in <a href="https://elixir-lang.org">Elixir</a> and <a href="https://www.phoenixframework.org">Phoenix</a>. It speaks <a href="https://joinmastodon.org">Mastodon</a>'s protocols: ActivityPub for federation and the complete Mastodon client API, all 289 endpoints, so existing apps work unchanged. It does what a Mastodon instance does, which means it can replace one, keeping the domain, the accounts and the posts. It exists for one reason: <strong>Mastodon is too slow.</strong></p>
+          <p class="lede">abuuba is a fediverse server written in <a href="https://elixir-lang.org">Elixir</a> and <a href="https://www.phoenixframework.org">Phoenix</a>. It speaks <a href="https://joinmastodon.org">Mastodon</a>'s protocols: ActivityPub for federation and the complete Mastodon client API, all 289 endpoints, so existing apps work unchanged. Think of it as a drop-in replacement for Mastodon. It takes an instance over in place, keeping the domain, the accounts, the posts and the tokens on people's phones. It exists for one reason: <strong>Mastodon is too slow.</strong></p>
         </div>
         <div class="giant" aria-live="polite">
           <span class="giant-num" id="giant-num">68<span class="times">×</span></span>


### PR DESCRIPTION
**TL;DR** The hero lede left the reader to work out that abuuba substitutes for Mastodon. It now says so.

**Where:** `site/index.html`, the `p.lede` in the hero.

**Now:** "It does what a Mastodon instance does, which means it can replace one, keeping the domain, the accounts and the posts."
**Want:** "Think of it as a drop-in replacement for Mastodon. It takes an instance over in place, keeping the domain, the accounts, the posts and the tokens on people's phones."

Replaced rather than added, because the two sentences would have made the same point twice. The tokens are a real claim: the importer copies OAuth access tokens, so a migration does not sign anybody out.

Checked in Chrome, no console errors.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014Q5hWq8iFZRhXnaHAQK3Yi
