### PR TITLE
Say what 1,428 npm packages actually cost

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -90,6 +90,7 @@
         <div class="big a"><span class="n num">364</span><span class="l"><b>abuuba</b> · lines of JavaScript · 0 npm dependencies</span></div>
         <div class="big"><span class="n num">97,209</span><span class="l"><b>Mastodon</b> · lines of JavaScript · 1,428 lockfile entries</span></div>
       </div>
+      <p>Every one of those 1,428 packages is code written by somebody you have never heard of, and any one of them can turn out to be a timebomb. You install one thing, it quietly brings a hundred more, nobody reads any of them, and the day one goes off it is already running in your users' browsers. Less JavaScript is simply safer, and the safest of all is the JavaScript that was never there.</p>
     </div>
   </section>
 


### PR DESCRIPTION
**TL;DR** "The same story, told in JavaScript" showed 364 lines against 97,209 and 1,428 lockfile entries, then stopped. One paragraph now says what those 1,428 cost.

**Where:** `site/index.html`, under the number pair.

> Every one of those 1,428 packages is code written by somebody you have never heard of, and any one of them can turn out to be a timebomb. You install one thing, it quietly brings a hundred more, nobody reads any of them, and the day one goes off it is already running in your users' browsers. Less JavaScript is simply safer, and the safest of all is the JavaScript that was never there.

Plain words on purpose: no lockfiles, no maintainer credentials, no supply-chain vocabulary. Everybody already knows this one, so the jargon only gets in the way. The single number is the 1,428 already on the page; nothing new is claimed.

Checked in Chrome, no console errors.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_014Q5hWq8iFZRhXnaHAQK3Yi
