### PR TITLE
Give the pages the controls the API already had

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ instead, and went with abuuba.
 
 ## Not for the faint of heart
 
-abuuba is version 1.0.1 and has never served real members on the open internet.
+abuuba is version 1.0.2 and has never served real members on the open internet.
 Every number above is measured and reproducible. None of it has been tested by
 anyone but me.
 

--- a/docs/admin/account-actions.md
+++ b/docs/admin/account-actions.md
@@ -12,12 +12,18 @@
 | `suspend` | Hidden from everybody, data purged after a grace window; the owner cannot sign in either |
 
 Disabling and suspending both end the sessions and app tokens the account
-already had, so the decision takes effect on the next request rather than the
-next time somebody signs out. Every request checks in any case -- an account
-that is suspended or disabled is refused by the API and by the pages here
-alike -- but a session token that still works is a live credential, and
-revoking the app tokens is also what closes a streaming connection, which
-authenticates once when it connects.
+already had, so the decision takes effect at once rather than the next time
+somebody signs out. Every request checks in any case -- an account that is
+suspended or disabled is refused by the API and by the pages here alike -- but
+a session token that still works is a live credential, and revoking the app
+tokens is also what closes a streaming connection, which authenticates once
+when it connects.
+
+Pages this server had already drawn are closed too. They are LiveViews, which
+read the session once when they open and hold the answer for as long as the
+browser stays on them, so a page left open was the one place a decision did not
+reach: it went on working, compose box and all, until somebody reloaded. Ending
+the sessions now sends every open page back to the sign-in screen.
 
 `none` is a real action, not a placeholder. Telling somebody is a moderation
 decision, and the most common one.

--- a/docs/de/user/beitraege.md
+++ b/docs/de/user/beitraege.md
@@ -240,7 +240,9 @@ wenn es aus demselben Thread gewachsen ist. Für dich sind es zwei Gespräche,
 also sind es zwei Zeilen.
 
 Eines zu öffnen markiert es als gelesen und zeigt den Thread auf der Seite der
-letzten Nachricht. **Als ungelesen markieren** stellt das zurück, und beides
+letzten Nachricht – das Eingabefeld steht schon offen, auf der letzten Nachricht
+und auf demselben Publikum: Eine Antwort in einem privaten Gespräch bleibt
+darin. **Als ungelesen markieren** stellt das zurück, und beides
 gilt nur für dich: Für die anderen im Thread ändert sich nichts. **Entfernen**
 nimmt es nur aus deinem Posteingang; niemand sonst verliert etwas, und eine
 spätere Nachricht holt es zurück.
@@ -318,7 +320,12 @@ seine Follower gerichtet hat. Eigene Emoji bleiben unangetastet, statt in etwas
 
 ## Löschen
 
-Einen Beitrag zu löschen gibt dir seinen Text zurück – das ist es, was
+Der Papierkorb unter einem eigenen Beitrag löscht ihn, überall wo er auftaucht:
+in einer Timeline, auf einem Profil, auf seiner eigenen Seite. Vorher wirst du
+gefragt, denn ein Löschen geht an jeden Server mit einer Kopie und nichts holt
+es zurück.
+
+Über die API gibt dir das Löschen den Text zurück – das ist es, was
 „löschen und neu schreiben“ in deiner App tut: Es löscht den Beitrag und legt
 den Text zurück ins Eingabefeld.
 

--- a/docs/de/user/einstellungen.md
+++ b/docs/de/user/einstellungen.md
@@ -173,8 +173,11 @@ Zug entfolgen, statt einzeln nacheinander.
 Passwort ändern, wofür das aktuelle nötig ist: Sonst gehört das Konto dem, der
 an einen unbeaufsichtigten Bildschirm tritt.
 
-Die Anmeldung in zwei Schritten hat eine eigene Seite. **Überall abmelden**
-beendet jede Sitzung, auch die, in der du gerade sitzt.
+Die Anmeldung in zwei Schritten hat eine eigene Seite. **Abmelden** beendet
+diese eine Sitzung und lässt deine anderen Geräte in Ruhe; es steht auch in der
+Seitenleiste unter der Navigation, auf jeder Seite. **Überall abmelden** beendet
+jede Sitzung, auch die, in der du gerade sitzt — das ist der Griff für einen
+Rechner, dem du nicht mehr traust.
 
 
 **Letzte Anmeldungen** listet die jüngsten Versuche an deinem Konto mit

--- a/docs/user/posting.md
+++ b/docs/user/posting.md
@@ -224,7 +224,9 @@ A conversation with a different set of people in it is a different line, even
 when it grew out of the same thread. To you they are two conversations, so they
 are two lines.
 
-Opening one marks it read and shows the thread on the last message's page.
+Opening one marks it read and shows the thread on the last message's page, with
+the box already open on the last message and already set to the same audience:
+an answer to a private conversation stays inside it.
 **Mark unread** puts it back, and is yours alone: neither marking changes
 anything for anybody else in the thread. **Remove** takes it out of your inbox
 only; nobody else loses anything, and a later message brings it back.
@@ -300,9 +302,13 @@ that no longer works.
 
 ## Deleting
 
-Deleting a post hands its text back, which is what "delete and redraft" in your
-app is doing: it deletes the post and puts what you wrote back in the compose
-box.
+The bin under a post of your own deletes it, wherever the post appears: a
+timeline, a profile, its own page. You are asked first, because a delete goes
+out to every server holding a copy and nothing brings it back.
+
+Through the API, deleting a post hands its text back, which is what "delete and
+redraft" in your app is doing: it deletes the post and puts what you wrote back
+in the compose box.
 
 Other servers are asked to delete their copy. Whether they do is up to them,
 and a server that was offline when you deleted may not hear about it at all.

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -158,8 +158,11 @@ one press rather than one at a time.
 Change your password, which needs your current one: otherwise somebody who
 walks up to an unlocked screen owns the account.
 
-Two-factor authentication has its own page. **Sign out everywhere** ends every
-session including the one you are using.
+Two-factor authentication has its own page. **Sign out** ends this session and
+leaves your other devices alone; it is also in the sidebar, under the
+navigation, on every page. **Sign out everywhere** ends every session including
+the one you are using, which is the one to reach for on a computer you no
+longer trust.
 
 
 **Recent sign-ins** lists the last attempts on your account with the time, the

--- a/lib/abuuba/accounts/auth.ex
+++ b/lib/abuuba/accounts/auth.ex
@@ -24,6 +24,7 @@ defmodule Abuuba.Accounts.Auth do
   alias Abuuba.Repo
   alias Abuuba.Roles
   alias Abuuba.Settings
+  alias Abuuba.Timelines.Broadcast
   alias Abuuba.Webhooks
   alias Ecto.Multi
 
@@ -379,12 +380,50 @@ defmodule Abuuba.Accounts.Auth do
 
   @doc """
   Ends every session a user has, which is what a password change should do.
+
+  The pages this server renders are LiveViews, and a LiveView reads the session
+  once, when it mounts. Deleting the rows refuses the *next* request and leaves
+  every page that is open right now exactly as it was -- so a suspended account
+  went on posting through the compose box until somebody reloaded it, and "sign
+  out everywhere" left the browser it was pressed in signed in. The same
+  reasoning `Abuuba.Streaming.revoked/1` already applies to a stream, which
+  authenticates once for the same reason.
   """
-  @spec delete_all_session_tokens(User.t()) :: :ok
-  def delete_all_session_tokens(%User{} = user) do
+  @spec delete_all_session_tokens(User.t(), keyword()) :: :ok
+  def delete_all_session_tokens(%User{} = user, opts \\ []) do
     Repo.delete_all(UserToken.by_user_and_contexts_query(user, ["session"]))
+
+    # `announce: false` for a caller inside a transaction, which has to make
+    # the announcement itself once that transaction has committed: a broadcast
+    # is the one thing here that does not roll back.
+    if Keyword.get(opts, :announce, true), do: sessions_revoked(user), else: :ok
+  end
+
+  @doc """
+  Tells the pages this server has already drawn that their session is dead.
+
+  Its own function because deleting the rows is not the only way sessions end:
+  a password reset takes them out inside a transaction (`reset_password/2`),
+  and announcing from inside the write meant that path silently did not --
+  which is the one path whose whole purpose is somebody else being in your
+  account.
+  """
+  @spec sessions_revoked(User.t()) :: :ok
+  def sessions_revoked(%User{} = user) do
+    Broadcast.announce(sessions_topic(user.id), {:sessions, :revoked})
+
     :ok
   end
+
+  @doc """
+  Where a live page listens for the moment its session stops being any good.
+
+  Per user rather than per token, because the raw token is only ever in the
+  browser's cookie -- what is stored here is its hash, so the server cannot
+  name one session from the outside.
+  """
+  @spec sessions_topic(integer()) :: String.t()
+  def sessions_topic(user_id), do: "user_sessions:#{user_id}"
 
   ## Confirmation
 
@@ -506,9 +545,16 @@ defmodule Abuuba.Accounts.Auth do
     |> OAuth.revoke_all_multi(user)
     |> Repo.transaction()
     |> case do
-      {:ok, %{confirmed: user}} -> {:ok, user}
-      {:error, :user, changeset, _changes} -> {:error, changeset}
-      _ -> :error
+      {:ok, %{confirmed: user}} ->
+        sessions_revoked(user)
+
+        {:ok, user}
+
+      {:error, :user, changeset, _changes} ->
+        {:error, changeset}
+
+      _ ->
+        :error
     end
   end
 

--- a/lib/abuuba/moderation/actions.ex
+++ b/lib/abuuba/moderation/actions.ex
@@ -61,6 +61,15 @@ defmodule Abuuba.Moderation.Actions do
   def take(%Account{} = moderator, %Account{} = target, action, opts \\ []) do
     with :ok <- allowed?(action),
          {:ok, strike} <- apply_and_record(moderator, target, action, opts) do
+      # After the commit, for the reason the comment inside the transaction
+      # gives: a broadcast is the one thing here that does not come back when
+      # it rolls back. Announced from inside, a suspension that failed on its
+      # strike still threw every page of an account nobody had suspended back
+      # to the sign-in screen -- and one that succeeded raced its own commit,
+      # so a page redrawing on the message could read the rows from before it
+      # and come back signed in.
+      shut_the_pages(target, action)
+
       AuditLog.record(moderator, "account.#{action}", :account, target.id, %{
         "strike_id" => strike.id
       })
@@ -427,10 +436,20 @@ defmodule Abuuba.Moderation.Actions do
         :ok
 
       user ->
-        Auth.delete_all_session_tokens(user)
+        Auth.delete_all_session_tokens(user, announce: false)
         OAuth.revoke_all_for(user)
     end
   end
+
+  # The half of `close_the_door/1` that has to wait for the commit.
+  defp shut_the_pages(target, action) when action in ~w(suspend disable) do
+    case Repo.get_by(User, account_id: target.id) do
+      nil -> :ok
+      user -> Auth.sessions_revoked(user)
+    end
+  end
+
+  defp shut_the_pages(_target, _action), do: :ok
 
   defp lift(nil, _action), do: :ok
 

--- a/lib/abuuba_web/components/layouts.ex
+++ b/lib/abuuba_web/components/layouts.ex
@@ -52,7 +52,7 @@ defmodule AbuubaWeb.Layouts do
       live timeline renders on every arriving post. As an attribute it is
       rebuilt only when `@current_scope` actually changes, which is where the
       badge can have moved. --%>
-      <.side_nav items={nav_items(@current_scope)} />
+      <.side_nav items={nav_items(@current_scope)} signed_in={@current_scope[:user] != nil} />
 
       <main id="main" tabindex="-1" class="min-w-0 border-base-300 lg:border-x">
         <h1 :if={@page_title} class="sr-only">{@page_title}</h1>
@@ -124,6 +124,7 @@ defmodule AbuubaWeb.Layouts do
   somebody else is describing one interface.
   """
   attr :items, :list, required: true
+  attr :signed_in, :boolean, default: false, doc: "whether there is a session to end"
 
   def side_nav(assigns) do
     ~H"""
@@ -138,8 +139,11 @@ defmodule AbuubaWeb.Layouts do
 
       <.nav_link :for={item <- @items} item={item} />
 
-      <div class="mt-auto px-3 py-2 text-sm">
+      <div class="mt-auto flex flex-col gap-1 px-3 py-2 text-sm">
         <a href={~p"/shortcuts"} class="link link-hover">{gettext("Keyboard shortcuts")}</a>
+        <.link :if={@signed_in} href={~p"/logout"} method="delete" class="link link-hover">
+          {gettext("Sign out")}
+        </.link>
       </div>
     </nav>
     """

--- a/lib/abuuba_web/components/status_component.ex
+++ b/lib/abuuba_web/components/status_component.ex
@@ -343,6 +343,15 @@ defmodule AbuubaWeb.StatusComponent do
     """
   end
 
+  # Which controls are the author's own. Once, rather than on each button that
+  # asks: two spellings of "is this mine" in one template is two to keep in
+  # step. What it decides is what is drawn; whether the event is allowed is
+  # answered again where it is acted on, because the event can be sent without
+  # the button ever existing.
+  defp own?(_status, nil), do: false
+  defp own?(%{"account" => %{"id" => id}}, viewer_id), do: id == viewer_id
+  defp own?(_status, _viewer_id), do: false
+
   # A card with nothing to say is worse than no card: an empty box under a post
   # tells a reader the link is broken when it is only uninformative.
   defp card?(%{"card" => %{"title" => title}}) when title != "", do: true
@@ -422,7 +431,7 @@ defmodule AbuubaWeb.StatusComponent do
       </button>
 
       <button
-        :if={@viewer_id && @status["account"]["id"] == @viewer_id}
+        :if={own?(@status, @viewer_id)}
         type="button"
         phx-click="edit"
         phx-value-id={@status["id"]}
@@ -430,6 +439,20 @@ defmodule AbuubaWeb.StatusComponent do
       >
         <span class="hero-pencil-square size-4" aria-hidden="true" />
         <span class="sr-only">{gettext("Edit")}</span>
+      </button>
+
+      <%!-- Your own posts only, and asked about first: a delete goes out to
+      every server that has a copy and nothing brings it back. --%>
+      <button
+        :if={own?(@status, @viewer_id)}
+        type="button"
+        phx-click="delete"
+        phx-value-id={@status["id"]}
+        data-confirm={gettext("Delete this post? Other servers are told to forget it too.")}
+        class="flex items-center gap-1"
+      >
+        <span class="hero-trash size-4" aria-hidden="true" />
+        <span class="sr-only">{gettext("Delete")}</span>
       </button>
 
       <%!-- Only where the server can actually translate and the post is in

--- a/lib/abuuba_web/live/conversations_live.ex
+++ b/lib/abuuba_web/live/conversations_live.ex
@@ -34,6 +34,7 @@ defmodule AbuubaWeb.ConversationsLive do
   alias Abuuba.Statuses.Formatter
   alias Abuuba.Streaming
   alias AbuubaWeb.API.Entities
+  alias AbuubaWeb.PostActions
 
   @page_size 20
 
@@ -149,14 +150,13 @@ defmodule AbuubaWeb.ConversationsLive do
   # The last message's own page, which renders the thread around it. A
   # conversation whose last message has since been deleted keeps its row and
   # its people, so this falls back to the inbox rather than to a 404.
+  #
+  # With the box open, because opening a conversation is opening it to answer.
+  # That also decides the audience: the composer takes a reply's visibility
+  # from the post it answers, and the empty box this used to land on defaults
+  # to public -- so the obvious reply to a private message went to everybody.
   defp path_to(row, account) do
-    with id when not is_nil(id) <- row.last_status_id,
-         %{} = status <- Statuses.get_status(id, account),
-         %{} = author <- Accounts.get_account(status.account_id) do
-      ~p"/@#{Account.acct(author)}/#{status.id}"
-    else
-      _ -> ~p"/conversations"
-    end
+    PostActions.page_of(account, row.last_status_id, compose: :reply) || ~p"/conversations"
   end
 
   defp load(socket) do

--- a/lib/abuuba_web/live/home_live.ex
+++ b/lib/abuuba_web/live/home_live.ex
@@ -317,12 +317,31 @@ defmodule AbuubaWeb.HomeLive do
   # button not being drawn is not the same as the event being refused.
   def handle_event("edit", %{"id" => id}, socket) do
     account = socket.assigns.account
+    status = status_by_id(id, account)
 
-    case status_by_id(id, account) do
-      %{account_id: author_id} = status when author_id == account.id ->
-        {:noreply, open_compose(socket, editing: status)}
+    if PostActions.own?(status, account) do
+      {:noreply, open_compose(socket, editing: status)}
+    else
+      {:noreply, socket}
+    end
+  end
 
-      _ ->
+  # The same shared decision the other five screens attach, answered here
+  # because this screen keeps a stream rather than a list and knows how to take
+  # a row out of one.
+  def handle_event("delete", %{"id" => id}, socket) do
+    case PostActions.delete(socket.assigns.account, id) do
+      {:ok, status} ->
+        # Its own row and every row that is a boost of it: the boost is drawn
+        # under the booster's id, so taking out only the post's own id leaves
+        # the words of a deleted post on screen under a flash saying it is
+        # gone.
+        {:noreply,
+         socket
+         |> stream_delete(:statuses, %{"id" => to_string(status.id)})
+         |> put_flash(:info, PostActions.gone())}
+
+      :error ->
         {:noreply, socket}
     end
   end

--- a/lib/abuuba_web/live/notifications_live.ex
+++ b/lib/abuuba_web/live/notifications_live.ex
@@ -60,7 +60,7 @@ defmodule AbuubaWeb.NotificationsLive do
        viewer: account,
        types: stored_types(socket.assigns.current_scope.user)
      )
-     |> PostActions.attach(put_back: &put_status_back/2)}
+     |> PostActions.attach(put_back: &put_status_back/2, remove: &drop_status/2)}
   end
 
   # This screen draws the action bar like the other five, but its posts are not
@@ -77,6 +77,16 @@ defmodule AbuubaWeb.NotificationsLive do
     do: %{group | status: rendered}
 
   defp swap_group(group, _rendered), do: group
+
+  # A deleted post takes its whole group with it. `Statuses.delete_status/1`
+  # has already forgotten the notifications about it, so leaving the group on
+  # screen would show a row that a reload no longer has.
+  defp drop_status(socket, id) do
+    update(socket, :groups, &Enum.reject(&1, fn group -> group_of?(group, id) end))
+  end
+
+  defp group_of?(%{status: %{} = status}, id), do: PostActions.about?(status, id)
+  defp group_of?(_group, _id), do: false
 
   @impl Phoenix.LiveView
   def handle_params(_params, _uri, socket) do

--- a/lib/abuuba_web/live/post_actions.ex
+++ b/lib/abuuba_web/live/post_actions.ex
@@ -31,6 +31,7 @@ defmodule AbuubaWeb.PostActions do
   use Gettext, backend: AbuubaWeb.Gettext
 
   alias Abuuba.Accounts.Account
+  alias Abuuba.Snowflake
   alias Abuuba.Statuses
   alias Abuuba.Statuses.Poll
   alias Abuuba.Statuses.Status
@@ -38,6 +39,9 @@ defmodule AbuubaWeb.PostActions do
   alias AbuubaWeb.API.Entities
 
   @toggles ~w(favourite boost bookmark)
+
+  # What a screen with no composer can ask a post's page to open on arrival.
+  @composers ~w(reply edit)
 
   @doc """
   The events this handles.
@@ -55,7 +59,7 @@ defmodule AbuubaWeb.PostActions do
   attached screen passing a check that is no longer true.
   """
   @spec answers() :: [String.t()]
-  def answers, do: Enum.sort(@toggles ++ ~w(edit reply translate vote))
+  def answers, do: Enum.sort(@toggles ++ ~w(delete edit reply translate vote))
 
   @doc """
   Performs one, answering with the post as it now stands.
@@ -182,6 +186,29 @@ defmodule AbuubaWeb.PostActions do
   end
 
   @doc """
+  Takes back a post the reader wrote, answering with the one that is gone.
+
+  Ownership is asked here rather than trusted from the button, for the reason
+  in "Read, then decide" above and one more: the event can be sent without the
+  button ever being drawn, so the only place the question can be answered is
+  the one that acts on it.
+
+  `:error` where there is nobody signed in, the id names nothing they can see,
+  or the post is somebody else's -- all three mean the same thing to a caller,
+  which is that nothing has left the screen.
+  """
+  @spec delete(Account.t() | nil, String.t() | integer()) :: {:ok, Status.t()} | :error
+  def delete(viewer, id)
+
+  def delete(%Account{} = viewer, id) do
+    status = find(viewer, id)
+
+    if own?(status, viewer), do: Statuses.delete_status(status), else: :error
+  end
+
+  def delete(_viewer, _id), do: :error
+
+  @doc """
   Puts a freshly rendered post in place of the one it supersedes.
 
   For the screens that hold their posts in a plain list. A stream has its own
@@ -199,23 +226,60 @@ defmodule AbuubaWeb.PostActions do
 
   For the screens with no composer: replying there goes to the post rather than
   opening a box, which is the same answer on all of them.
+
+  `:compose` says what the reader came to do, and the post's page opens the box
+  on arrival. Without it the button sent them to a page with a closed composer,
+  so "Reply" did nothing once they got there and "Edit" showed an empty box on
+  the post they meant to change. The accepted values are `composers/0`, which
+  is what `AbuubaWeb.StatusLive` matches on, so the two ends cannot drift.
   """
-  @spec page_of(Account.t() | nil, String.t() | integer()) :: String.t() | nil
-  def page_of(viewer, id) do
+  @spec page_of(Account.t() | nil, String.t() | integer(), keyword()) :: String.t() | nil
+  def page_of(viewer, id, opts \\ []) do
     with %Status{} = status <- find(viewer, id),
          %Account{} = account <- Abuuba.Repo.get(Account, status.account_id) do
-      "/@#{Account.acct(account)}/#{status.id}"
+      "/@#{Account.acct(account)}/#{status.id}#{compose_query(opts[:compose])}"
     else
       _nothing -> nil
     end
   end
 
+  @doc """
+  What `:compose` accepts, and what a post's page answers.
+  """
+  @spec composers() :: [String.t()]
+  def composers, do: @composers
+
+  defp compose_query(nil), do: ""
+
+  defp compose_query(what) do
+    case to_string(what) do
+      known when known in @composers -> "?compose=#{known}"
+      _unknown -> ""
+    end
+  end
+
+  @doc """
+  Whether this post is the reader's own.
+
+  Asked of the `%Status{}` rather than of the button that raised the event: the
+  event can be sent without the button ever being drawn, so the only place the
+  question can be answered is the one that acts on it.
+  """
+  @spec own?(Status.t(), Account.t() | nil) :: boolean()
+  def own?(%Status{account_id: account_id}, %Account{id: account_id}), do: true
+  def own?(_status, _viewer), do: false
+
   # `get_status/2` is what applies the viewer's own visibility, so a post
   # somebody cannot see answers nil here rather than being acted on.
+  #
+  # `Snowflake.cast/1` rather than `Integer.parse/1`, which reads a number too
+  # big for the column and hands it to Ecto, where it is a cast error that
+  # takes the socket down. Every button on the action bar comes through here,
+  # so one id nobody could have meant emptied the page.
   defp find(viewer, id) do
-    case Integer.parse(to_string(id)) do
-      {number, ""} -> Statuses.get_status(number, viewer)
-      _not_a_number -> nil
+    case Snowflake.cast(id) do
+      {:ok, number} -> Statuses.get_status(number, viewer)
+      :error -> nil
     end
   end
 
@@ -245,60 +309,83 @@ defmodule AbuubaWeb.PostActions do
   """
   @spec attach(Phoenix.LiveView.Socket.t(), keyword()) :: Phoenix.LiveView.Socket.t()
   def attach(socket, opts) do
-    put_back = put_back_fun(opts)
+    ways = ways(opts)
 
     Phoenix.LiveView.attach_hook(socket, :post_actions, :handle_event, fn event, params, socket ->
-      handle(event, params, socket, put_back)
+      handle(event, params, socket, ways)
     end)
   end
 
   # `:lists` covers every screen that keeps posts in plain lists, which is most
-  # of them. `:put_back` is for the one that does not — the notifications page
-  # holds each post inside the group of notifications about it — and is the
-  # same division of labour the moduledoc describes: this decides what an
-  # action does, the screen decides where the answer goes.
-  defp put_back_fun(opts) do
-    case Keyword.fetch(opts, :put_back) do
+  # of them. `:put_back` and `:remove` are for the one that does not — the
+  # notifications page holds each post inside the group of notifications about
+  # it — and are the same division of labour the moduledoc describes: this
+  # decides what an action does, the screen decides where the answer goes.
+  #
+  # Two ways rather than one because the actions divide in two: everything but
+  # a delete redraws a post where it was, and a delete takes it off the screen.
+  defp ways(opts) do
+    %{
+      put_back: way(opts, :put_back, &lists_put_back/1),
+      remove: way(opts, :remove, &lists_remove/1)
+    }
+  end
+
+  defp way(opts, key, from_lists) do
+    case Keyword.fetch(opts, key) do
       {:ok, fun} when is_function(fun, 2) -> fun
-      :error -> lists_put_back(opts |> Keyword.fetch!(:lists) |> List.wrap())
+      :error -> opts |> Keyword.fetch!(:lists) |> List.wrap() |> from_lists.()
     end
   end
 
-  defp lists_put_back(lists), do: &swap_lists(&1, lists, &2)
+  defp lists_put_back(lists), do: &update_lists(&1, lists, fn posts -> swap(posts, &2) end)
 
-  defp swap_lists(socket, lists, rendered) do
-    Enum.reduce(lists, socket, fn list, acc ->
-      Phoenix.Component.update(acc, list, &swap(&1, rendered))
-    end)
+  defp lists_remove(lists),
+    do: &update_lists(&1, lists, fn posts -> Enum.reject(posts, fn p -> about?(p, &2) end) end)
+
+  @doc """
+  Whether a drawn post is the one with this id, boost included.
+
+  A boost is drawn as the boost row, and the action bar on it acts on the
+  post inside (`@status["reblog"] || @status`). So the id a delete answers
+  with is the original's, while the row it has to come off is the boost's --
+  and matching only the row's own id left the words of a deleted post sitting
+  on screen under a flash saying it was gone.
+  """
+  @spec about?(map(), String.t()) :: boolean()
+  def about?(post, id), do: post["id"] == id or get_in(post, ["reblog", "id"]) == id
+
+  defp update_lists(socket, lists, fun) do
+    Enum.reduce(lists, socket, fn list, acc -> Phoenix.Component.update(acc, list, fun) end)
   end
 
-  defp handle(event, %{"id" => id}, socket, put_back) when event in @toggles do
+  defp handle(event, %{"id" => id}, socket, ways) when event in @toggles do
     case toggle(socket.assigns.viewer, event, id) do
-      {:ok, status} -> {:halt, rendered_back(socket, status, put_back)}
+      {:ok, status} -> {:halt, rendered_back(socket, status, ways.put_back)}
       :error -> {:halt, socket}
     end
   end
 
-  defp handle("vote", %{"poll_id" => poll_id} = params, socket, put_back) do
+  defp handle("vote", %{"poll_id" => poll_id} = params, socket, ways) do
     choices = params |> Map.get("choices", []) |> List.wrap()
 
     case vote(socket.assigns.viewer, poll_id, choices) do
-      {:ok, status} -> {:halt, rendered_back(socket, status, put_back)}
+      {:ok, status} -> {:halt, rendered_back(socket, status, ways.put_back)}
       :error -> {:halt, socket}
     end
   end
 
-  defp handle(event, %{"id" => id}, socket, _put_back) when event in ~w(reply edit) do
-    case page_of(socket.assigns.viewer, id) do
+  defp handle(event, %{"id" => id}, socket, _ways) when event in @composers do
+    case page_of(socket.assigns.viewer, id, compose: event) do
       nil -> {:halt, socket}
       path -> {:halt, Phoenix.LiveView.push_navigate(socket, to: path)}
     end
   end
 
-  defp handle("translate", %{"id" => id}, socket, put_back) do
+  defp handle("translate", %{"id" => id}, socket, ways) do
     case translate(socket.assigns.viewer, id, locale(socket)) do
       {:ok, rendered} ->
-        {:halt, put_back.(socket, rendered)}
+        {:halt, ways.put_back.(socket, rendered)}
 
       :error ->
         {:halt,
@@ -310,12 +397,35 @@ defmodule AbuubaWeb.PostActions do
     end
   end
 
-  defp handle(_event, _params, socket, _put_back), do: {:cont, socket}
+  defp handle("delete", %{"id" => id}, socket, ways) do
+    case delete(socket.assigns.viewer, id) do
+      {:ok, status} ->
+        {:halt,
+         socket
+         |> ways.remove.(to_string(status.id))
+         |> Phoenix.LiveView.put_flash(:info, gone())}
+
+      :error ->
+        {:halt, socket}
+    end
+  end
+
+  defp handle(_event, _params, socket, _ways), do: {:cont, socket}
 
   # Rendered the way the screen rendered the rest of them, then handed back.
   defp rendered_back(socket, %Status{} = status, put_back) do
     put_back.(socket, Entities.status(status, socket.assigns.viewer))
   end
+
+  @doc """
+  What a screen says once a post is gone.
+
+  Public because the two screens with a composer answer `delete` themselves --
+  one has a stream to take a row out of, the other may have to leave the page
+  -- and a delete that reports nothing looks like a button that did nothing.
+  """
+  @spec gone() :: String.t()
+  def gone, do: gettext("That post is gone.")
 
   @doc """
   The language to translate into for this reader.

--- a/lib/abuuba_web/live/settings_live.ex
+++ b/lib/abuuba_web/live/settings_live.ex
@@ -906,9 +906,15 @@ defmodule AbuubaWeb.SettingsLive do
         {gettext("Signing out everywhere ends every session, including this one.")}
       </p>
 
-      <button type="button" phx-click="sign_out_everywhere" class="btn">
-        {gettext("Sign out everywhere")}
-      </button>
+      <div class="flex flex-wrap gap-3">
+        <.link href={~p"/logout"} method="delete" class="btn">
+          {gettext("Sign out")}
+        </.link>
+
+        <button type="button" phx-click="sign_out_everywhere" class="btn">
+          {gettext("Sign out everywhere")}
+        </button>
+      </div>
     </div>
 
     <h3 class="mt-8 font-semibold">{gettext("Recent sign-ins")}</h3>

--- a/lib/abuuba_web/live/status_live.ex
+++ b/lib/abuuba_web/live/status_live.ex
@@ -54,6 +54,28 @@ defmodule AbuubaWeb.StatusLive do
     end
   end
 
+  # The other half of the reply and edit buttons on a screen with no composer:
+  # they send the reader here and say in the address what they came to do. A
+  # value that is neither, or an edit of somebody else's post, opens nothing --
+  # the box being closed is the safe answer to a URL somebody typed.
+  @impl Phoenix.LiveView
+  def handle_params(%{"compose" => "reply"}, _uri, socket) do
+    {:noreply, open_compose(socket, reply_to: socket.assigns.status)}
+  end
+
+  def handle_params(%{"compose" => "edit"}, _uri, socket) do
+    viewer = socket.assigns.viewer
+    status = socket.assigns.status
+
+    if viewer && status.account_id == viewer.id do
+      {:noreply, open_compose(socket, editing: status)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_params(_params, _uri, socket), do: {:noreply, socket}
+
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
@@ -133,6 +155,25 @@ defmodule AbuubaWeb.StatusLive do
         {:noreply, open_compose(socket, editing: status)}
 
       _ ->
+        {:noreply, socket}
+    end
+  end
+
+  # The one action that can take away the page you are standing on. Deleting
+  # the post this page is about leaves nothing to reload, so it goes to the
+  # author's profile; deleting a reply in the thread reloads it in place.
+  def handle_event("delete", %{"id" => id}, socket) do
+    case PostActions.delete(socket.assigns.viewer, id) do
+      {:ok, status} ->
+        socket = put_flash(socket, :info, PostActions.gone())
+
+        if status.id == socket.assigns.status.id do
+          {:noreply, push_navigate(socket, to: ~p"/@#{socket.assigns.author.username}")}
+        else
+          {:noreply, load_thread(socket)}
+        end
+
+      :error ->
         {:noreply, socket}
     end
   end

--- a/lib/abuuba_web/user_auth.ex
+++ b/lib/abuuba_web/user_auth.ex
@@ -104,27 +104,106 @@ defmodule AbuubaWeb.UserAuth do
 
   @doc """
   Makes the signed-in user available to a LiveView.
+
+  Every page of this server's own interface is a LiveView, so this is the twin
+  of `fetch_current_scope/2` and has to ask the same question: a session that
+  exists is not the same as a session that may be used. It asked only the
+  first, which left a suspended account signed in on every live page.
+
+  A LiveView also asks once and then holds the answer for as long as the socket
+  lives, so the mount subscribes to the user's sessions and shuts the page down
+  when they are revoked. Without it a moderator's decision took effect whenever
+  the person happened to reload, and "sign out everywhere" left the browser it
+  was pressed in signed in.
   """
   def on_mount(:mount_current_scope, _params, session, socket) do
-    user = session["user_token"] && Auth.get_user_by_session_token(session["user_token"])
-
-    {:cont, Phoenix.Component.assign(socket, :current_scope, %{user: user})}
+    # A public page goes on being a public page: it is drawn again as a
+    # stranger would get it, rather than answering "you have to be signed in to
+    # see that page" about a page anybody can see. Drawn again rather than
+    # patched, because the reader is not only in the scope -- every screen
+    # takes an account out of it at mount and hands that to the action bar, so
+    # anything short of a fresh mount leaves the buttons live.
+    {:cont, socket |> assign_scope(session) |> watch_sessions(:draw_it_again)}
   end
 
   def on_mount(:ensure_authenticated, _params, session, socket) do
-    case session["user_token"] && Auth.get_user_by_session_token(session["user_token"]) do
-      %User{} = user ->
-        {:cont, Phoenix.Component.assign(socket, :current_scope, %{user: user})}
+    socket = assign_scope(socket, session)
 
-      _ ->
-        {:halt,
-         socket
-         |> Phoenix.LiveView.put_flash(
-           :error,
-           gettext("You have to be signed in to see that page.")
-         )
-         |> Phoenix.LiveView.redirect(to: ~p"/login")}
+    case socket.assigns.current_scope do
+      %{user: %User{}} -> {:cont, watch_sessions(socket, :send_them_to_sign_in)}
+      _ -> {:halt, to_login(socket)}
     end
+  end
+
+  defp assign_scope(socket, session) do
+    user = session["user_token"] && Auth.get_user_by_session_token(session["user_token"])
+
+    Phoenix.Component.assign(socket, :current_scope, %{user: usable(user)})
+  end
+
+  # Only worth a subscription on a connected socket: the dead render is one
+  # request and is gone before anything could be revoked.
+  #
+  # Straight to PubSub rather than through `Abuuba.Timelines.Broadcast`, which
+  # every other subscriber here uses. That one keeps a per-topic listener count
+  # for deciding whether a timeline is worth rendering, and buys it with a
+  # `GenServer.call` and a monitor through a single process -- on the connect
+  # path of every page, for a count nothing reads on this topic. On a reconnect
+  # storm that process is where every socket would queue.
+  defp watch_sessions(%{assigns: %{current_scope: %{user: %User{} = user}}} = socket, answer) do
+    if Phoenix.LiveView.connected?(socket) do
+      Phoenix.PubSub.subscribe(Abuuba.PubSub, Auth.sessions_topic(user.id))
+
+      socket
+      |> remember_where(answer)
+      |> Phoenix.LiveView.attach_hook(:session_revoked, :handle_info, fn
+        {:sessions, :revoked}, socket -> {:halt, answer(answer, socket)}
+        _message, socket -> {:cont, socket}
+      end)
+    else
+      socket
+    end
+  end
+
+  defp watch_sessions(socket, _answer), do: socket
+
+  # Where the reader is, so a public page can send them to it again. Only that
+  # answer needs it: a `handle_info` hook is not told the address, and the
+  # sign-in page is the same address wherever they were.
+  # `socket.router` is nil for a LiveView rendered inside another one, and
+  # attaching a `handle_params` hook to one of those raises. Nothing nests a
+  # LiveView today; this is so that the first one to do it does not crash at
+  # mount for a reason nobody would look for here.
+  defp remember_where(%{router: nil} = socket, _answer), do: socket
+
+  defp remember_where(socket, :draw_it_again) do
+    Phoenix.LiveView.attach_hook(socket, :session_here, :handle_params, fn _params, uri, socket ->
+      {:cont, Phoenix.Component.assign(socket, :session_here, here(uri))}
+    end)
+  end
+
+  defp remember_where(socket, _answer), do: socket
+
+  # Query string included: a reader on `/search?q=hello` who is drawn again at
+  # `/search` has lost their results, which reads as the page having emptied
+  # itself.
+  defp here(uri) do
+    case URI.parse(uri) do
+      %URI{path: path, query: nil} -> path
+      %URI{path: path, query: query} -> path <> "?" <> query
+    end
+  end
+
+  defp answer(:send_them_to_sign_in, socket), do: to_login(socket)
+
+  defp answer(:draw_it_again, socket) do
+    Phoenix.LiveView.push_navigate(socket, to: socket.assigns[:session_here] || ~p"/")
+  end
+
+  defp to_login(socket) do
+    socket
+    |> Phoenix.LiveView.put_flash(:error, gettext("You have to be signed in to see that page."))
+    |> Phoenix.LiveView.redirect(to: ~p"/login")
   end
 
   defp maybe_write_remember_me(conn, token, %{"remember_me" => "true"}) do

--- a/lib/abuuba_web/user_auth.ex
+++ b/lib/abuuba_web/user_auth.ex
@@ -170,10 +170,11 @@ defmodule AbuubaWeb.UserAuth do
   # Where the reader is, so a public page can send them to it again. Only that
   # answer needs it: a `handle_info` hook is not told the address, and the
   # sign-in page is the same address wherever they were.
+  #
   # `socket.router` is nil for a LiveView rendered inside another one, and
   # attaching a `handle_params` hook to one of those raises. Nothing nests a
-  # LiveView today; this is so that the first one to do it does not crash at
-  # mount for a reason nobody would look for here.
+  # LiveView today; the clause is so that the first one to do it does not crash
+  # at mount for a reason nobody would look for here.
   defp remember_where(%{router: nil} = socket, _answer), do: socket
 
   defp remember_where(socket, :draw_it_again) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.1",
+      version: "1.0.2",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -39,8 +39,8 @@ msgstr[1] "vor %{count} Minuten"
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/abuuba_web/components/layouts.ex:285
-#: lib/abuuba_web/components/layouts.ex:300
+#: lib/abuuba_web/components/layouts.ex:289
+#: lib/abuuba_web/components/layouts.ex:304
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr "Verbindung wird wiederhergestellt"
@@ -51,12 +51,12 @@ msgid "Change"
 msgstr "Ändern"
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:713
+#: lib/abuuba_web/live/compose_component.ex:714
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr "Sprache"
 
-#: lib/abuuba_web/components/layouts.ex:292
+#: lib/abuuba_web/components/layouts.ex:296
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr "Da ist etwas schiefgelaufen"
@@ -66,7 +66,7 @@ msgstr "Da ist etwas schiefgelaufen"
 msgid "That language is not available."
 msgstr "Diese Sprache steht nicht zur Verfügung."
 
-#: lib/abuuba_web/components/layouts.ex:277
+#: lib/abuuba_web/components/layouts.ex:281
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr "Keine Internetverbindung"
@@ -287,7 +287,7 @@ msgid "You are signed out."
 msgstr "Du bist abgemeldet."
 
 #: lib/abuuba_web/user_auth.ex:88
-#: lib/abuuba_web/user_auth.ex:124
+#: lib/abuuba_web/user_auth.ex:205
 #, elixir-autogen, elixir-format
 msgid "You have to be signed in to see that page."
 msgstr "Du musst angemeldet sein, um diese Seite zu sehen."
@@ -420,7 +420,7 @@ msgstr "Einschalten"
 msgid "Turn off two-factor authentication?"
 msgstr "Zwei-Faktor-Authentifizierung ausschalten?"
 
-#: lib/abuuba_web/live/settings_live.ex:901
+#: lib/abuuba_web/live/settings_live.ex:902
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -468,8 +468,8 @@ msgstr "%{app} autorisieren"
 
 #: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:387
-#: lib/abuuba_web/live/compose_component.ex:400
+#: lib/abuuba_web/live/compose_component.ex:388
+#: lib/abuuba_web/live/compose_component.ex:401
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -654,51 +654,51 @@ msgstr "Ein Server darf nur nach seinen eigenen Followern fragen."
 msgid "That request has to be signed."
 msgstr "Diese Anfrage muss signiert sein."
 
-#: lib/abuuba_web/components/layouts.ex:243
-#: lib/abuuba_web/components/layouts.ex:252
-#: lib/abuuba_web/live/explore_live.ex:48
+#: lib/abuuba_web/components/layouts.ex:247
+#: lib/abuuba_web/components/layouts.ex:256
+#: lib/abuuba_web/live/explore_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr "Entdecken"
 
-#: lib/abuuba_web/components/layouts.ex:230
-#: lib/abuuba_web/components/layouts.ex:251
+#: lib/abuuba_web/components/layouts.ex:234
+#: lib/abuuba_web/components/layouts.ex:255
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2311
+#: lib/abuuba_web/live/settings_live.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
 
-#: lib/abuuba_web/components/layouts.ex:142
+#: lib/abuuba_web/components/layouts.ex:143
 #: lib/abuuba_web/controllers/shortcuts_controller.ex:15
 #: lib/abuuba_web/controllers/shortcuts_html/show.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr "Tastaturkürzel"
 
-#: lib/abuuba_web/components/layouts.ex:254
+#: lib/abuuba_web/components/layouts.ex:258
 #: lib/abuuba_web/live/landing_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Anmelden"
 
-#: lib/abuuba_web/components/layouts.ex:132
-#: lib/abuuba_web/components/layouts.ex:154
+#: lib/abuuba_web/components/layouts.ex:133
+#: lib/abuuba_web/components/layouts.ex:158
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr "Hauptnavigation"
 
-#: lib/abuuba_web/components/layouts.ex:233
+#: lib/abuuba_web/components/layouts.ex:237
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2312
+#: lib/abuuba_web/live/settings_live.ex:2319
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr "Mitteilungen"
 
-#: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:120
-#: lib/abuuba_web/live/settings_live.ex:2120
+#: lib/abuuba_web/components/layouts.ex:249
+#: lib/abuuba_web/live/settings_live.ex:121
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -737,12 +737,12 @@ msgstr "%{name} hat geteilt"
 msgid "Attachment"
 msgstr "Anhang"
 
-#: lib/abuuba_web/components/status_component.ex:421
+#: lib/abuuba_web/components/status_component.ex:430
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/abuuba_web/components/status_component.ex:398
+#: lib/abuuba_web/components/status_component.ex:407
 #, elixir-autogen, elixir-format
 msgid "Boost"
 msgstr "Teilen"
@@ -752,7 +752,7 @@ msgstr "Teilen"
 msgid "Closed"
 msgstr "Beendet"
 
-#: lib/abuuba_web/components/status_component.ex:410
+#: lib/abuuba_web/components/status_component.ex:419
 #, elixir-autogen, elixir-format
 msgid "Favourite"
 msgstr "Favorisieren"
@@ -763,12 +763,12 @@ msgid "Follow some people and their posts will appear here."
 msgstr "Folge ein paar Menschen, dann erscheinen ihre Beiträge hier."
 
 #: lib/abuuba_web/components/status_component.ex:267
-#: lib/abuuba_web/live/compose_component.ex:593
+#: lib/abuuba_web/live/compose_component.ex:594
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Umfrage"
 
-#: lib/abuuba_web/components/status_component.ex:386
+#: lib/abuuba_web/components/status_component.ex:395
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
@@ -793,303 +793,303 @@ msgstr "Du bist am Ende angekommen."
 msgid "Your choice"
 msgstr "Deine Wahl"
 
-#: lib/abuuba_web/live/compose_component.ex:1657
+#: lib/abuuba_web/live/compose_component.ex:1658
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr "1 Tag"
 
-#: lib/abuuba_web/live/compose_component.ex:1655
+#: lib/abuuba_web/live/compose_component.ex:1656
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr "1 Stunde"
 
-#: lib/abuuba_web/live/compose_component.ex:1658
+#: lib/abuuba_web/live/compose_component.ex:1659
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr "3 Tage"
 
-#: lib/abuuba_web/live/compose_component.ex:1654
+#: lib/abuuba_web/live/compose_component.ex:1655
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr "30 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1653
+#: lib/abuuba_web/live/compose_component.ex:1654
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr "5 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1656
+#: lib/abuuba_web/live/compose_component.ex:1657
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr "6 Stunden"
 
-#: lib/abuuba_web/live/compose_component.ex:1659
+#: lib/abuuba_web/live/compose_component.ex:1660
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr "7 Tage"
 
-#: lib/abuuba_web/live/compose_component.ex:1131
+#: lib/abuuba_web/live/compose_component.ex:1132
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr "Eine Umfrage braucht mindestens zwei Antworten."
 
-#: lib/abuuba_web/live/compose_component.ex:628
+#: lib/abuuba_web/live/compose_component.ex:629
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr "Antwort hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:699
+#: lib/abuuba_web/live/compose_component.ex:700
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr "Umfrage hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:640
+#: lib/abuuba_web/live/compose_component.ex:641
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr "Mehrfachauswahl erlauben"
 
-#: lib/abuuba_web/live/compose_component.ex:1674
-#: lib/abuuba_web/live/settings_live.ex:2306
+#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr "Alle"
 
-#: lib/abuuba_web/live/compose_component.ex:1665
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/settings_live.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr "Alle, und überall gelistet"
 
-#: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2302
+#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/settings_live.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr "Alle, aber nicht in öffentlichen Timelines"
 
-#: lib/abuuba_web/live/compose_component.ex:604
+#: lib/abuuba_web/live/compose_component.ex:605
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr "Antwort %{number}"
 
-#: lib/abuuba_web/live/compose_component.ex:428
-#: lib/abuuba_web/live/compose_component.ex:689
+#: lib/abuuba_web/live/compose_component.ex:429
+#: lib/abuuba_web/live/compose_component.ex:690
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/abuuba_web/live/compose_component.ex:790
+#: lib/abuuba_web/live/compose_component.ex:791
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr "Strg + Enter veröffentlicht"
 
-#: lib/abuuba_web/live/compose_component.ex:423
+#: lib/abuuba_web/live/compose_component.ex:424
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr "Diese Person nicht mit anschreiben"
 
-#: lib/abuuba_web/components/status_component.ex:432
+#: lib/abuuba_web/components/status_component.ex:441
 #: lib/abuuba_web/live/admin_live.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/abuuba_web/live/compose_component.ex:393
+#: lib/abuuba_web/live/compose_component.ex:394
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/abuuba_web/live/compose_component.ex:644
+#: lib/abuuba_web/live/compose_component.ex:645
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr "Endet nach"
 
-#: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/profile_live.ex:804
+#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/profile_live.ex:792
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/compose_component.ex:1669
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr "Erwähnte Personen"
 
-#: lib/abuuba_web/live/admin_live.ex:3428
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2308
+#: lib/abuuba_web/live/admin_live.ex:3427
+#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/settings_live.ex:2315
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr "Niemand"
 
-#: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2303
+#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/settings_live.ex:2310
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr "Nur die Leute, die dir folgen"
 
-#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/compose_component.ex:1669
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr "Nur die Leute, die du nennst"
 
-#: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2307
+#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/settings_live.ex:2314
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr "Leute, die dir folgen"
 
-#: lib/abuuba_web/live/compose_component.ex:1432
+#: lib/abuuba_web/live/compose_component.ex:1433
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/compose_component.ex:673
+#: lib/abuuba_web/live/compose_component.ex:674
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/abuuba_web/live/compose_component.ex:1665
-#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/compose_component.ex:1684
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/compose_component.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr "Still öffentlich"
 
-#: lib/abuuba_web/live/compose_component.ex:709
+#: lib/abuuba_web/live/compose_component.ex:710
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr "Umfrage entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:616
+#: lib/abuuba_web/live/compose_component.ex:617
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr "Diese Antwort entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:380
+#: lib/abuuba_web/live/compose_component.ex:381
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr "Antwort an %{name}"
 
-#: lib/abuuba_web/live/compose_component.ex:1430
+#: lib/abuuba_web/live/compose_component.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
-#: lib/abuuba_web/live/admin_live.ex:3389
-#: lib/abuuba_web/live/compose_component.ex:455
+#: lib/abuuba_web/live/admin_live.ex:3388
+#: lib/abuuba_web/live/compose_component.ex:456
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr "Vorschläge"
 
-#: lib/abuuba_web/live/compose_component.ex:1093
+#: lib/abuuba_web/live/compose_component.ex:1094
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr "Das ist %{count} Zeichen zu lang."
 
-#: lib/abuuba_web/live/compose_component.ex:1155
-#: lib/abuuba_web/live/compose_component.ex:1190
-#: lib/abuuba_web/live/compose_component.ex:1386
+#: lib/abuuba_web/live/compose_component.ex:1156
+#: lib/abuuba_web/live/compose_component.ex:1191
+#: lib/abuuba_web/live/compose_component.ex:1387
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr "Der Beitrag konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/compose_component.ex:439
-#: lib/abuuba_web/live/compose_component.ex:445
+#: lib/abuuba_web/live/compose_component.ex:440
+#: lib/abuuba_web/live/compose_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr "Was beschäftigt dich?"
 
-#: lib/abuuba_web/live/compose_component.ex:433
+#: lib/abuuba_web/live/compose_component.ex:434
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr "Wovor sollen die Leute gewarnt werden?"
 
-#: lib/abuuba_web/live/compose_component.ex:749
+#: lib/abuuba_web/live/compose_component.ex:750
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr "Wer das zitieren darf"
 
-#: lib/abuuba_web/live/compose_component.ex:729
+#: lib/abuuba_web/live/compose_component.ex:730
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr "Wer das sehen darf"
 
-#: lib/abuuba_web/live/compose_component.ex:1089
+#: lib/abuuba_web/live/compose_component.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr "Schreib erst mal etwas."
 
-#: lib/abuuba_web/live/compose_component.ex:1187
+#: lib/abuuba_web/live/compose_component.ex:1188
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr "Du hast gerade viel veröffentlicht. Versuch es später noch einmal."
 
-#: lib/abuuba_web/live/compose_component.ex:1626
+#: lib/abuuba_web/live/compose_component.ex:1627
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr "jemanden"
 
-#: lib/abuuba_web/live/compose_component.ex:796
+#: lib/abuuba_web/live/compose_component.ex:797
 #, elixir-autogen, elixir-format
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] "%{count} Entwurf"
 msgstr[1] "%{count} Entwürfe"
 
-#: lib/abuuba_web/live/compose_component.ex:828
+#: lib/abuuba_web/live/compose_component.ex:829
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] "%{count} Beitrag wartet auf den Versand"
 msgstr[1] "%{count} Beiträge warten auf den Versand"
 
-#: lib/abuuba_web/live/compose_component.ex:1135
+#: lib/abuuba_web/live/compose_component.ex:1136
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr "Eine Antwort ist zu lang. Halte jede unter %{count} Zeichen."
 
-#: lib/abuuba_web/live/compose_component.ex:859
+#: lib/abuuba_web/live/compose_component.ex:860
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr "Absagen"
 
-#: lib/abuuba_web/live/compose_component.ex:820
+#: lib/abuuba_web/live/compose_component.ex:821
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: lib/abuuba_web/live/compose_component.ex:659
+#: lib/abuuba_web/live/compose_component.ex:660
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr "Geht raus am"
 
-#: lib/abuuba_web/live/compose_component.ex:810
-#: lib/abuuba_web/live/compose_component.ex:849
+#: lib/abuuba_web/live/compose_component.ex:811
+#: lib/abuuba_web/live/compose_component.ex:850
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr "Öffnen"
 
-#: lib/abuuba_web/live/compose_component.ex:1106
-#: lib/abuuba_web/live/compose_component.ex:1377
+#: lib/abuuba_web/live/compose_component.ex:1107
+#: lib/abuuba_web/live/compose_component.ex:1378
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr "Sag, wann der Beitrag rausgehen soll."
 
-#: lib/abuuba_web/live/compose_component.ex:781
+#: lib/abuuba_web/live/compose_component.ex:782
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr "Planen"
 
-#: lib/abuuba_web/live/compose_component.ex:1431
+#: lib/abuuba_web/live/compose_component.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr "Einplanen"
 
-#: lib/abuuba_web/live/compose_component.ex:305
+#: lib/abuuba_web/live/compose_component.ex:306
 #, elixir-autogen, elixir-format
 msgid "That draft could not be saved."
 msgstr "Der Entwurf konnte nicht gespeichert werden."
@@ -1099,109 +1099,109 @@ msgstr "Der Entwurf konnte nicht gespeichert werden."
 msgid "That post is scheduled."
 msgstr "Der Beitrag ist eingeplant."
 
-#: lib/abuuba_web/live/compose_component.ex:1140
+#: lib/abuuba_web/live/compose_component.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr "Zwei Antworten sind gleich. Mach sie unterschiedlich."
 
-#: lib/abuuba_web/live/compose_component.ex:301
+#: lib/abuuba_web/live/compose_component.ex:302
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr "Du hast zu viele Entwürfe für einen weiteren. Verwirf erst einen."
 
-#: lib/abuuba_web/live/compose_component.ex:1425
+#: lib/abuuba_web/live/compose_component.ex:1426
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr "ein leerer Beitrag"
 
-#: lib/abuuba_web/live/compose_component.ex:666
+#: lib/abuuba_web/live/compose_component.ex:667
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr "deine eigene Zeit, mindestens %{count} Minuten ab jetzt"
 
-#: lib/abuuba_web/live/compose_component.ex:1103
+#: lib/abuuba_web/live/compose_component.ex:1104
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr "Ein Bild geht ohne Beschreibung raus. Schick noch einmal ab, um es trotzdem zu veröffentlichen."
 
-#: lib/abuuba_web/live/compose_component.ex:474
+#: lib/abuuba_web/live/compose_component.ex:475
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr "Bild, Video oder Ton hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:569
+#: lib/abuuba_web/live/compose_component.ex:570
 #, elixir-autogen, elixir-format
 msgid "Add a still"
 msgstr "Standbild hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:519
+#: lib/abuuba_web/live/compose_component.ex:520
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr "Klick auf den wichtigsten Teil"
 
-#: lib/abuuba_web/live/compose_component.ex:536
-#: lib/abuuba_web/live/compose_component.ex:544
+#: lib/abuuba_web/live/compose_component.ex:537
+#: lib/abuuba_web/live/compose_component.ex:545
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr "Beschreibe das für Leute, die es nicht sehen können"
 
-#: lib/abuuba_web/live/compose_component.ex:558
+#: lib/abuuba_web/live/compose_component.ex:559
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr "Nach vorne"
 
-#: lib/abuuba_web/live/compose_component.ex:573
+#: lib/abuuba_web/live/compose_component.ex:574
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr "Standbild auswählen"
 
-#: lib/abuuba_web/live/compose_component.ex:531
+#: lib/abuuba_web/live/compose_component.ex:532
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr "Bildmittelpunkt festlegen"
 
-#: lib/abuuba_web/live/compose_component.ex:499
+#: lib/abuuba_web/live/compose_component.ex:500
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr "Abbrechen"
 
-#: lib/abuuba_web/live/compose_component.ex:584
+#: lib/abuuba_web/live/compose_component.ex:585
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:240
-#: lib/abuuba_web/live/compose_component.ex:1421
+#: lib/abuuba_web/live/compose_component.ex:241
+#: lib/abuuba_web/live/compose_component.ex:1422
 #, elixir-autogen, elixir-format
 msgid "That file could not be uploaded."
 msgstr "Die Datei konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/compose_component.ex:1418
+#: lib/abuuba_web/live/compose_component.ex:1419
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/compose_component.ex:227
+#: lib/abuuba_web/live/compose_component.ex:228
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr "Mehr als %{count} Bilder trägt ein Beitrag nicht."
 
-#: lib/abuuba_web/live/compose_component.ex:1419
+#: lib/abuuba_web/live/compose_component.ex:1420
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr "Das sind mehr Dateien, als ein Beitrag tragen kann."
 
-#: lib/abuuba_web/live/compose_component.ex:1420
+#: lib/abuuba_web/live/compose_component.ex:1421
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr "Dieser Server nimmt keine Dateien dieser Art."
 
-#: lib/abuuba_web/live/compose_component.ex:478
+#: lib/abuuba_web/live/compose_component.ex:479
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr "oder zieh eine ins Feld oder füg sie ein"
 
-#: lib/abuuba_web/live/status_live.ex:277
+#: lib/abuuba_web/live/status_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr "%{name} auf %{server}"
@@ -1216,7 +1216,7 @@ msgstr "Eine Notiz, die nur du liest"
 msgid "Block"
 msgstr "Blockieren"
 
-#: lib/abuuba_web/live/explore_live.ex:112
+#: lib/abuuba_web/live/explore_live.ex:113
 #: lib/abuuba_web/live/profile_live.ex:144
 #: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
@@ -1228,12 +1228,12 @@ msgstr "Folgen"
 msgid "Go to the new account"
 msgstr "Zum neuen Konto"
 
-#: lib/abuuba_web/live/status_live.ex:99
+#: lib/abuuba_web/live/status_live.ex:121
 #, elixir-autogen, elixir-format
 msgid "Look for more replies on the other server"
 msgstr "Auf dem anderen Server nach weiteren Antworten suchen"
 
-#: lib/abuuba_web/live/profile_live.ex:803
+#: lib/abuuba_web/live/profile_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr "Medien"
@@ -1254,8 +1254,8 @@ msgstr "Hier ist noch nichts."
 msgid "Pinned"
 msgstr "Angeheftet"
 
-#: lib/abuuba_web/live/explore_live.ex:248
-#: lib/abuuba_web/live/profile_live.ex:801
+#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/profile_live.ex:789
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:208
@@ -1263,7 +1263,7 @@ msgstr "Angeheftet"
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/abuuba_web/live/profile_live.ex:802
+#: lib/abuuba_web/live/profile_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr "Beiträge und Antworten"
@@ -1274,7 +1274,7 @@ msgstr "Beiträge und Antworten"
 msgid "Save the note"
 msgstr "Notiz speichern"
 
-#: lib/abuuba_web/live/status_live.ex:318
+#: lib/abuuba_web/live/status_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "That server could not be reached, so this is all there is."
 msgstr "Der Server war nicht erreichbar, mehr gibt es also nicht."
@@ -1285,7 +1285,7 @@ msgid "This account has moved to %{handle}."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
 #: lib/abuuba_web/live/profile_live.ex:196
-#: lib/abuuba_web/live/settings_live.ex:827
+#: lib/abuuba_web/live/settings_live.ex:828
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr "Blockierung aufheben"
@@ -1312,103 +1312,103 @@ msgstr "Bestätigt"
 msgid "What to show"
 msgstr "Was gezeigt wird"
 
-#: lib/abuuba_web/live/notifications_live.ex:101
+#: lib/abuuba_web/live/notifications_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] "%{count} neu"
 msgstr[1] "%{count} neu"
 
-#: lib/abuuba_web/live/notifications_live.ex:151
+#: lib/abuuba_web/live/notifications_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] "%{count} Mitteilung"
 msgstr[1] "%{count} Mitteilungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:398
+#: lib/abuuba_web/live/notifications_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] "%{count} Person hat deinen Beitrag geteilt"
 msgstr[1] "%{count} Leute haben deinen Beitrag geteilt"
 
-#: lib/abuuba_web/live/notifications_live.ex:402
+#: lib/abuuba_web/live/notifications_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] "%{count} Person hat deinen Beitrag favorisiert"
 msgstr[1] "%{count} Leute haben deinen Beitrag favorisiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:409
+#: lib/abuuba_web/live/notifications_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] "%{count} Person folgt dir jetzt"
 msgstr[1] "%{count} Leute folgen dir jetzt"
 
-#: lib/abuuba_web/live/notifications_live.ex:412
+#: lib/abuuba_web/live/notifications_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] "%{count} Person hat dich erwähnt"
 msgstr[1] "%{count} Leute haben dich erwähnt"
 
-#: lib/abuuba_web/live/notifications_live.ex:136
+#: lib/abuuba_web/live/notifications_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] "%{count} Person wartet darauf, dich zu erreichen"
 msgstr[1] "%{count} Leute warten darauf, dich zu erreichen"
 
-#: lib/abuuba_web/live/notifications_live.ex:416
+#: lib/abuuba_web/live/notifications_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] "%{name} und %{count} weitere Person"
 msgstr[1] "%{name} und %{count} weitere Leute"
 
-#: lib/abuuba_web/live/notifications_live.ex:365
+#: lib/abuuba_web/live/notifications_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr "%{name} möchte dir folgen"
 
-#: lib/abuuba_web/live/notifications_live.ex:363
+#: lib/abuuba_web/live/notifications_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "%{name} boosted your post"
 msgstr "%{name} hat deinen Beitrag geteilt"
 
-#: lib/abuuba_web/live/notifications_live.ex:368
+#: lib/abuuba_web/live/notifications_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr "%{name} hat einen Beitrag bearbeitet, den du geteilt hast"
 
-#: lib/abuuba_web/live/notifications_live.ex:366
+#: lib/abuuba_web/live/notifications_live.ex:377
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr "%{name} hat deinen Beitrag favorisiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:364
+#: lib/abuuba_web/live/notifications_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr "%{name} folgt dir jetzt"
 
-#: lib/abuuba_web/live/notifications_live.ex:362
+#: lib/abuuba_web/live/notifications_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr "%{name} hat dich erwähnt"
 
-#: lib/abuuba_web/live/notifications_live.ex:369
+#: lib/abuuba_web/live/notifications_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "%{name} posted"
 msgstr "%{name} hat etwas veröffentlicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:370
+#: lib/abuuba_web/live/notifications_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr "%{name} hat deinen Beitrag zitiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:367
+#: lib/abuuba_web/live/notifications_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr "Eine Umfrage von %{name} ist beendet"
@@ -1433,7 +1433,7 @@ msgstr "Konten, die eine Moderation eingeschränkt hat"
 msgid "Accounts made very recently"
 msgstr "Ganz neu angelegte Konten"
 
-#: lib/abuuba_web/live/notifications_live.ex:448
+#: lib/abuuba_web/live/notifications_live.ex:459
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr "Alle"
@@ -1463,17 +1463,17 @@ msgstr "Alle, denen du nicht folgst."
 msgid "Automated accounts"
 msgstr "Automatische Konten"
 
-#: lib/abuuba_web/live/notifications_live.ex:457
+#: lib/abuuba_web/live/notifications_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Boosts"
 msgstr "Geteilte Beiträge"
 
-#: lib/abuuba_web/live/notifications_live.ex:129
+#: lib/abuuba_web/live/notifications_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr "Alle löschen"
 
-#: lib/abuuba_web/live/notifications_live.ex:196
+#: lib/abuuba_web/live/notifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr "Ausblenden"
@@ -1483,12 +1483,12 @@ msgstr "Ausblenden"
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr "Jede Zeile beschreibt eine Art von Absender. Annehmen lässt sie durch, Filtern legt sie in die Warteliste auf deiner Mitteilungsseite, und Ignorieren verwirft sie."
 
-#: lib/abuuba_web/live/notifications_live.ex:462
+#: lib/abuuba_web/live/notifications_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Edits"
 msgstr "Bearbeitungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:460
+#: lib/abuuba_web/live/notifications_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Favourites"
 msgstr "Favoriten"
@@ -1498,15 +1498,15 @@ msgstr "Favoriten"
 msgid "Filter"
 msgstr "Filtern"
 
-#: lib/abuuba_web/live/notifications_live.ex:459
+#: lib/abuuba_web/live/notifications_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr "Folgeanfragen"
 
-#: lib/abuuba_web/live/notifications_live.ex:458
-#: lib/abuuba_web/live/profile_live.ex:805
-#: lib/abuuba_web/live/settings_live.ex:2104
-#: lib/abuuba_web/live/settings_live.ex:2242
+#: lib/abuuba_web/live/notifications_live.ex:469
+#: lib/abuuba_web/live/profile_live.ex:793
+#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2249
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folge ich"
@@ -1521,28 +1521,28 @@ msgstr "Ignorieren"
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr "Bei Ignorieren ist Vorsicht geboten: nichts wird irgendwo abgelegt und es lässt sich nicht wiederherstellen. Filtern ist die umkehrbare Wahl."
 
-#: lib/abuuba_web/live/notifications_live.ex:165
+#: lib/abuuba_web/live/notifications_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr "Durchlassen"
 
-#: lib/abuuba_web/live/notifications_live.ex:125
+#: lib/abuuba_web/live/notifications_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
-#: lib/abuuba_web/live/notifications_live.ex:448
-#: lib/abuuba_web/live/notifications_live.ex:456
+#: lib/abuuba_web/live/notifications_live.ex:459
+#: lib/abuuba_web/live/notifications_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr "Erwähnungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:174
+#: lib/abuuba_web/live/notifications_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:210
+#: lib/abuuba_web/live/notifications_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr "Es ist noch nichts passiert."
@@ -1557,7 +1557,7 @@ msgstr "Leute, die dir nicht folgen"
 msgid "People you do not follow"
 msgstr "Leute, denen du nicht folgst"
 
-#: lib/abuuba_web/live/notifications_live.ex:461
+#: lib/abuuba_web/live/notifications_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "Polls"
 msgstr "Umfragen"
@@ -1574,27 +1574,27 @@ msgstr "Private Erwähnungen aus dem Nichts"
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
 #: lib/abuuba_web/live/profile_live.ex:262
-#: lib/abuuba_web/live/settings_live.ex:295
-#: lib/abuuba_web/live/settings_live.ex:389
-#: lib/abuuba_web/live/settings_live.ex:426
-#: lib/abuuba_web/live/settings_live.ex:490
-#: lib/abuuba_web/live/settings_live.ex:597
-#: lib/abuuba_web/live/settings_live.ex:642
-#: lib/abuuba_web/live/settings_live.ex:675
-#: lib/abuuba_web/live/settings_live.ex:997
+#: lib/abuuba_web/live/settings_live.ex:296
+#: lib/abuuba_web/live/settings_live.ex:390
+#: lib/abuuba_web/live/settings_live.ex:427
+#: lib/abuuba_web/live/settings_live.ex:491
+#: lib/abuuba_web/live/settings_live.ex:598
+#: lib/abuuba_web/live/settings_live.ex:643
+#: lib/abuuba_web/live/settings_live.ex:676
+#: lib/abuuba_web/live/settings_live.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Speichern"
 
 #: lib/abuuba_web/live/admin_live.ex:245
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:137
+#: lib/abuuba_web/live/settings_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr "Gespeichert."
 
-#: lib/abuuba_web/live/notifications_live.ex:360
-#: lib/abuuba_web/live/notifications_live.ex:425
+#: lib/abuuba_web/live/notifications_live.ex:371
+#: lib/abuuba_web/live/notifications_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr "Jemand"
@@ -1604,7 +1604,7 @@ msgstr "Jemand"
 msgid "Somebody a moderator here has already restricted."
 msgstr "Jemand, den eine Moderation hier bereits eingeschränkt hat."
 
-#: lib/abuuba_web/live/notifications_live.ex:395
+#: lib/abuuba_web/live/notifications_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr "Etwas ist passiert, das %{name} betrifft"
@@ -1614,7 +1614,7 @@ msgstr "Etwas ist passiert, das %{name} betrifft"
 msgid "That could not be saved. Try again."
 msgstr "Das konnte nicht gespeichert werden. Versuch es noch einmal."
 
-#: lib/abuuba_web/live/notifications_live.ex:90
+#: lib/abuuba_web/live/notifications_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr "Welche Mitteilungen"
@@ -1624,13 +1624,13 @@ msgstr "Welche Mitteilungen"
 msgid "Who can reach you"
 msgstr "Wer dich erreichen kann"
 
-#: lib/abuuba_web/live/notifications_live.ex:143
+#: lib/abuuba_web/live/notifications_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr "Deine Einstellungen haben diese abgelegt, statt sie zu zeigen."
 
-#: lib/abuuba_web/components/layouts.ex:186
-#: lib/abuuba_web/live/conversations_live.ex:87
+#: lib/abuuba_web/components/layouts.ex:190
+#: lib/abuuba_web/live/conversations_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "unread"
 msgstr "ungelesen"
@@ -1641,13 +1641,13 @@ msgid "A name, a #tag, or some words"
 msgstr "Ein Name, ein #Tag oder ein paar Wörter"
 
 #: lib/abuuba_web/live/admin_live.ex:2277
-#: lib/abuuba_web/live/admin_live.ex:3587
+#: lib/abuuba_web/live/admin_live.ex:3583
 #: lib/abuuba_web/live/search_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr "Alles"
 
-#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/explore_live.ex:250
 #: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:207
@@ -1680,7 +1680,7 @@ msgstr "Hier hat noch niemand öffentlich etwas veröffentlicht."
 msgid "Nobody has posted under this tag yet."
 msgstr "Unter diesem Tag hat noch niemand etwas veröffentlicht."
 
-#: lib/abuuba_web/live/explore_live.ex:122
+#: lib/abuuba_web/live/explore_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht haben."
@@ -1690,7 +1690,7 @@ msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht habe
 msgid "Nothing matched that."
 msgstr "Dazu gab es keine Treffer."
 
-#: lib/abuuba_web/live/explore_live.ex:250
+#: lib/abuuba_web/live/explore_live.ex:251
 #: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:206
@@ -1718,8 +1718,8 @@ msgstr "Die Registrierung ist offen: jeder darf sich anmelden."
 msgid "Registration needs approval: you sign up and an admin reads your request."
 msgstr "Die Registrierung braucht eine Freigabe: du meldest dich an und eine Administration liest deine Anfrage."
 
-#: lib/abuuba_web/components/layouts.ex:244
-#: lib/abuuba_web/components/layouts.ex:253
+#: lib/abuuba_web/components/layouts.ex:248
+#: lib/abuuba_web/components/layouts.ex:257
 #: lib/abuuba_web/live/search_live.ex:38
 #: lib/abuuba_web/live/search_live.ex:61
 #: lib/abuuba_web/live/search_live.ex:70
@@ -1732,7 +1732,7 @@ msgstr "Suche"
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr "Dies ist ein Server im Fediverse: ein Netzwerk unabhängiger Server, deren Leute einander folgen und miteinander reden können, egal auf welchem sie sind. Ein Konto hier kann allen überall darin folgen."
 
-#: lib/abuuba_web/live/explore_live.ex:64
+#: lib/abuuba_web/live/explore_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "What to explore"
 msgstr "Was erkundet wird"
@@ -1757,220 +1757,221 @@ msgstr "Beiträge nach einem Datum"
 msgid "posts older than a date"
 msgstr "Beiträge vor einem Datum"
 
-#: lib/abuuba_web/live/settings_live.ex:892
+#: lib/abuuba_web/live/settings_live.ex:893
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr "Ein neues Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:235
+#: lib/abuuba_web/live/settings_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Über dich"
 
-#: lib/abuuba_web/live/admin_live.ex:3379
-#: lib/abuuba_web/live/settings_live.ex:2107
+#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/settings_live.ex:2114
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Konto"
 
-#: lib/abuuba_web/live/settings_live.ex:291
+#: lib/abuuba_web/live/settings_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "Add a field"
 msgstr "Feld hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:808
+#: lib/abuuba_web/live/settings_live.ex:809
 #, elixir-autogen, elixir-format
 msgid "Add a filter"
 msgstr "Filter hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/abuuba_web/live/settings_live.ex:2278
+#: lib/abuuba_web/live/settings_live.ex:2285
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr "Gilt nur für deine öffentlichen Beiträge."
 
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2113
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2138
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr "Apps, die in dein Konto gelassen wurden."
 
-#: lib/abuuba_web/live/settings_live.ex:948
+#: lib/abuuba_web/live/settings_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr "Apps, bei denen du angemeldet bist. Eine wieder hinauszunehmen meldet sie sofort ab."
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr "Vor jedem Follow fragen"
 
-#: lib/abuuba_web/live/settings_live.ex:896
+#: lib/abuuba_web/live/settings_live.ex:897
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr "Passwort ändern"
 
+#: lib/abuuba_web/components/status_component.ex:455
 #: lib/abuuba_web/live/admin_live.ex:998
-#: lib/abuuba_web/live/settings_live.ex:755
+#: lib/abuuba_web/live/settings_live.ex:756
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:224
+#: lib/abuuba_web/live/settings_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr "Anzeigename"
 
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr "Medien nicht von selbst abspielen"
 
-#: lib/abuuba_web/live/settings_live.ex:1601
+#: lib/abuuba_web/live/settings_live.ex:1608
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr "Jede Zeile muss eine Webadresse sein, eine pro Zeile."
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr "Jeder Follow wird zu einer Anfrage, die du beantwortest."
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2136
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr "Allen, denen du folgst, und ein Weg, damit aufzuhören."
 
-#: lib/abuuba_web/live/settings_live.ex:202
+#: lib/abuuba_web/live/settings_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr "Alles zu deinem Konto ist hier. Wähl einen Bereich."
 
-#: lib/abuuba_web/live/settings_live.ex:240
+#: lib/abuuba_web/live/settings_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr "Felder"
 
-#: lib/abuuba_web/live/settings_live.ex:2103
-#: lib/abuuba_web/live/settings_live.ex:2248
+#: lib/abuuba_web/live/settings_live.ex:2110
+#: lib/abuuba_web/live/settings_live.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr "Hinter einer Warnung zusammenklappen"
 
-#: lib/abuuba_web/live/settings_live.ex:2331
+#: lib/abuuba_web/live/settings_live.ex:2338
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr "Ganz ausblenden"
 
-#: lib/abuuba_web/live/settings_live.ex:2279
+#: lib/abuuba_web/live/settings_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr "Verbergen, wem ich folge und wer mir folgt"
 
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr "Mehr Kontrast"
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr "Wie sich die Oberfläche verhält und liest."
 
-#: lib/abuuba_web/live/settings_live.ex:255
+#: lib/abuuba_web/live/settings_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2277
+#: lib/abuuba_web/live/settings_live.ex:2284
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr "Suchmaschinen meine Beiträge indexieren lassen"
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2282
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr "Mich im Verzeichnis listen"
 
-#: lib/abuuba_web/live/settings_live.ex:2282
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr "Markiert das Konto als Bot, worauf manche Leute filtern."
 
-#: lib/abuuba_web/live/settings_live.ex:273
+#: lib/abuuba_web/live/settings_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/abuuba_web/live/settings_live.ex:977
+#: lib/abuuba_web/live/settings_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr "Es wurde keine App hereingelassen."
 
-#: lib/abuuba_web/live/settings_live.ex:991
+#: lib/abuuba_web/live/settings_live.ex:998
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr "Eine Webadresse pro Zeile. Ein Konto hier zu nennen erlaubt dir später den Umzug dorthin, und es muss dieses hier zurücknennen."
 
-#: lib/abuuba_web/live/settings_live.ex:450
+#: lib/abuuba_web/live/settings_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr "Nur die genannten Leute fehlt mit Absicht: als Voreinstellung wird jeder Beitrag, den du zu ändern vergisst, zu einer Nachricht an niemanden."
 
-#: lib/abuuba_web/live/settings_live.ex:2132
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr "Deine anderen Konten und der Umzug zwischen ihnen."
 
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr "Überschreibt deine Systemeinstellung, wenn sie für dich falsch ist."
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Überblick"
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2109
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2322
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
-#: lib/abuuba_web/live/settings_live.ex:2313
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr "Öffentliche Timelines"
 
-#: lib/abuuba_web/live/settings_live.ex:2286
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr "Bewegung reduzieren"
@@ -1980,166 +1981,166 @@ msgstr "Bewegung reduzieren"
 #: lib/abuuba_web/live/admin_live.ex:1786
 #: lib/abuuba_web/live/admin_live.ex:1878
 #: lib/abuuba_web/live/admin_live.ex:2202
-#: lib/abuuba_web/live/conversations_live.ex:112
-#: lib/abuuba_web/live/settings_live.ex:281
-#: lib/abuuba_web/live/settings_live.ex:316
+#: lib/abuuba_web/live/conversations_live.ex:113
+#: lib/abuuba_web/live/settings_live.ex:282
+#: lib/abuuba_web/live/settings_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2112
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr "Sicherheit"
 
-#: lib/abuuba_web/live/settings_live.ex:909
+#: lib/abuuba_web/live/settings_live.ex:915
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr "Überall abmelden"
 
-#: lib/abuuba_web/live/settings_live.ex:905
+#: lib/abuuba_web/live/settings_live.ex:906
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr "Überall abmelden beendet jede Sitzung, auch diese."
 
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2304
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr "Hält das erste Absenden an, wenn ein Bild keine Beschreibung hat."
 
-#: lib/abuuba_web/live/settings_live.ex:971
+#: lib/abuuba_web/live/settings_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr "Wieder hinausnehmen"
 
-#: lib/abuuba_web/live/admin_live.ex:3750
-#: lib/abuuba_web/live/settings_live.ex:2094
+#: lib/abuuba_web/live/admin_live.ex:3746
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr "Das konnte nicht gespeichert werden. Prüf, was du eingegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1576
+#: lib/abuuba_web/live/settings_live.ex:1583
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr "Das aktuelle Passwort stimmt nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:469
+#: lib/abuuba_web/live/settings_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr "Die Sprache, in der du meistens schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2287
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr "Die Listen sind nicht mehr öffentlich; die Follows selbst funktionieren weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr "Dieses Konto veröffentlicht automatisch"
 
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr "Threads"
 
-#: lib/abuuba_web/live/settings_live.ex:850
+#: lib/abuuba_web/live/settings_live.ex:851
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr "Hak alle an, denen du nicht mehr folgen willst, und drück dann einmal den Knopf."
 
-#: lib/abuuba_web/live/settings_live.ex:875
+#: lib/abuuba_web/live/settings_live.ex:876
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr "Den angehakten entfolgen"
 
-#: lib/abuuba_web/live/settings_live.ex:242
+#: lib/abuuba_web/live/settings_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr "Bis zu vier Zeilen auf deinem Profil. Die Reihenfolge hier ist die Reihenfolge dort."
 
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/settings_live.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr "Die Schrift meines Systems verwenden"
 
-#: lib/abuuba_web/live/settings_live.ex:262
+#: lib/abuuba_web/live/settings_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr "Wert"
 
-#: lib/abuuba_web/live/settings_live.ex:2290
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr "Mich auf fehlende Beschreibungen hinweisen"
 
-#: lib/abuuba_web/live/settings_live.ex:800
+#: lib/abuuba_web/live/settings_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr "Was er tut"
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2133
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr "Womit das Schreibfeld beginnt."
 
 #: lib/abuuba_web/live/admin_live.ex:2178
-#: lib/abuuba_web/live/settings_live.ex:762
+#: lib/abuuba_web/live/settings_live.ex:763
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr "Wie er heißen soll"
 
-#: lib/abuuba_web/live/settings_live.ex:767
+#: lib/abuuba_web/live/settings_live.ex:768
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr "Wo er gilt"
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr "Wer dich finden kann und wer fragen muss, um zu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:456
+#: lib/abuuba_web/live/settings_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr "Wer neue Beiträge zitieren darf"
 
-#: lib/abuuba_web/live/settings_live.ex:437
+#: lib/abuuba_web/live/settings_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr "An wen neue Beiträge gehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr "Wörter und Wendungen, die du lieber nicht siehst."
 
-#: lib/abuuba_web/live/settings_live.ex:871
+#: lib/abuuba_web/live/settings_live.ex:872
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr "Du folgst noch niemandem."
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2283
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr "Dein Konto erscheint auf der öffentlichen Verzeichnisseite dieses Servers."
 
-#: lib/abuuba_web/live/settings_live.ex:887
+#: lib/abuuba_web/live/settings_live.ex:888
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr "Dein aktuelles Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr "Dein Name, was du über dich sagst, deine Felder."
 
-#: lib/abuuba_web/live/settings_live.ex:988
+#: lib/abuuba_web/live/settings_live.ex:995
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr "Deine anderen Konten"
 
-#: lib/abuuba_web/live/settings_live.ex:2130
+#: lib/abuuba_web/live/settings_live.ex:2137
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr "Dein Passwort, Zwei-Faktor und das Abmelden."
@@ -2295,110 +2296,110 @@ msgstr "Beiträge"
 msgid "servers known"
 msgstr "bekannte Server"
 
-#: lib/abuuba_web/live/settings_live.ex:1859
+#: lib/abuuba_web/live/settings_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr "Eine Verwarnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2135
+#: lib/abuuba_web/live/settings_live.ex:2142
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr "Alles, was eine Moderatorin oder ein Moderator hier über dein Konto entschieden hat."
 
-#: lib/abuuba_web/live/settings_live.ex:1197
+#: lib/abuuba_web/live/settings_live.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr "Einspruch einlegen"
 
-#: lib/abuuba_web/live/settings_live.ex:2108
+#: lib/abuuba_web/live/settings_live.ex:2115
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr "Moderation"
 
-#: lib/abuuba_web/live/settings_live.ex:1227
+#: lib/abuuba_web/live/settings_live.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr "Hier ist nichts. Niemand aus der Moderation hat etwas gegen dein Konto unternommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1843
+#: lib/abuuba_web/live/settings_live.ex:1850
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr "Schreib bitte etwas dazu, warum du das für falsch hältst."
 
-#: lib/abuuba_web/live/settings_live.ex:1194
+#: lib/abuuba_web/live/settings_live.ex:1201
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr "Warum hältst du das für falsch?"
 
-#: lib/abuuba_web/live/settings_live.ex:1862
+#: lib/abuuba_web/live/settings_live.ex:1869
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr "Einige deiner Beiträge wurden gelöscht"
 
-#: lib/abuuba_web/live/settings_live.ex:1201
-#: lib/abuuba_web/live/settings_live.ex:1839
+#: lib/abuuba_web/live/settings_live.ex:1208
+#: lib/abuuba_web/live/settings_live.ex:1846
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr "Die Frist für einen Einspruch ist abgelaufen."
 
-#: lib/abuuba_web/live/settings_live.ex:1172
+#: lib/abuuba_web/live/settings_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr "Was die Moderation hier über dein Konto entschieden hat und was dir dazu gesagt wurde."
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1861
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr "Du hast Einspruch eingelegt, er wurde abgelehnt."
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1860
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr "Du hast Einspruch eingelegt, ihm wurde stattgegeben."
 
-#: lib/abuuba_web/live/settings_live.ex:1855
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr "Du hast Einspruch eingelegt. Entschieden ist noch nichts."
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr "Dein Konto wurde deaktiviert"
 
-#: lib/abuuba_web/live/settings_live.ex:1863
+#: lib/abuuba_web/live/settings_live.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr "Dein Konto wurde eingeschränkt"
 
-#: lib/abuuba_web/live/settings_live.ex:1864
+#: lib/abuuba_web/live/settings_live.ex:1871
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr "Dein Konto wurde gesperrt"
 
-#: lib/abuuba_web/live/settings_live.ex:1861
+#: lib/abuuba_web/live/settings_live.ex:1868
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr "Deine Beiträge wurden als sensibel markiert"
 
-#: lib/abuuba_web/live/settings_live.ex:1180
+#: lib/abuuba_web/live/settings_live.ex:1187
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr "inzwischen aufgehoben"
 
-#: lib/abuuba_web/live/settings_live.ex:1218
+#: lib/abuuba_web/live/settings_live.ex:1225
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] "%{count} Verbindung verloren"
 msgstr[1] "%{count} Verbindungen verloren"
 
-#: lib/abuuba_web/live/settings_live.ex:1207
+#: lib/abuuba_web/live/settings_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr "Verbindungen, die dich die Entscheidungen dieses Servers gekostet haben"
 
-#: lib/abuuba_web/live/settings_live.ex:1209
+#: lib/abuuba_web/live/settings_live.ex:1216
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr "Wenn dieser Server die Verbindung zu einem anderen abbricht, gehen die Folgebeziehungen zwischen dir und den Leuten dort verloren. Von hier aus lassen sie sich nicht wiederherstellen, weil die andere Seite nicht mehr erreichbar ist."
@@ -2413,7 +2414,7 @@ msgstr "Eine neue Regel"
 msgid "A rule needs some text."
 msgstr "Eine Regel braucht einen Text."
 
-#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/admin_live.ex:3377
 #, elixir-autogen, elixir-format
 msgid "Accounts"
 msgstr "Konten"
@@ -2431,12 +2432,12 @@ msgid "Address people can write to"
 msgstr "Adresse, an die man schreiben kann"
 
 #: lib/abuuba_web/live/admin_live.ex:228
-#: lib/abuuba_web/live/admin_live.ex:3396
+#: lib/abuuba_web/live/admin_live.ex:3395
 #, elixir-autogen, elixir-format
 msgid "Administration"
 msgstr "Verwaltung"
 
-#: lib/abuuba_web/live/admin_live.ex:3733
+#: lib/abuuba_web/live/admin_live.ex:3729
 #, elixir-autogen, elixir-format
 msgid "An open server left unattended fills with spam registrations within days. Put sign-ups behind approval unless somebody is watching."
 msgstr "Ein offener Server ohne Aufsicht füllt sich innerhalb von Tagen mit Spam-Anmeldungen. Stell Anmeldungen auf Freigabe um, solange niemand mitliest."
@@ -2446,17 +2447,17 @@ msgstr "Ein offener Server ohne Aufsicht füllt sich innerhalb von Tagen mit Spa
 msgid "Any state"
 msgstr "Beliebiger Zustand"
 
-#: lib/abuuba_web/live/admin_live.ex:3718
+#: lib/abuuba_web/live/admin_live.ex:3714
 #, elixir-autogen, elixir-format
 msgid "Anybody may sign up without being checked"
 msgstr "Jede und jeder kann sich ungeprüft anmelden"
 
-#: lib/abuuba_web/live/admin_live.ex:3427
+#: lib/abuuba_web/live/admin_live.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Anybody, after somebody here says yes"
 msgstr "Alle, nachdem jemand hier zustimmt"
 
-#: lib/abuuba_web/live/admin_live.ex:3426
+#: lib/abuuba_web/live/admin_live.ex:3425
 #, elixir-autogen, elixir-format
 msgid "Anybody, straight away"
 msgstr "Alle, sofort"
@@ -2472,7 +2473,7 @@ msgstr "Überall"
 msgid "Appeals waiting"
 msgstr "Offene Einsprüche"
 
-#: lib/abuuba_web/live/admin_live.ex:3395
+#: lib/abuuba_web/live/admin_live.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Audit log"
 msgstr "Protokoll"
@@ -2482,7 +2483,7 @@ msgstr "Protokoll"
 msgid "Change an address only when somebody cannot reach their own."
 msgstr "Ändere eine Adresse nur, wenn jemand die eigene nicht mehr erreicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3377
+#: lib/abuuba_web/live/admin_live.ex:3376
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr "Übersicht"
@@ -2492,7 +2493,7 @@ msgstr "Übersicht"
 msgid "Deleting posts needs the posts named, which this page cannot do yet."
 msgstr "Beiträge zu löschen setzt voraus, dass die Beiträge benannt sind. Das kann diese Seite noch nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3437
+#: lib/abuuba_web/live/admin_live.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Disable: they cannot sign in"
 msgstr "Deaktivieren: Anmeldung nicht mehr möglich"
@@ -2512,7 +2513,7 @@ msgstr "Anderswo"
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
-#: lib/abuuba_web/live/admin_live.ex:3723
+#: lib/abuuba_web/live/admin_live.ex:3719
 #, elixir-autogen, elixir-format
 msgid "Everything else on this page is guesswork until that is fixed."
 msgstr "Alles andere auf dieser Seite ist geraten, solange das nicht behoben ist."
@@ -2542,12 +2543,12 @@ msgstr "Aufnehmen"
 msgid "Lift it"
 msgstr "Aufheben"
 
-#: lib/abuuba_web/live/admin_live.ex:3419
+#: lib/abuuba_web/live/admin_live.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Limited"
 msgstr "Eingeschränkt"
 
-#: lib/abuuba_web/live/admin_live.ex:3438
+#: lib/abuuba_web/live/admin_live.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Mark everything they post sensitive"
 msgstr "Alle Beiträge als sensibel markieren"
@@ -2557,12 +2558,12 @@ msgstr "Alle Beiträge als sensibel markieren"
 msgid "Name or name@server"
 msgstr "Name oder name@server"
 
-#: lib/abuuba_web/live/admin_live.ex:3739
+#: lib/abuuba_web/live/admin_live.ex:3735
 #, elixir-autogen, elixir-format
 msgid "Nobody can grant roles or change settings that need it. Give somebody a role holding the administrator permission."
 msgstr "Niemand kann Rollen vergeben oder Einstellungen ändern, die das voraussetzen. Gib jemandem eine Rolle mit der Administrator-Berechtigung."
 
-#: lib/abuuba_web/live/admin_live.ex:3719
+#: lib/abuuba_web/live/admin_live.ex:3715
 #, elixir-autogen, elixir-format
 msgid "Nobody here is an administrator"
 msgstr "Niemand hier ist Administrator"
@@ -2620,7 +2621,7 @@ msgstr "Rolle"
 msgid "Rules people agree to"
 msgstr "Regeln, denen man zustimmt"
 
-#: lib/abuuba_web/live/admin_live.ex:3434
+#: lib/abuuba_web/live/admin_live.ex:3433
 #, elixir-autogen, elixir-format
 msgid "Send a warning and nothing else"
 msgstr "Nur verwarnen, sonst nichts"
@@ -2631,12 +2632,12 @@ msgstr "Nur verwarnen, sonst nichts"
 msgid "Server name"
 msgstr "Name des Servers"
 
-#: lib/abuuba_web/live/admin_live.ex:3394
+#: lib/abuuba_web/live/admin_live.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Server settings"
 msgstr "Servereinstellungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3727
+#: lib/abuuba_web/live/admin_live.ex:3723
 #, elixir-autogen, elixir-format
 msgid "Servers running authorized fetch will refuse this one. It is created on first use, so this usually means something went wrong writing it."
 msgstr "Server mit Authorized Fetch weisen diesen hier ab. Er wird beim ersten Bedarf angelegt, das heißt hier ist beim Schreiben etwas schiefgegangen."
@@ -2651,17 +2652,17 @@ msgstr "Anzeigen"
 msgid "Shown when somebody signs up and when they file a report."
 msgstr "Wird bei der Anmeldung und beim Melden angezeigt."
 
-#: lib/abuuba_web/live/admin_live.ex:3435
+#: lib/abuuba_web/live/admin_live.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Silence: out of everywhere nobody asked for them"
 msgstr "Einschränken: nicht mehr dort, wo niemand danach gefragt hat"
 
-#: lib/abuuba_web/live/admin_live.ex:3436
+#: lib/abuuba_web/live/admin_live.ex:3435
 #, elixir-autogen, elixir-format
 msgid "Suspend: hidden, and deleted after the grace window"
 msgstr "Sperren: verborgen, nach Ablauf der Frist gelöscht"
 
-#: lib/abuuba_web/live/admin_live.ex:3420
+#: lib/abuuba_web/live/admin_live.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr "Gesperrt"
@@ -2671,7 +2672,7 @@ msgstr "Gesperrt"
 msgid "Talk only to servers on the allowlist"
 msgstr "Nur mit Servern auf der Positivliste sprechen"
 
-#: lib/abuuba_web/live/admin_live.ex:3345
+#: lib/abuuba_web/live/admin_live.ex:3344
 #, elixir-autogen, elixir-format
 msgid "That account outranks yours, so there is nothing here you can do to it."
 msgstr "Dieses Konto steht über deinem, hier kannst du nichts damit machen."
@@ -2693,13 +2694,13 @@ msgid "That is not an address."
 msgstr "Das ist keine Adresse."
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
-#: lib/abuuba_web/live/admin_live.ex:3340
-#: lib/abuuba_web/live/settings_live.ex:1629
+#: lib/abuuba_web/live/admin_live.ex:3339
+#: lib/abuuba_web/live/settings_live.ex:1636
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr "Das kann dein Konto nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3716
+#: lib/abuuba_web/live/admin_live.ex:3712
 #, elixir-autogen, elixir-format
 msgid "The database is not answering"
 msgstr "Die Datenbank antwortet nicht"
@@ -2714,7 +2715,7 @@ msgstr "Dieses Konto steht über deinem, hier kannst du nichts damit machen."
 msgid "This deletes the account as well. Go ahead?"
 msgstr "Damit wird auch das Konto gelöscht. Fortfahren?"
 
-#: lib/abuuba_web/live/admin_live.ex:3717
+#: lib/abuuba_web/live/admin_live.ex:3713
 #, elixir-autogen, elixir-format
 msgid "This server has no actor of its own"
 msgstr "Dieser Server hat keinen eigenen Actor"
@@ -2724,7 +2725,7 @@ msgstr "Dieser Server hat keinen eigenen Actor"
 msgid "Turn away"
 msgstr "Ablehnen"
 
-#: lib/abuuba_web/live/admin_live.ex:3418
+#: lib/abuuba_web/live/admin_live.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Waiting to be let in"
 msgstr "Wartet auf Aufnahme"
@@ -2818,7 +2819,7 @@ msgstr "Ablehnen"
 msgid "Take it down"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/admin_live.ex:3384
+#: lib/abuuba_web/live/admin_live.ex:3383
 #, elixir-autogen, elixir-format
 msgid "Trends"
 msgstr "Trends"
@@ -2828,17 +2829,17 @@ msgstr "Trends"
 msgid "What is trending now"
 msgstr "Was gerade im Trend liegt"
 
-#: lib/abuuba_web/live/explore_live.ex:76
+#: lib/abuuba_web/live/explore_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr "Worüber gerade mehr Leute als sonst schreiben, danach alles Übrige, das Neueste zuerst."
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr "%{uses} von %{max} genutzt"
 
-#: lib/abuuba_web/live/settings_live.ex:1243
+#: lib/abuuba_web/live/settings_live.ex:1250
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr "Ein Code, mit dem sich jemand anmelden kann, auch wenn Anmeldungen geschlossen sind. Lass die Anzahl leer für beliebig viele."
@@ -2848,12 +2849,12 @@ msgstr "Ein Code, mit dem sich jemand anmelden kann, auch wenn Anmeldungen gesch
 msgid "An announcement needs some text."
 msgstr "Eine Ankündigung braucht einen Text."
 
-#: lib/abuuba_web/live/admin_live.ex:3385
+#: lib/abuuba_web/live/admin_live.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Announcements"
 msgstr "Ankündigungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2144
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr "Codes, mit denen sich Bekannte von dir anmelden können."
@@ -2868,7 +2869,7 @@ msgstr "Jede Fassung wird mit dem Tag aufbewahrt, an dem sie gilt, damit man nac
 msgid "Earlier versions"
 msgstr "Frühere Fassungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3796
+#: lib/abuuba_web/live/admin_live.ex:3792
 #, elixir-autogen, elixir-format
 msgid "Everybody has already been told about that one."
 msgstr "Darüber wurden bereits alle informiert."
@@ -2878,7 +2879,7 @@ msgstr "Darüber wurden bereits alle informiert."
 msgid "Goes up"
 msgstr "Erscheint"
 
-#: lib/abuuba_web/live/settings_live.ex:1254
+#: lib/abuuba_web/live/settings_live.ex:1261
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr "Wie viele Personen"
@@ -2893,12 +2894,12 @@ msgstr "Gültig ab"
 msgid "In effect from %{date}"
 msgstr "Gültig ab %{date}"
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr "Einladungen"
 
-#: lib/abuuba_web/live/settings_live.ex:1238
+#: lib/abuuba_web/live/settings_live.ex:1245
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
@@ -2908,7 +2909,7 @@ msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
 msgid "Leave this empty to publish it now."
 msgstr "Leer lassen, um sofort zu veröffentlichen."
 
-#: lib/abuuba_web/live/settings_live.ex:1261
+#: lib/abuuba_web/live/settings_live.ex:1268
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr "Erstellen"
@@ -2938,7 +2939,7 @@ msgstr "Veröffentlicht"
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr "Etwas, das hier alle lesen sollten. Mit einer Uhrzeit veröffentlicht es sich selbst, sodass ein Hinweis auf Sonntag schon am Donnerstag geschrieben werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1275
+#: lib/abuuba_web/live/settings_live.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr "Zurücknehmen"
@@ -2953,12 +2954,12 @@ msgstr "Alle informieren"
 msgid "Terms need some text and a day they take effect."
 msgstr "Nutzungsbedingungen brauchen einen Text und einen Tag, ab dem sie gelten."
 
-#: lib/abuuba_web/live/settings_live.ex:1259
+#: lib/abuuba_web/live/settings_live.ex:1266
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr "Sie folgen dir"
 
-#: lib/abuuba_web/live/settings_live.ex:1250
+#: lib/abuuba_web/live/settings_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr "Wofür sie ist"
@@ -2979,7 +2980,7 @@ msgstr "Wann es veröffentlicht wird"
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr "Du meldest dich auf eine Einladung hin an, eine Freigabe brauchst du deshalb nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:1281
+#: lib/abuuba_web/live/settings_live.ex:1288
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr "Du hast noch keine erstellt."
@@ -2989,7 +2990,7 @@ msgstr "Du hast noch keine erstellt."
 msgid "everybody was told"
 msgstr "alle wurden informiert"
 
-#: lib/abuuba_web/live/settings_live.ex:2089
+#: lib/abuuba_web/live/settings_live.ex:2096
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3006,7 +3007,7 @@ msgstr "Adressen"
 msgid "Anywhere in a name"
 msgstr "Irgendwo im Namen"
 
-#: lib/abuuba_web/live/admin_live.ex:3778
+#: lib/abuuba_web/live/admin_live.ex:3774
 #, elixir-autogen, elixir-format
 msgid "Ask for approval"
 msgstr "Freigabe verlangen"
@@ -3033,12 +3034,12 @@ msgstr "Als Hashes gespeichert, nicht als Adressen. Die Liste muss jemanden wied
 msgid "Mail domains"
 msgstr "Mail-Domains"
 
-#: lib/abuuba_web/live/admin_live.ex:3780
+#: lib/abuuba_web/live/admin_live.ex:3776
 #, elixir-autogen, elixir-format
 msgid "No access at all"
 msgstr "Gar kein Zugriff"
 
-#: lib/abuuba_web/live/admin_live.ex:3779
+#: lib/abuuba_web/live/admin_live.ex:3775
 #, elixir-autogen, elixir-format
 msgid "No sign-ups"
 msgstr "Keine Anmeldungen"
@@ -3058,7 +3059,7 @@ msgstr "Nur Freigabe verlangen"
 msgid "Please complete the puzzle so we know you are a person."
 msgstr "Bitte löse das Rätsel, damit wir wissen, dass du ein Mensch bist."
 
-#: lib/abuuba_web/live/admin_live.ex:3386
+#: lib/abuuba_web/live/admin_live.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Sign-up blocks"
 msgstr "Anmeldesperren"
@@ -3103,14 +3104,14 @@ msgstr "nur mit Freigabe"
 msgid "by %{name}"
 msgstr "von %{name}"
 
-#: lib/abuuba_web/live/home_live.ex:338
-#: lib/abuuba_web/live/post_actions.ex:297
-#: lib/abuuba_web/live/status_live.ex:185
+#: lib/abuuba_web/live/home_live.ex:357
+#: lib/abuuba_web/live/post_actions.ex:395
+#: lib/abuuba_web/live/status_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "That could not be translated just now."
 msgstr "Das ließ sich gerade nicht übersetzen."
 
-#: lib/abuuba_web/components/status_component.ex:446
+#: lib/abuuba_web/components/status_component.ex:469
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
@@ -3125,245 +3126,245 @@ msgstr "Übersetzt von %{provider}. Lade die Seite neu für das Original."
 msgid "This account has been disabled. Contact the moderators."
 msgstr "Dieses Konto wurde deaktiviert. Wende dich an die Moderation."
 
-#: lib/abuuba_web/live/settings_live.ex:1988
+#: lib/abuuba_web/live/settings_live.ex:1995
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr "%{count} konnten nicht übernommen werden"
 
-#: lib/abuuba_web/live/settings_live.ex:1979
+#: lib/abuuba_web/live/settings_live.ex:1986
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr "%{done} von %{total} gelesen, %{imported} übernommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1895
+#: lib/abuuba_web/live/settings_live.ex:1902
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr "Boosts und Umfragen. Ein Boost verweist auf den Beitrag einer anderen Person, den das Archiv nicht enthält, und die Stimmen einer Umfrage wären hier nicht mehr richtig."
 
-#: lib/abuuba_web/live/settings_live.ex:2052
+#: lib/abuuba_web/live/settings_live.ex:2059
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr "Wähle zuerst ein Archiv aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1876
+#: lib/abuuba_web/live/settings_live.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr "Jeder Fediverse-Server gibt dir ein ZIP mit allem, was du geschrieben hast. Lade es hier hoch, und deine Beiträge kommen zurück, mit ihren Bildern und ihrem ursprünglichen Datum."
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2082
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr "Fertig."
 
-#: lib/abuuba_web/live/settings_live.ex:2110
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
 
-#: lib/abuuba_web/live/settings_live.ex:1901
+#: lib/abuuba_web/live/settings_live.ex:1908
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr "Importierte Beiträge tauchen in keiner Timeline auf und gehen nicht ins Netzwerk. Sie stehen in deinem Profil, in der Reihenfolge, in der du sie geschrieben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr "Ein Archiv auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:2140
+#: lib/abuuba_web/live/settings_live.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr "Ein Archiv deiner Beiträge von einem anderen Server wieder einlesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr "Dein Archiv wird gelesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2076
+#: lib/abuuba_web/live/settings_live.ex:2083
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr "Das Archiv konnte nicht gelesen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2048
+#: lib/abuuba_web/live/settings_live.ex:2055
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr "Das konnte nicht gelesen werden. Lade das Archiv hoch, das dir dein alter Server gegeben hat."
 
-#: lib/abuuba_web/live/settings_live.ex:2063
-#: lib/abuuba_web/live/settings_live.ex:2068
+#: lib/abuuba_web/live/settings_live.ex:2070
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr "Das konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2072
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr "Das ist keine Archivdatei."
 
-#: lib/abuuba_web/live/settings_live.ex:1885
+#: lib/abuuba_web/live/settings_live.ex:1892
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr "Die alten Adressen. Deine Beiträge lagen auf einer anderen Domain und können dort nicht wieder liegen, also bleibt jeder Link darauf tot."
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr "Wartet auf den Start."
 
-#: lib/abuuba_web/live/settings_live.ex:1882
+#: lib/abuuba_web/live/settings_live.ex:1889
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr "Was nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:1890
+#: lib/abuuba_web/live/settings_live.ex:1897
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr "Deine Follower. Ein Follow ist eine Abmachung zwischen zwei Servern, und einer davon ist weg; sie müssen diesem Konto neu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:2079
+#: lib/abuuba_web/live/settings_live.ex:2086
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr "ein Boost, der nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2088
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr "eine Umfrage, die nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2089
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr "kein Datum, also kein Platz dafür"
 
-#: lib/abuuba_web/live/settings_live.ex:2085
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr "die Datei ist kein Archiv"
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2090
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr "der Beitrag wurde nicht gefunden"
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr "dieser Server hat ihn nicht angenommen"
 
-#: lib/abuuba_web/live/settings_live.ex:1046
+#: lib/abuuba_web/live/settings_live.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr "Alle annehmen"
 
-#: lib/abuuba_web/live/settings_live.ex:1934
+#: lib/abuuba_web/live/settings_live.ex:1941
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr "Dazu hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:1041
+#: lib/abuuba_web/live/settings_live.ex:1048
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr "Nach einem Umzug kommen alle, die dir gefolgt sind, auf einmal an. Das nimmt sie alle an, was dieselbe Antwort ist, die du ihnen schon gegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1952
+#: lib/abuuba_web/live/settings_live.ex:1959
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr "Ein Archiv deiner Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:1051
+#: lib/abuuba_web/live/settings_live.ex:1058
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr "Für den Export deiner Daten und das Löschen des Kontos steht die Arbeit noch aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1039
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr "Wartende Folgeanfragen"
 
-#: lib/abuuba_web/live/settings_live.ex:1008
+#: lib/abuuba_web/live/settings_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr "Ich bin zurück"
 
-#: lib/abuuba_web/live/settings_live.ex:1965
+#: lib/abuuba_web/live/settings_live.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr "Archiv importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1942
+#: lib/abuuba_web/live/settings_live.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr "Liste importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1065
-#: lib/abuuba_web/live/settings_live.ex:1914
-#: lib/abuuba_web/live/settings_live.ex:2245
+#: lib/abuuba_web/live/settings_live.ex:1072
+#: lib/abuuba_web/live/settings_live.ex:1921
+#: lib/abuuba_web/live/settings_live.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr "Listen"
 
-#: lib/abuuba_web/live/settings_live.ex:1035
+#: lib/abuuba_web/live/settings_live.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr "Umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:1019
+#: lib/abuuba_web/live/settings_live.ex:1026
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr "Zu einem anderen Konto umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2038
+#: lib/abuuba_web/live/settings_live.ex:2045
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr "Unter dieser Adresse war niemand zu finden."
 
-#: lib/abuuba_web/live/settings_live.ex:1003
+#: lib/abuuba_web/live/settings_live.ex:1010
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr "Anderen Servern wird gesagt, dass sie stattdessen dem neuen Konto folgen sollen. Wer dir von diesem Server aus folgt, ist bereits umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1938
+#: lib/abuuba_web/live/settings_live.ex:1945
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr "Durch die Datei ersetzen"
 
-#: lib/abuuba_web/live/settings_live.ex:2028
+#: lib/abuuba_web/live/settings_live.ex:2035
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr "Dieses Konto nennt dieses hier nicht als eines von deinen. Trage die Adresse dieses Kontos zuerst dort bei den Aliassen ein."
 
-#: lib/abuuba_web/live/settings_live.ex:2039
+#: lib/abuuba_web/live/settings_live.ex:2046
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr "Das ist dieses Konto."
 
-#: lib/abuuba_web/live/settings_live.ex:1916
+#: lib/abuuba_web/live/settings_live.ex:1923
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr "Die CSV-Dateien, die dir dein alter Server gibt: Follows, Blocks, Stummschaltungen, Domain-Blocks, Listen, Lesezeichen, Filter. Lade sie einzeln hoch, unter dem Namen, unter dem sie kamen."
 
-#: lib/abuuba_web/live/settings_live.ex:1029
+#: lib/abuuba_web/live/settings_live.ex:1036
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr "Das andere Konto muss dieses hier zuerst in seinen eigenen Aliassen nennen. Deine Follower hier ziehen mit um, und alle anderen Server werden benachrichtigt; ein Konto kann nur alle %{days} Tage umziehen."
 
-#: lib/abuuba_web/live/settings_live.ex:1001
+#: lib/abuuba_web/live/settings_live.ex:1008
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1931
+#: lib/abuuba_web/live/settings_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr "Was mit dem passieren soll, was schon da ist"
 
-#: lib/abuuba_web/live/settings_live.ex:2034
+#: lib/abuuba_web/live/settings_live.ex:2041
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr "Du bist vor Kurzem umgezogen. Ein Konto kann nur alle %{days} Tage umziehen."
@@ -3373,27 +3374,27 @@ msgstr "Du bist vor Kurzem umgezogen. Ein Konto kann nur alle %{days} Tage umzie
 msgid "No such post here."
 msgstr "So einen Beitrag gibt es hier nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:245
+#: lib/abuuba_web/live/settings_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr "Ein Link bekommt einen Haken, sobald die Seite, auf die er zeigt, mit rel=\"me\" auf dein Profil zurückverweist. Wir schauen etwa einmal pro Woche wieder nach."
 
-#: lib/abuuba_web/live/settings_live.ex:783
+#: lib/abuuba_web/live/settings_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr "Ein Wort pro Zeile. Ein Beitrag passt, wenn eines davon darin vorkommt."
 
-#: lib/abuuba_web/live/settings_live.ex:796
+#: lib/abuuba_web/live/settings_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr "Nur ganze Wörter, damit „Katze“ nicht auf „Katzenklo“ passt"
 
-#: lib/abuuba_web/live/settings_live.ex:780
+#: lib/abuuba_web/live/settings_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr "Wonach gesucht wird"
 
-#: lib/abuuba_web/live/settings_live.ex:1515
+#: lib/abuuba_web/live/settings_live.ex:1522
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr "Ein Filter braucht mindestens ein Wort, nach dem er suchen soll."
@@ -3403,54 +3404,54 @@ msgstr "Ein Filter braucht mindestens ein Wort, nach dem er suchen soll."
 msgid "Why they want to join:"
 msgstr "Warum die Person mitmachen möchte:"
 
-#: lib/abuuba_web/live/settings_live.ex:308
+#: lib/abuuba_web/live/settings_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] "%{count} Beitrag"
 msgstr[1] "%{count} Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:325
+#: lib/abuuba_web/live/settings_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr "Ein Hashtag, ohne das #"
 
-#: lib/abuuba_web/live/settings_live.ex:328
+#: lib/abuuba_web/live/settings_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Feature it"
 msgstr "Hervorheben"
 
-#: lib/abuuba_web/live/settings_live.ex:299
+#: lib/abuuba_web/live/settings_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr "Hervorgehobene Hashtags"
 
-#: lib/abuuba_web/live/settings_live.ex:301
+#: lib/abuuba_web/live/settings_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr "Stehen auf deinem Profil als Abkürzung zu dem, worüber du schreibst."
 
-#: lib/abuuba_web/live/settings_live.ex:1498
+#: lib/abuuba_web/live/settings_live.ex:1505
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr "Das ist kein Hashtag, den man benutzen kann."
 
-#: lib/abuuba_web/live/settings_live.ex:332
+#: lib/abuuba_web/live/settings_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr "Du schreibst oft über:"
 
-#: lib/abuuba_web/live/settings_live.ex:1492
+#: lib/abuuba_web/live/settings_live.ex:1499
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr "Ein Profil kann %{count} Hashtags tragen. Nimm zuerst einen weg."
 
-#: lib/abuuba_web/live/settings_live.ex:483
+#: lib/abuuba_web/live/settings_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr "Sagen, aus welcher App du schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:485
+#: lib/abuuba_web/live/settings_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr "Steht für alle anderen unter deinen Beiträgen. An deinen eigenen siehst du es immer."
@@ -3487,7 +3488,7 @@ msgid_plural "%{count} accounts"
 msgstr[0] "%{count} Konto"
 msgstr[1] "%{count} Konten"
 
-#: lib/abuuba_web/live/collection_live.ex:117
+#: lib/abuuba_web/live/collection_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "A collection by %{name}"
 msgstr "Eine Sammlung von %{name}"
@@ -3598,7 +3599,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr "Jede Person muss es zusätzlich für sich selbst einschalten, und jede Adresse muss bestätigen, bevor irgendetwas dorthin geht."
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:646
+#: lib/abuuba_web/live/settings_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "Email updates"
 msgstr "Neuigkeiten per E-Mail"
@@ -3613,7 +3614,7 @@ msgstr "Neuigkeiten per E-Mail von %{name}"
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr "Wenn du das nicht warst, kannst du diese Nachricht ignorieren. An diese Adresse geht dann nichts weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:664
+#: lib/abuuba_web/live/settings_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr "Leute dürfen meine Neuigkeiten per E-Mail abonnieren"
@@ -3623,7 +3624,7 @@ msgstr "Leute dürfen meine Neuigkeiten per E-Mail abonnieren"
 msgid "No, remove my address"
 msgstr "Nein, meine Adresse löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:666
+#: lib/abuuba_web/live/settings_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3676,7 +3677,7 @@ msgstr "jemand hat diese Adresse angegeben, um Neuigkeiten von %{name} auf %{sit
 msgid "Let people collect email addresses for updates"
 msgstr "Erlaube es, E-Mail-Adressen für Neuigkeiten zu sammeln"
 
-#: lib/abuuba_web/live/settings_live.ex:648
+#: lib/abuuba_web/live/settings_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr "Wer hier kein Konto möchte, kann stattdessen eine E-Mail-Adresse angeben. Die Adresse bestätigt selbst und kann die Neuigkeiten aus jeder Nachricht heraus wieder abbestellen. Verschickt wird noch nichts; das hier sammelt die Liste."
@@ -3824,75 +3825,75 @@ msgstr "jemand hat für dein Konto auf %{site} ein neues Passwort angefordert. W
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr "das Passwort deines Kontos auf %{site} wurde gerade geändert, und überall, wo du angemeldet warst, wurdest du abgemeldet."
 
-#: lib/abuuba_web/live/settings_live.ex:1078
+#: lib/abuuba_web/live/settings_live.ex:1085
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr "Eine Kopie von allem"
 
-#: lib/abuuba_web/live/settings_live.ex:2252
+#: lib/abuuba_web/live/settings_live.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr "Wird gebaut"
 
-#: lib/abuuba_web/live/settings_live.ex:811
-#: lib/abuuba_web/live/settings_live.ex:2246
+#: lib/abuuba_web/live/settings_live.ex:812
+#: lib/abuuba_web/live/settings_live.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr "Blockierte Server"
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2243
+#: lib/abuuba_web/live/settings_live.ex:2250
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr "Blockierte"
 
-#: lib/abuuba_web/live/settings_live.ex:2247
+#: lib/abuuba_web/live/settings_live.ex:2254
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/abuuba_web/live/settings_live.ex:1120
+#: lib/abuuba_web/live/settings_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr "Bau mir eine Kopie"
 
-#: lib/abuuba_web/live/settings_live.ex:2254
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr "Hat nicht geklappt"
 
-#: lib/abuuba_web/live/settings_live.ex:1103
+#: lib/abuuba_web/live/settings_live.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr "Herunterladen"
 
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2118
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr "Exportieren"
 
-#: lib/abuuba_web/live/settings_live.ex:2244
+#: lib/abuuba_web/live/settings_live.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr "Stummgeschaltete"
 
-#: lib/abuuba_web/live/settings_live.ex:1067
+#: lib/abuuba_web/live/settings_live.ex:1074
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr "Je eine Datei, im Format, das der Import dieses Servers liest. Ein Export von hier ist ein Import anderswo."
 
-#: lib/abuuba_web/live/settings_live.ex:1388
+#: lib/abuuba_web/live/settings_live.ex:1395
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr "Eine wird gerade schon gebaut."
 
-#: lib/abuuba_web/live/settings_live.ex:1085
+#: lib/abuuba_web/live/settings_live.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr "Bilder und Videos sind nicht in der Datei. Sie enthält ihre Adressen, die funktionieren, solange dieser Server läuft."
 
-#: lib/abuuba_web/live/settings_live.ex:2253
+#: lib/abuuba_web/live/settings_live.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr "Fertig"
@@ -3912,13 +3913,13 @@ msgstr "Die Datei wird nach %{days} Tagen gelöscht, weil sie dein ganzes Konto 
 msgid "There is nothing of that kind to export."
 msgstr "So etwas gibt es hier nicht zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:2251
+#: lib/abuuba_web/live/settings_live.ex:2258
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr "Wartet auf den Start"
 
-#: lib/abuuba_web/live/settings_live.ex:1109
-#: lib/abuuba_web/live/settings_live.ex:1394
+#: lib/abuuba_web/live/settings_live.ex:1116
+#: lib/abuuba_web/live/settings_live.ex:1401
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr "Ab %{date} kannst du eine neue anfordern."
@@ -3928,7 +3929,7 @@ msgstr "Ab %{date} kannst du eine neue anfordern."
 msgid "Your archive is ready"
 msgstr "Deine Kopie ist fertig"
 
-#: lib/abuuba_web/live/settings_live.ex:1080
+#: lib/abuuba_web/live/settings_live.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wird im Hintergrund gebaut; wir schicken dir eine E-Mail, wenn sie fertig ist."
@@ -3938,67 +3939,67 @@ msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wi
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr "die Kopie deines Kontos auf %{site}, die du angefordert hast, ist fertig. Hier herunterladen:"
 
-#: lib/abuuba_web/live/settings_live.ex:1159
+#: lib/abuuba_web/live/settings_live.ex:1166
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr "Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1157
+#: lib/abuuba_web/live/settings_live.ex:1164
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr "Das Konto endgültig schließen? Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1123
+#: lib/abuuba_web/live/settings_live.ex:1130
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr "Dieses Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1062
+#: lib/abuuba_web/live/settings_live.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr "Alles hier gehört dir, und das Konto zu schließen ist deine Entscheidung."
 
-#: lib/abuuba_web/live/settings_live.ex:2143
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr "Eine Kopie von allem mitnehmen, oder das Konto endgültig schließen."
 
-#: lib/abuuba_web/live/settings_live.ex:1140
+#: lib/abuuba_web/live/settings_live.ex:1147
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr "Hol dir vorher deine Kopie. Danach gibt es nichts mehr zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:1421
+#: lib/abuuba_web/live/settings_live.ex:1428
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr "Das hat nicht geklappt. Es wurde nichts gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:1418
+#: lib/abuuba_web/live/settings_live.ex:1425
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr "Das ist nicht dein Passwort."
 
-#: lib/abuuba_web/live/settings_live.ex:1130
+#: lib/abuuba_web/live/settings_live.ex:1137
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr "Das Konto verschwindet sofort. Die Datensätze werden kurz danach gelöscht, damit die Nachricht an die anderen Server noch signiert und verschickt werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1414
+#: lib/abuuba_web/live/settings_live.ex:1421
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr "Das Konto ist geschlossen. Danke, dass du hier warst."
 
-#: lib/abuuba_web/live/settings_live.ex:1145
+#: lib/abuuba_web/live/settings_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr "Dein Passwort, damit sicher ist, dass du es bist"
 
-#: lib/abuuba_web/live/settings_live.ex:1125
+#: lib/abuuba_web/live/settings_live.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr "Deine Beiträge, Folge-Beziehungen, Listen, Filter, Lesezeichen und Einstellungen werden gelöscht, und andere Server werden aufgefordert, ihre Kopien zu löschen. Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1135
+#: lib/abuuba_web/live/settings_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr "Dein Benutzername bleibt und niemand kann ihn je bekommen, damit alte Links und Erwähnungen von dir nie auf jemand anderen zeigen."
@@ -4044,99 +4045,99 @@ msgstr "Diese Einladung kennen wir nicht."
 msgid "You can still sign up without one."
 msgstr "Du kannst dich trotzdem ohne eine anmelden."
 
-#: lib/abuuba_web/live/settings_live.ex:1450
+#: lib/abuuba_web/live/settings_live.ex:1457
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr "Ein Alter muss mindestens 7 Tage betragen, und die Anzahlen dürfen nicht negativ sein."
 
-#: lib/abuuba_web/live/settings_live.ex:915
+#: lib/abuuba_web/live/settings_live.ex:922
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr "Gescheiterte Versuche stehen hier ebenfalls. Dass jemand anderes dein Passwort probiert, sollte man früh mitbekommen, und nichts sonst würde es dir sagen."
 
-#: lib/abuuba_web/live/settings_live.ex:524
+#: lib/abuuba_web/live/settings_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr "Meine alten Beiträge löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:533
+#: lib/abuuba_web/live/settings_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr "Beiträge löschen, die älter sind als, in Tagen"
 
-#: lib/abuuba_web/live/settings_live.ex:552
+#: lib/abuuba_web/live/settings_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr "Angeheftete Beiträge behalten"
 
-#: lib/abuuba_web/live/settings_live.ex:579
+#: lib/abuuba_web/live/settings_live.ex:580
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr "Beiträge behalten, die mindestens so oft geboostet wurden"
 
-#: lib/abuuba_web/live/settings_live.ex:568
+#: lib/abuuba_web/live/settings_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr "Beiträge behalten, die mindestens so oft favorisiert wurden"
 
-#: lib/abuuba_web/live/settings_live.ex:564
+#: lib/abuuba_web/live/settings_live.ex:565
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr "Beiträge mit Bildern oder Video behalten"
 
-#: lib/abuuba_web/live/settings_live.ex:938
+#: lib/abuuba_web/live/settings_live.ex:945
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr "Wird %{days} Tage aufgehoben und dann gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:521
+#: lib/abuuba_web/live/settings_live.ex:522
 #, elixir-autogen, elixir-format
 msgid "Nothing pinned."
 msgstr "Nichts angeheftet."
 
-#: lib/abuuba_web/live/settings_live.ex:934
+#: lib/abuuba_web/live/settings_live.ex:941
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr "Noch nichts aufgezeichnet."
 
-#: lib/abuuba_web/live/settings_live.ex:526
+#: lib/abuuba_web/live/settings_live.ex:527
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr "Aus, solange du es nicht einschaltest. Lass das Alter leer, um es wieder auszuschalten; bis du eines setzt, wird nichts gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:590
+#: lib/abuuba_web/live/settings_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] "Ein Beitrag passt gerade auf diese Einstellungen."
 msgstr[1] "%{count} Beiträge passen gerade auf diese Einstellungen."
 
-#: lib/abuuba_web/live/settings_live.ex:501
+#: lib/abuuba_web/live/settings_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Pinned posts"
 msgstr "Angeheftete Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:913
+#: lib/abuuba_web/live/settings_live.ex:920
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr "Letzte Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:923
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr "Abgelehnt"
 
-#: lib/abuuba_web/live/settings_live.ex:923
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr "Angemeldet"
 
-#: lib/abuuba_web/live/settings_live.ex:515
+#: lib/abuuba_web/live/settings_live.ex:516
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr "Lösen"
 
-#: lib/abuuba_web/live/settings_live.ex:503
+#: lib/abuuba_web/live/settings_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr "Was oben auf deinem Profil steht. Angeheftet wird vom Beitrag aus."
@@ -4208,17 +4209,17 @@ msgstr "Letzter Fehler:"
 msgid "No relays yet."
 msgstr "Noch keine Relays."
 
-#: lib/abuuba_web/live/admin_live.ex:3681
+#: lib/abuuba_web/live/admin_live.ex:3677
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr "Aus"
 
-#: lib/abuuba_web/live/admin_live.ex:3683
+#: lib/abuuba_web/live/admin_live.ex:3679
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr "An"
 
-#: lib/abuuba_web/live/admin_live.ex:3387
+#: lib/abuuba_web/live/admin_live.ex:3386
 #, elixir-autogen, elixir-format
 msgid "Relays"
 msgstr "Relays"
@@ -4233,7 +4234,7 @@ msgstr "Dieses Relay entfernen?"
 msgid "That is not an https inbox address, or it is already here."
 msgstr "Das ist keine https-Inbox-Adresse, oder sie ist schon da."
 
-#: lib/abuuba_web/live/admin_live.ex:3684
+#: lib/abuuba_web/live/admin_live.ex:3680
 #, elixir-autogen, elixir-format
 msgid "The relay refused"
 msgstr "Das Relay hat abgelehnt"
@@ -4255,7 +4256,7 @@ msgstr "Ausschalten"
 msgid "Turn on"
 msgstr "Einschalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3682
+#: lib/abuuba_web/live/admin_live.ex:3678
 #, elixir-autogen, elixir-format
 msgid "Waiting for the relay to answer"
 msgstr "Wartet auf die Antwort des Relays"
@@ -4295,18 +4296,18 @@ msgstr "Noch nichts verschickt."
 msgid "Remove this webhook?"
 msgstr "Diesen Webhook entfernen?"
 
-#: lib/abuuba_web/live/admin_live.ex:3109
-#: lib/abuuba_web/live/admin_live.ex:3677
+#: lib/abuuba_web/live/admin_live.ex:3108
+#: lib/abuuba_web/live/admin_live.ex:3673
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr "Das hat nicht geklappt."
 
-#: lib/abuuba_web/live/admin_live.ex:3674
+#: lib/abuuba_web/live/admin_live.ex:3670
 #, elixir-autogen, elixir-format
 msgid "That is not an event this server sends."
 msgstr "So ein Ereignis verschickt dieser Server nicht."
 
-#: lib/abuuba_web/live/admin_live.ex:3671
+#: lib/abuuba_web/live/admin_live.ex:3667
 #, elixir-autogen, elixir-format
 msgid "That is not an https address, or it is already here."
 msgstr "Das ist keine https-Adresse, oder sie ist schon da."
@@ -4326,7 +4327,7 @@ msgstr "Das Signatur-Geheimnis"
 msgid "This server posts to a webhook when something happens that a moderator would want to know about."
 msgstr "Dieser Server schickt etwas an einen Webhook, wenn etwas passiert, das die Moderation wissen möchte."
 
-#: lib/abuuba_web/live/admin_live.ex:3393
+#: lib/abuuba_web/live/admin_live.ex:3392
 #, elixir-autogen, elixir-format
 msgid "Webhooks"
 msgstr "Webhooks"
@@ -4346,37 +4347,37 @@ msgstr "Eine Rolle ist ein Satz Berechtigungen und eine Position. Die Position e
 msgid "Above yours"
 msgstr "Über deiner"
 
-#: lib/abuuba_web/live/admin_live.ex:3590
+#: lib/abuuba_web/live/admin_live.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Act on accounts"
 msgstr "Auf Konten einwirken"
 
-#: lib/abuuba_web/live/admin_live.ex:3594
+#: lib/abuuba_web/live/admin_live.ex:3590
 #, elixir-autogen, elixir-format
 msgid "Answer appeals"
 msgstr "Einsprüche beantworten"
 
-#: lib/abuuba_web/live/admin_live.ex:3620
+#: lib/abuuba_web/live/admin_live.ex:3616
 #, elixir-autogen, elixir-format
 msgid "Approve registrations, and turn two-factor off for somebody locked out."
 msgstr "Anmeldungen freigeben und die Zwei-Faktor-Anmeldung für Ausgesperrte abschalten."
 
-#: lib/abuuba_web/live/admin_live.ex:3598
+#: lib/abuuba_web/live/admin_live.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Approve what trends"
 msgstr "Freigeben, was in den Trends erscheint"
 
-#: lib/abuuba_web/live/admin_live.ex:3628
+#: lib/abuuba_web/live/admin_live.ex:3624
 #, elixir-autogen, elixir-format
 msgid "Block and unblock other servers, and set up relays."
 msgstr "Andere Server blockieren und freigeben, und Relays einrichten."
 
-#: lib/abuuba_web/live/admin_live.ex:3596
+#: lib/abuuba_web/live/admin_live.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Block sign-ups"
 msgstr "Anmeldungen blockieren"
 
-#: lib/abuuba_web/live/admin_live.ex:3597
+#: lib/abuuba_web/live/admin_live.ex:3593
 #, elixir-autogen, elixir-format
 msgid "Change the server's settings"
 msgstr "Die Einstellungen des Servers ändern"
@@ -4391,62 +4392,62 @@ msgstr "Farbe"
 msgid "Create the role"
 msgstr "Rolle anlegen"
 
-#: lib/abuuba_web/live/admin_live.ex:3595
+#: lib/abuuba_web/live/admin_live.ex:3591
 #, elixir-autogen, elixir-format
 msgid "Decide about other servers"
 msgstr "Über andere Server entscheiden"
 
-#: lib/abuuba_web/live/admin_live.ex:3634
+#: lib/abuuba_web/live/admin_live.ex:3630
 #, elixir-autogen, elixir-format
 msgid "Decide which hashtags, links and posts may appear in what is trending."
 msgstr "Entscheiden, welche Hashtags, Links und Beiträge in den Trends erscheinen dürfen."
 
-#: lib/abuuba_web/live/admin_live.ex:3592
+#: lib/abuuba_web/live/admin_live.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Delete an account's data"
 msgstr "Die Daten eines Kontos löschen"
 
-#: lib/abuuba_web/live/admin_live.ex:3623
+#: lib/abuuba_web/live/admin_live.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Delete somebody's posts and files. This cannot be undone."
 msgstr "Beiträge und Dateien einer Person löschen. Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/admin_live.ex:3609
+#: lib/abuuba_web/live/admin_live.ex:3605
 #, elixir-autogen, elixir-format
 msgid "Every permission below, including ones added later. Give it to very few people."
 msgstr "Alle Berechtigungen unten, auch später hinzugekommene. Gib sie nur ganz wenigen Leuten."
 
-#: lib/abuuba_web/live/admin_live.ex:3593
+#: lib/abuuba_web/live/admin_live.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Handle reports"
 msgstr "Meldungen bearbeiten"
 
-#: lib/abuuba_web/live/admin_live.ex:3591
+#: lib/abuuba_web/live/admin_live.ex:3587
 #, elixir-autogen, elixir-format
 msgid "Let people in and out"
 msgstr "Leute hereinlassen und hinauslassen"
 
-#: lib/abuuba_web/live/admin_live.ex:3638
+#: lib/abuuba_web/live/admin_live.ex:3634
 #, elixir-autogen, elixir-format
 msgid "Make and change roles, never above their own and never granting more than they hold."
 msgstr "Rollen anlegen und ändern, nie über der eigenen und nie mit mehr, als man selbst hat."
 
-#: lib/abuuba_web/live/admin_live.ex:3603
+#: lib/abuuba_web/live/admin_live.ex:3599
 #, elixir-autogen, elixir-format
 msgid "Manage custom emoji"
 msgstr "Eigene Emojis verwalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3599
+#: lib/abuuba_web/live/admin_live.ex:3595
 #, elixir-autogen, elixir-format
 msgid "Manage everybody's invites"
 msgstr "Die Einladungen aller verwalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3605
+#: lib/abuuba_web/live/admin_live.ex:3601
 #, elixir-autogen, elixir-format
 msgid "Manage roles"
 msgstr "Rollen verwalten"
 
-#: lib/abuuba_web/live/admin_live.ex:3604
+#: lib/abuuba_web/live/admin_live.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Manage webhooks"
 msgstr "Webhooks verwalten"
@@ -4471,12 +4472,12 @@ msgstr "Position"
 msgid "Position %{position}"
 msgstr "Position %{position}"
 
-#: lib/abuuba_web/live/admin_live.ex:3589
+#: lib/abuuba_web/live/admin_live.ex:3585
 #, elixir-autogen, elixir-format
 msgid "Read the audit log"
 msgstr "Das Protokoll lesen"
 
-#: lib/abuuba_web/live/admin_live.ex:3625
+#: lib/abuuba_web/live/admin_live.ex:3621
 #, elixir-autogen, elixir-format
 msgid "Read the queue, resolve and reopen."
 msgstr "Die Warteschlange lesen, erledigen und wieder öffnen."
@@ -4486,7 +4487,7 @@ msgstr "Die Warteschlange lesen, erledigen und wieder öffnen."
 msgid "Remove this role? Anybody holding it keeps their account."
 msgstr "Diese Rolle entfernen? Wer sie hat, behält sein Konto."
 
-#: lib/abuuba_web/live/admin_live.ex:3392
+#: lib/abuuba_web/live/admin_live.ex:3391
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr "Rollen"
@@ -4496,23 +4497,23 @@ msgstr "Rollen"
 msgid "Save the role"
 msgstr "Rolle speichern"
 
-#: lib/abuuba_web/live/admin_live.ex:3588
+#: lib/abuuba_web/live/admin_live.ex:3584
 #, elixir-autogen, elixir-format
 msgid "See the admin area"
 msgstr "Den Administrationsbereich sehen"
 
-#: lib/abuuba_web/live/admin_live.ex:3617
+#: lib/abuuba_web/live/admin_live.ex:3613
 #, elixir-autogen, elixir-format
 msgid "Silence, suspend, approve and reject accounts on this server."
 msgstr "Konten auf diesem Server einschränken, sperren, freigeben und ablehnen."
 
-#: lib/abuuba_web/live/admin_live.ex:3502
-#: lib/abuuba_web/live/admin_live.ex:3528
+#: lib/abuuba_web/live/admin_live.ex:3501
+#: lib/abuuba_web/live/admin_live.ex:3524
 #, elixir-autogen, elixir-format
 msgid "That role could not be saved."
 msgstr "Diese Rolle konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3614
+#: lib/abuuba_web/live/admin_live.ex:3610
 #, elixir-autogen, elixir-format
 msgid "What every moderator has done, including this person's own actions."
 msgstr "Was jede moderierende Person getan hat, auch die eigenen Aktionen."
@@ -4522,32 +4523,32 @@ msgstr "Was jede moderierende Person getan hat, auch die eigenen Aktionen."
 msgid "What this role may do"
 msgstr "Was diese Rolle darf"
 
-#: lib/abuuba_web/live/admin_live.ex:3631
+#: lib/abuuba_web/live/admin_live.ex:3627
 #, elixir-autogen, elixir-format
 msgid "Who may sign up, the server's name and description, and the rest."
 msgstr "Wer sich anmelden darf, Name und Beschreibung des Servers, und der Rest."
 
-#: lib/abuuba_web/live/admin_live.ex:3611
+#: lib/abuuba_web/live/admin_live.ex:3607
 #, elixir-autogen, elixir-format
 msgid "Without this the admin area is closed."
 msgstr "Ohne das ist der Administrationsbereich zu."
 
-#: lib/abuuba_web/live/admin_live.ex:3602
+#: lib/abuuba_web/live/admin_live.ex:3598
 #, elixir-autogen, elixir-format
 msgid "Write announcements"
 msgstr "Ankündigungen schreiben"
 
-#: lib/abuuba_web/live/admin_live.ex:3600
+#: lib/abuuba_web/live/admin_live.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Write invites"
 msgstr "Einladungen schreiben"
 
-#: lib/abuuba_web/live/admin_live.ex:3601
+#: lib/abuuba_web/live/admin_live.ex:3597
 #, elixir-autogen, elixir-format
 msgid "Write the server rules"
 msgstr "Die Serverregeln schreiben"
 
-#: lib/abuuba_web/live/admin_live.ex:3581
+#: lib/abuuba_web/live/admin_live.ex:3577
 #, elixir-autogen, elixir-format
 msgid "You cannot make a role at or above your own position, or grant a permission you do not hold."
 msgstr "Du kannst keine Rolle auf oder über deiner eigenen Position anlegen und keine Berechtigung vergeben, die du selbst nicht hast."
@@ -4557,7 +4558,7 @@ msgstr "Du kannst keine Rolle auf oder über deiner eigenen Position anlegen und
 msgid "You do not hold this yourself, so you cannot grant it."
 msgstr "Das hast du selbst nicht, also kannst du es nicht vergeben."
 
-#: lib/abuuba_web/live/admin_live.ex:3651
+#: lib/abuuba_web/live/admin_live.ex:3647
 #, elixir-autogen, elixir-format
 msgid "nothing in particular"
 msgstr "nichts Bestimmtes"
@@ -4605,7 +4606,7 @@ msgid_plural "%{count} accounts"
 msgstr[0] "Ein Konto"
 msgstr[1] "%{count} Konten"
 
-#: lib/abuuba_web/live/admin_live.ex:3391
+#: lib/abuuba_web/live/admin_live.ex:3390
 #, elixir-autogen, elixir-format
 msgid "Other servers"
 msgstr "Andere Server"
@@ -4755,7 +4756,7 @@ msgstr "Erlaubte"
 msgid "Checking for updates"
 msgstr "Nach Aktualisierungen sehen"
 
-#: lib/abuuba_web/live/admin_live.ex:3390
+#: lib/abuuba_web/live/admin_live.ex:3389
 #, elixir-autogen, elixir-format
 msgid "Domain lists"
 msgstr "Domain-Listen"
@@ -4765,7 +4766,7 @@ msgstr "Domain-Listen"
 msgid "Domains this server has already decided about are left exactly as they are. An import adds and never removes: one paste should not be able to undo every decision made here, silently and unrecoverably."
 msgstr "Domains, über die dieser Server schon entschieden hat, bleiben genau so, wie sie sind. Ein Import fügt hinzu und entfernt nie: ein einziges Einfügen soll nicht jede hier getroffene Entscheidung stillschweigend und unwiederbringlich rückgängig machen können."
 
-#: lib/abuuba_web/live/admin_live.ex:3388
+#: lib/abuuba_web/live/admin_live.ex:3387
 #, elixir-autogen, elixir-format
 msgid "Email subscriptions"
 msgstr "E-Mail-Abos"
@@ -4866,17 +4867,17 @@ msgstr[1] "%{count} erlaubte Domains"
 msgid "%{label}, highest %{top}"
 msgstr "%{label}, höchster Wert %{top}"
 
-#: lib/abuuba_web/live/admin_live.ex:3705
+#: lib/abuuba_web/live/admin_live.ex:3701
 #, elixir-autogen, elixir-format
 msgid "Favourites, boosts and replies"
 msgstr "Favoriten, Boosts und Antworten"
 
-#: lib/abuuba_web/live/admin_live.ex:3710
+#: lib/abuuba_web/live/admin_live.ex:3706
 #, elixir-autogen, elixir-format
 msgid "Languages people write in"
 msgstr "Sprachen, in denen geschrieben wird"
 
-#: lib/abuuba_web/live/admin_live.ex:3703
+#: lib/abuuba_web/live/admin_live.ex:3699
 #, elixir-autogen, elixir-format
 msgid "New accounts"
 msgstr "Neue Konten"
@@ -4886,27 +4887,27 @@ msgstr "Neue Konten"
 msgid "Of the people who signed up in a given week, how many were still posting in the weeks after. A number that only means something once the server has been running a while."
 msgstr "Von den Leuten, die sich in einer bestimmten Woche angemeldet haben: wie viele in den Wochen danach noch geschrieben haben. Eine Zahl, die erst etwas bedeutet, wenn der Server eine Weile läuft."
 
-#: lib/abuuba_web/live/admin_live.ex:3702
+#: lib/abuuba_web/live/admin_live.ex:3698
 #, elixir-autogen, elixir-format
 msgid "People who posted"
 msgstr "Leute, die geschrieben haben"
 
-#: lib/abuuba_web/live/admin_live.ex:3704
+#: lib/abuuba_web/live/admin_live.ex:3700
 #, elixir-autogen, elixir-format
 msgid "Posts written here"
 msgstr "Hier geschriebene Beiträge"
 
-#: lib/abuuba_web/live/admin_live.ex:3706
+#: lib/abuuba_web/live/admin_live.ex:3702
 #, elixir-autogen, elixir-format
 msgid "Reports opened"
 msgstr "Eröffnete Meldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3707
+#: lib/abuuba_web/live/admin_live.ex:3703
 #, elixir-autogen, elixir-format
 msgid "Reports resolved"
 msgstr "Erledigte Meldungen"
 
-#: lib/abuuba_web/live/admin_live.ex:3712
+#: lib/abuuba_web/live/admin_live.ex:3708
 #, elixir-autogen, elixir-format
 msgid "Servers we hear most from"
 msgstr "Server, von denen wir am meisten hören"
@@ -4921,12 +4922,12 @@ msgstr "Die letzten dreißig Tage"
 msgid "The same numbers a moderation client draws from the API, so what you see here and what it shows are the same figures rather than two answers to one question."
 msgstr "Dieselben Zahlen, die sich ein Moderations-Client über die API holt — was du hier siehst und was der anzeigt, sind also dieselben Werte und nicht zwei Antworten auf eine Frage."
 
-#: lib/abuuba_web/live/admin_live.ex:3713
+#: lib/abuuba_web/live/admin_live.ex:3709
 #, elixir-autogen, elixir-format
 msgid "What those servers run"
 msgstr "Was auf diesen Servern läuft"
 
-#: lib/abuuba_web/live/admin_live.ex:3711
+#: lib/abuuba_web/live/admin_live.ex:3707
 #, elixir-autogen, elixir-format
 msgid "Where accounts signed up from"
 msgstr "Woher sich Konten angemeldet haben"
@@ -4948,55 +4949,55 @@ msgid_plural "%{count} signed up"
 msgstr[0] "eine Anmeldung"
 msgstr[1] "%{count} Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2221
+#: lib/abuuba_web/live/settings_live.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr "Profilbild"
 
-#: lib/abuuba_web/live/settings_live.ex:2222
+#: lib/abuuba_web/live/settings_live.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr "Titelbild"
 
-#: lib/abuuba_web/live/settings_live.ex:347
+#: lib/abuuba_web/live/settings_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr "JPEG, PNG, GIF oder WebP, bis %{size}. Größere werden schon vor dem Hochladen abgelehnt und nicht erst danach, und was du schickst, wird hier verkleinert, damit niemand ein ganzes Foto lädt, um es bei vierzig Pixeln zu sehen."
 
 #: lib/abuuba_web/live/admin_live.ex:565
-#: lib/abuuba_web/live/settings_live.ex:365
+#: lib/abuuba_web/live/settings_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "None yet."
 msgstr "Noch keins."
 
-#: lib/abuuba_web/live/settings_live.ex:2062
+#: lib/abuuba_web/live/settings_live.ex:2069
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr "Ein Bild auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:345
+#: lib/abuuba_web/live/settings_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr "Bilder"
 
-#: lib/abuuba_web/live/settings_live.ex:397
+#: lib/abuuba_web/live/settings_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Take it off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2060
-#: lib/abuuba_web/live/settings_live.ex:2215
+#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2222
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr "Damit kann dieser Server nichts anfangen. Versuch es mit JPEG, PNG, GIF oder WebP."
 
-#: lib/abuuba_web/live/settings_live.ex:2210
 #: lib/abuuba_web/live/settings_live.ex:2217
+#: lib/abuuba_web/live/settings_live.ex:2224
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr "Dieses Bild konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2057
+#: lib/abuuba_web/live/settings_live.ex:2064
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr "Dieses Bild ist zu groß. Die Grenze steht eine Zeile weiter oben."
@@ -5027,7 +5028,7 @@ msgstr "Schau in dieses Postfach: Dort liegt eine Nachricht mit der Bitte um Bes
 msgid "Get updates from %{name} by email"
 msgstr "Neuigkeiten von %{name} per E-Mail"
 
-#: lib/abuuba_web/live/settings_live.ex:681
+#: lib/abuuba_web/live/settings_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr "Geht an jede bestätigte Adresse, mit einem Link, der die Neuigkeiten beendet. Bis zu %{count} Nachrichten am Tag."
@@ -5037,7 +5038,7 @@ msgstr "Geht an jede bestätigte Adresse, mit einem Link, der die Neuigkeiten be
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr "Kein Konto nötig. Wir schreiben einmal an die Adresse, um zu prüfen, ob sie dir gehört, und in jeder Nachricht steht ein Link, der die Neuigkeiten beendet."
 
-#: lib/abuuba_web/live/settings_live.ex:706
+#: lib/abuuba_web/live/settings_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "Send it"
 msgstr "Abschicken"
@@ -5047,15 +5048,15 @@ msgstr "Abschicken"
 msgid "Send me updates"
 msgstr "Neuigkeiten schicken"
 
-#: lib/abuuba_web/live/settings_live.ex:715
+#: lib/abuuba_web/live/settings_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] "Am %{date} an eine Adresse geschickt."
 msgstr[1] "Am %{date} an %{count} Adressen geschickt."
 
-#: lib/abuuba_web/live/settings_live.ex:692
-#: lib/abuuba_web/live/settings_live.ex:1789
+#: lib/abuuba_web/live/settings_live.ex:693
+#: lib/abuuba_web/live/settings_live.ex:1796
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Betreff"
@@ -5065,7 +5066,7 @@ msgstr "Betreff"
 msgid "That does not look like a valid email address."
 msgstr "Das sieht nicht nach einer gültigen E-Mail-Adresse aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1369
+#: lib/abuuba_web/live/settings_live.ex:1376
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr "Diese Liste ist nicht offen."
@@ -5080,12 +5081,12 @@ msgstr "Zum Beenden diesen Link öffnen:"
 msgid "Too many tries from here just now. Try again later."
 msgstr "Gerade zu viele Versuche von hier. Bitte später noch einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:699
+#: lib/abuuba_web/live/settings_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr "Was du ihnen sagen möchtest"
 
-#: lib/abuuba_web/live/settings_live.ex:679
+#: lib/abuuba_web/live/settings_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr "An sie schreiben"
@@ -5095,7 +5096,7 @@ msgstr "An sie schreiben"
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr "Du bekommst das, weil du auf %{site} um Neuigkeiten von %{name} gebeten hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1374
+#: lib/abuuba_web/live/settings_live.ex:1381
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr "Du hast heute schon so viele Nachrichten geschickt, wie du kannst."
@@ -5105,12 +5106,12 @@ msgstr "Du hast heute schon so viele Nachrichten geschickt, wie du kannst."
 msgid "you@example.com"
 msgstr "du@example.com"
 
-#: lib/abuuba_web/live/settings_live.ex:1790
+#: lib/abuuba_web/live/settings_live.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
 
-#: lib/abuuba_web/live/settings_live.ex:722
+#: lib/abuuba_web/live/settings_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr "Unterwegs."
@@ -5161,7 +5162,7 @@ msgstr "Ich kümmere mich"
 msgid "Keep it"
 msgstr "Speichern"
 
-#: lib/abuuba_web/live/admin_live.ex:3310
+#: lib/abuuba_web/live/admin_live.ex:3309
 #, elixir-autogen, elixir-format
 msgid "Limit them"
 msgstr "Einschränken"
@@ -5198,7 +5199,7 @@ msgstr "Zurück in die Warteschlange"
 msgid "Ready-made texts a moderator picks instead of retyping. Kept for the server rather than for one moderator, so two people writing about the same thing say the same thing."
 msgstr "Fertige Texte, die man auswählt, statt sie neu zu tippen. Sie gehören zum Server und nicht zu einer einzelnen moderierenden Person, damit zwei Leute zur selben Sache dasselbe schreiben."
 
-#: lib/abuuba_web/live/admin_live.ex:3382
+#: lib/abuuba_web/live/admin_live.ex:3381
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr "Meldung"
@@ -5208,7 +5209,7 @@ msgstr "Meldung"
 msgid "Report %{id}"
 msgstr "Meldung %{id}"
 
-#: lib/abuuba_web/live/admin_live.ex:3380
+#: lib/abuuba_web/live/admin_live.ex:3379
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr "Meldungen"
@@ -5223,12 +5224,12 @@ msgstr "Ausgehen von"
 msgid "Still open"
 msgstr "Noch offen"
 
-#: lib/abuuba_web/live/admin_live.ex:3312
+#: lib/abuuba_web/live/admin_live.ex:3311
 #, elixir-autogen, elixir-format
 msgid "Stop them signing in"
 msgstr "Anmeldung sperren"
 
-#: lib/abuuba_web/live/admin_live.ex:3311
+#: lib/abuuba_web/live/admin_live.ex:3310
 #, elixir-autogen, elixir-format
 msgid "Suspend them"
 msgstr "Sperren"
@@ -5296,7 +5297,7 @@ msgstr "erledigt"
 msgid "from"
 msgstr "von"
 
-#: lib/abuuba_web/live/admin_live.ex:3328
+#: lib/abuuba_web/live/admin_live.ex:3327
 #, elixir-autogen, elixir-format
 msgid "somebody who is gone"
 msgstr "jemand, den es nicht mehr gibt"
@@ -5306,14 +5307,14 @@ msgstr "jemand, den es nicht mehr gibt"
 msgid "taken"
 msgstr "übernommen"
 
-#: lib/abuuba_web/live/admin_live.ex:3287
+#: lib/abuuba_web/live/admin_live.ex:3286
 #, elixir-autogen, elixir-format
 msgid "One account could not be changed."
 msgid_plural "%{count} accounts could not be changed."
 msgstr[0] "Ein Konto konnte nicht geändert werden."
 msgstr[1] "%{count} Konten konnten nicht geändert werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3280
+#: lib/abuuba_web/live/admin_live.ex:3279
 #, elixir-autogen, elixir-format
 msgid "One account was left alone because it outranks yours."
 msgid_plural "%{count} accounts were left alone because they outrank yours."
@@ -5325,7 +5326,7 @@ msgstr[1] "%{count} Konten blieben unangetastet, weil sie über deinem stehen."
 msgid "Showing the newest %{count}. Deal with some to see the ones that have waited longest."
 msgstr "Es werden die neuesten %{count} gezeigt. Arbeite welche ab, um die am längsten wartenden zu sehen."
 
-#: lib/abuuba_web/live/admin_live.ex:3245
+#: lib/abuuba_web/live/admin_live.ex:3244
 #, elixir-autogen, elixir-format
 msgid "That is not something this list can do."
 msgstr "Das kann diese Liste nicht."
@@ -5396,7 +5397,7 @@ msgstr "Deine Unterhaltungen als gelesen markieren"
 msgid "Mute and unmute people for you"
 msgstr "Leute für dich stummschalten und wieder lautstellen"
 
-#: lib/abuuba_web/live/settings_live.ex:961
+#: lib/abuuba_web/live/settings_live.ex:968
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr "Nichts. Sie sieht nur, dass du angemeldet bist, sonst nichts."
@@ -5456,24 +5457,24 @@ msgstr "Trotzdem anzeigen"
 msgid "A PNG or a GIF, at most %{size}."
 msgstr "Ein PNG oder ein GIF, höchstens %{size}."
 
-#: lib/abuuba_web/live/admin_live.ex:3212
+#: lib/abuuba_web/live/admin_live.ex:3211
 #, elixir-autogen, elixir-format
 msgid "A shortcode is letters, numbers and underscores, and nothing else."
 msgstr "Ein Kurzname besteht aus Buchstaben, Ziffern und Unterstrichen, sonst nichts."
 
-#: lib/abuuba_web/live/admin_live.ex:3148
-#: lib/abuuba_web/live/admin_live.ex:3194
+#: lib/abuuba_web/live/admin_live.ex:3147
+#: lib/abuuba_web/live/admin_live.ex:3193
 #, elixir-autogen, elixir-format
 msgid "An emoji has to be a PNG or a GIF."
 msgstr "Ein Emoji muss ein PNG oder ein GIF sein."
 
-#: lib/abuuba_web/live/admin_live.ex:3138
-#: lib/abuuba_web/live/admin_live.ex:3172
+#: lib/abuuba_web/live/admin_live.ex:3137
+#: lib/abuuba_web/live/admin_live.ex:3171
 #, elixir-autogen, elixir-format
 msgid "Choose a picture for it."
 msgstr "Wähle ein Bild dafür aus."
 
-#: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/admin_live.ex:3380
 #, elixir-autogen, elixir-format
 msgid "Custom emoji"
 msgstr "Eigene Emojis"
@@ -5508,23 +5509,23 @@ msgstr "Kurzname"
 msgid "Stop offering it"
 msgstr "Nicht mehr anbieten"
 
-#: lib/abuuba_web/live/admin_live.ex:3214
+#: lib/abuuba_web/live/admin_live.ex:3213
 #, elixir-autogen, elixir-format
 msgid "That emoji could not be saved."
 msgstr "Dieses Emoji konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3200
+#: lib/abuuba_web/live/admin_live.ex:3199
 #, elixir-autogen, elixir-format
 msgid "That picture could not be stored."
 msgstr "Dieses Bild konnte nicht abgelegt werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3154
+#: lib/abuuba_web/live/admin_live.ex:3153
 #, elixir-autogen, elixir-format
 msgid "That picture could not be used."
 msgstr "Dieses Bild konnte nicht verwendet werden."
 
-#: lib/abuuba_web/live/admin_live.ex:3151
-#: lib/abuuba_web/live/admin_live.ex:3197
+#: lib/abuuba_web/live/admin_live.ex:3150
+#: lib/abuuba_web/live/admin_live.ex:3196
 #, elixir-autogen, elixir-format
 msgid "That picture is too large for an emoji."
 msgstr "Dieses Bild ist zu groß für ein Emoji."
@@ -5534,7 +5535,7 @@ msgstr "Dieses Bild ist zu groß für ein Emoji."
 msgid "The picture"
 msgstr "Das Bild"
 
-#: lib/abuuba_web/live/admin_live.ex:3135
+#: lib/abuuba_web/live/admin_live.ex:3134
 #, elixir-autogen, elixir-format
 msgid "The picture is still uploading. Try again in a moment."
 msgstr "Das Bild wird noch hochgeladen. Gleich noch einmal versuchen."
@@ -5564,27 +5565,27 @@ msgstr "Ihre Weitergaben anderer Leute"
 msgid "What you see from them"
 msgstr "Was du von ihnen siehst"
 
-#: lib/abuuba_web/components/status_component.ex:464
+#: lib/abuuba_web/components/status_component.ex:487
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Mehr"
 
-#: lib/abuuba_web/components/status_component.ex:476
+#: lib/abuuba_web/components/status_component.ex:499
 #, elixir-autogen, elixir-format
 msgid "Mute this conversation"
 msgstr "Diese Unterhaltung stummschalten"
 
-#: lib/abuuba_web/components/status_component.ex:483
+#: lib/abuuba_web/components/status_component.ex:506
 #, elixir-autogen, elixir-format
 msgid "Stops its notifications and takes it out of your timeline. Nobody is told."
 msgstr "Beendet die Benachrichtigungen und nimmt sie aus deiner Timeline. Niemand erfährt es."
 
-#: lib/abuuba_web/components/status_component.ex:475
+#: lib/abuuba_web/components/status_component.ex:498
 #, elixir-autogen, elixir-format
 msgid "Unmute this conversation"
 msgstr "Stummschaltung dieser Unterhaltung aufheben"
 
-#: lib/abuuba_web/live/notifications_live.ex:468
+#: lib/abuuba_web/live/notifications_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr "Beiträge von Leuten, die du beobachtest"
@@ -5594,37 +5595,37 @@ msgstr "Beiträge von Leuten, die du beobachtest"
 msgid "Tell me when they post"
 msgstr "Sag mir Bescheid, wenn sie etwas posten"
 
-#: lib/abuuba_web/live/notifications_live.ex:387
+#: lib/abuuba_web/live/notifications_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr "%{name} hat deinen Beitrag zu einer Sammlung hinzugefügt"
 
-#: lib/abuuba_web/live/notifications_live.ex:391
+#: lib/abuuba_web/live/notifications_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr "%{name} hat eine Meldung eingereicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:389
+#: lib/abuuba_web/live/notifications_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "%{name} signed up"
 msgstr "%{name} hat sich registriert"
 
-#: lib/abuuba_web/live/notifications_live.ex:380
+#: lib/abuuba_web/live/notifications_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr "Einige deiner Follows wurden entfernt, als dieser Server die Föderation mit einem anderen beendet hat"
 
-#: lib/abuuba_web/live/notifications_live.ex:376
+#: lib/abuuba_web/live/notifications_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr "Dein Konto hat eine Verwarnung der Moderation erhalten"
 
-#: lib/abuuba_web/live/notifications_live.ex:384
+#: lib/abuuba_web/live/notifications_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr "Dein Jahr auf diesem Server ist fertig zum Lesen"
 
-#: lib/abuuba_web/live/notifications_live.ex:463
+#: lib/abuuba_web/live/notifications_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Quotes"
 msgstr "Zitate"
@@ -5649,24 +5650,24 @@ msgstr "Jeder Beitrag, der es benutzt hat, verliert sein Bild, bis du es wieder 
 msgid "turned off"
 msgstr "ausgeschaltet"
 
-#: lib/abuuba_web/live/conversations_live.ex:98
+#: lib/abuuba_web/live/conversations_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Mark unread"
 msgstr "Als ungelesen markieren"
 
-#: lib/abuuba_web/components/layouts.ex:239
-#: lib/abuuba_web/live/conversations_live.ex:45
-#: lib/abuuba_web/live/conversations_live.ex:61
+#: lib/abuuba_web/components/layouts.ex:243
+#: lib/abuuba_web/live/conversations_live.ex:46
+#: lib/abuuba_web/live/conversations_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr "Nachrichten"
 
-#: lib/abuuba_web/live/conversations_live.ex:64
+#: lib/abuuba_web/live/conversations_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. A post addressed to only the people you name arrives as a message, and its replies stay with it."
 msgstr "Hier ist noch nichts. Ein Beitrag an „nur die Erwähnten“ kommt als Nachricht an, und seine Antworten bleiben bei ihm."
 
-#: lib/abuuba_web/live/conversations_live.ex:83
+#: lib/abuuba_web/live/conversations_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Open the conversation with %{people}"
 msgstr "Das Gespräch mit %{people} öffnen"
@@ -5676,7 +5677,7 @@ msgstr "Das Gespräch mit %{people} öffnen"
 msgid "The last message has been deleted."
 msgstr "Die letzte Nachricht wurde gelöscht."
 
-#: lib/abuuba_web/live/conversations_live.ex:106
+#: lib/abuuba_web/live/conversations_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "This takes it out of your inbox only. Nobody else loses anything, and a later message brings it back. Go ahead?"
 msgstr "Das nimmt es nur aus deinem Posteingang. Niemand sonst verliert etwas, und eine spätere Nachricht holt es zurück. Fortfahren?"
@@ -5748,22 +5749,22 @@ msgstr "Niemand: der Server sagt es nicht"
 msgid "Who may read the blocklist"
 msgstr "Wer die Sperrliste lesen darf"
 
-#: lib/abuuba_web/live/settings_live.ex:636
+#: lib/abuuba_web/live/settings_live.ex:637
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr "Eine Domain pro Zeile. Wird hier ein Link auf eine dieser Seiten geteilt, weist die Vorschau dich als Urheberin oder Urheber aus. Eine Seite, die du nicht eingetragen hast, kann dich nicht für sich beanspruchen, egal was in ihrer Seitenquelle steht."
 
-#: lib/abuuba_web/live/settings_live.ex:628
+#: lib/abuuba_web/live/settings_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr "Seiten, die mich als Autorin oder Autor nennen dürfen"
 
-#: lib/abuuba_web/live/settings_live.ex:840
+#: lib/abuuba_web/live/settings_live.ex:841
 #, elixir-autogen, elixir-format
 msgid "Block a server"
 msgstr "Server blockieren"
 
-#: lib/abuuba_web/live/settings_live.ex:813
+#: lib/abuuba_web/live/settings_live.ex:814
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht deine Timelines, deine Suche, deine Threads oder deine Benachrichtigungen. Folge-Beziehungen in beide Richtungen werden aufgelöst, genau wie beim Blockieren einer einzelnen Person."
@@ -5773,28 +5774,28 @@ msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht d
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr "Zu viele Anmeldungen von hier im Moment. Bitte versuche es später noch einmal."
 
-#: lib/abuuba_web/live/explore_live.ex:147
+#: lib/abuuba_web/live/explore_live.ex:148
 #: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr "Zu viele Follows für heute. Versuche es morgen noch einmal."
 
-#: lib/abuuba_web/live/admin_live.ex:3370
+#: lib/abuuba_web/live/admin_live.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Account disabled"
 msgstr "Konto deaktiviert"
 
-#: lib/abuuba_web/live/admin_live.ex:3373
+#: lib/abuuba_web/live/admin_live.ex:3372
 #, elixir-autogen, elixir-format
 msgid "Account limited"
 msgstr "Konto eingeschränkt"
 
-#: lib/abuuba_web/live/admin_live.ex:3374
+#: lib/abuuba_web/live/admin_live.ex:3373
 #, elixir-autogen, elixir-format
 msgid "Account suspended"
 msgstr "Konto gesperrt"
 
-#: lib/abuuba_web/live/admin_live.ex:3383
+#: lib/abuuba_web/live/admin_live.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Appeals"
 msgstr "Einsprüche"
@@ -5804,12 +5805,12 @@ msgstr "Einsprüche"
 msgid "Nothing is waiting. Appeals against a strike show up here."
 msgstr "Es wartet nichts. Einsprüche gegen eine Maßnahme erscheinen hier."
 
-#: lib/abuuba_web/live/admin_live.ex:3372
+#: lib/abuuba_web/live/admin_live.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Posts deleted"
 msgstr "Beiträge gelöscht"
 
-#: lib/abuuba_web/live/admin_live.ex:3371
+#: lib/abuuba_web/live/admin_live.ex:3370
 #, elixir-autogen, elixir-format
 msgid "Posts marked sensitive"
 msgstr "Beiträge als sensibel markiert"
@@ -5819,7 +5820,7 @@ msgstr "Beiträge als sensibel markiert"
 msgid "Somebody who was warned, silenced or suspended saying it was a mistake. Upholding an appeal undoes the action where it can be undone; where it cannot, the appeal is still recorded as upheld. Either way the account's owner is told."
 msgstr "Jemand, der verwarnt, eingeschränkt oder gesperrt wurde und sagt, dass das ein Fehler war. Wird einem Einspruch stattgegeben, wird die Maßnahme rückgängig gemacht, soweit das geht; wo nicht, gilt der Einspruch trotzdem als angenommen. In beiden Fällen wird die Person benachrichtigt."
 
-#: lib/abuuba_web/live/admin_live.ex:3085
+#: lib/abuuba_web/live/admin_live.ex:3084
 #, elixir-autogen, elixir-format
 msgid "That appeal is no longer waiting."
 msgstr "Dieser Einspruch wartet nicht mehr."
@@ -5834,13 +5835,13 @@ msgstr "Ablehnen"
 msgid "Uphold and undo"
 msgstr "Stattgeben und rückgängig machen"
 
-#: lib/abuuba_web/live/admin_live.ex:3369
+#: lib/abuuba_web/live/admin_live.ex:3368
 #, elixir-autogen, elixir-format
 msgid "Warned"
 msgstr "Verwarnt"
 
-#: lib/abuuba_web/live/settings_live.ex:2235
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2242
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr "%{size} MB"
@@ -5850,7 +5851,7 @@ msgstr "%{size} MB"
 msgid "Cancel follow request"
 msgstr "Folgeanfrage zurückziehen"
 
-#: lib/abuuba_web/live/explore_live.ex:116
+#: lib/abuuba_web/live/explore_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr "Angefragt"
@@ -5859,3 +5860,19 @@ msgstr "Angefragt"
 #, elixir-autogen, elixir-format
 msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr "Dieses Konto bestätigt seine Follower selbst. Deine Anfrage wartet auf eine Antwort."
+
+#: lib/abuuba_web/components/status_component.ex:451
+#, elixir-autogen, elixir-format
+msgid "Delete this post? Other servers are told to forget it too."
+msgstr "Diesen Beitrag löschen? Andere Server werden aufgefordert, ihre Kopie ebenfalls zu löschen."
+
+#: lib/abuuba_web/components/layouts.ex:145
+#: lib/abuuba_web/live/settings_live.ex:911
+#, elixir-autogen, elixir-format
+msgid "Sign out"
+msgstr "Abmelden"
+
+#: lib/abuuba_web/live/post_actions.ex:428
+#, elixir-autogen, elixir-format
+msgid "That post is gone."
+msgstr "Der Beitrag ist gelöscht."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -37,8 +37,8 @@ msgstr[1] ""
 msgid "Actions"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:285
-#: lib/abuuba_web/components/layouts.ex:300
+#: lib/abuuba_web/components/layouts.ex:289
+#: lib/abuuba_web/components/layouts.ex:304
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
@@ -49,12 +49,12 @@ msgid "Change"
 msgstr ""
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:713
+#: lib/abuuba_web/live/compose_component.ex:714
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:292
+#: lib/abuuba_web/components/layouts.ex:296
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
@@ -64,7 +64,7 @@ msgstr ""
 msgid "That language is not available."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:277
+#: lib/abuuba_web/components/layouts.ex:281
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
@@ -285,7 +285,7 @@ msgid "You are signed out."
 msgstr ""
 
 #: lib/abuuba_web/user_auth.ex:88
-#: lib/abuuba_web/user_auth.ex:124
+#: lib/abuuba_web/user_auth.ex:205
 #, elixir-autogen, elixir-format
 msgid "You have to be signed in to see that page."
 msgstr ""
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:901
+#: lib/abuuba_web/live/settings_live.ex:902
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -466,8 +466,8 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:387
-#: lib/abuuba_web/live/compose_component.ex:400
+#: lib/abuuba_web/live/compose_component.ex:388
+#: lib/abuuba_web/live/compose_component.ex:401
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -652,51 +652,51 @@ msgstr ""
 msgid "That request has to be signed."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:243
-#: lib/abuuba_web/components/layouts.ex:252
-#: lib/abuuba_web/live/explore_live.ex:48
+#: lib/abuuba_web/components/layouts.ex:247
+#: lib/abuuba_web/components/layouts.ex:256
+#: lib/abuuba_web/live/explore_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:230
-#: lib/abuuba_web/components/layouts.ex:251
+#: lib/abuuba_web/components/layouts.ex:234
+#: lib/abuuba_web/components/layouts.ex:255
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2311
+#: lib/abuuba_web/live/settings_live.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:142
+#: lib/abuuba_web/components/layouts.ex:143
 #: lib/abuuba_web/controllers/shortcuts_controller.ex:15
 #: lib/abuuba_web/controllers/shortcuts_html/show.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:254
+#: lib/abuuba_web/components/layouts.ex:258
 #: lib/abuuba_web/live/landing_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:132
-#: lib/abuuba_web/components/layouts.ex:154
+#: lib/abuuba_web/components/layouts.ex:133
+#: lib/abuuba_web/components/layouts.ex:158
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:233
+#: lib/abuuba_web/components/layouts.ex:237
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2312
+#: lib/abuuba_web/live/settings_live.ex:2319
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:120
-#: lib/abuuba_web/live/settings_live.ex:2120
+#: lib/abuuba_web/components/layouts.ex:249
+#: lib/abuuba_web/live/settings_live.ex:121
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -735,12 +735,12 @@ msgstr ""
 msgid "Attachment"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:421
+#: lib/abuuba_web/components/status_component.ex:430
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:398
+#: lib/abuuba_web/components/status_component.ex:407
 #, elixir-autogen, elixir-format
 msgid "Boost"
 msgstr ""
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Closed"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:410
+#: lib/abuuba_web/components/status_component.ex:419
 #, elixir-autogen, elixir-format
 msgid "Favourite"
 msgstr ""
@@ -761,12 +761,12 @@ msgid "Follow some people and their posts will appear here."
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:267
-#: lib/abuuba_web/live/compose_component.ex:593
+#: lib/abuuba_web/live/compose_component.ex:594
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:386
+#: lib/abuuba_web/components/status_component.ex:395
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
@@ -791,303 +791,303 @@ msgstr ""
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1657
+#: lib/abuuba_web/live/compose_component.ex:1658
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1655
+#: lib/abuuba_web/live/compose_component.ex:1656
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1658
+#: lib/abuuba_web/live/compose_component.ex:1659
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1654
+#: lib/abuuba_web/live/compose_component.ex:1655
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1653
+#: lib/abuuba_web/live/compose_component.ex:1654
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1656
+#: lib/abuuba_web/live/compose_component.ex:1657
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1659
+#: lib/abuuba_web/live/compose_component.ex:1660
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1131
+#: lib/abuuba_web/live/compose_component.ex:1132
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:628
+#: lib/abuuba_web/live/compose_component.ex:629
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:699
+#: lib/abuuba_web/live/compose_component.ex:700
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:640
+#: lib/abuuba_web/live/compose_component.ex:641
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1674
-#: lib/abuuba_web/live/settings_live.ex:2306
+#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1665
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/settings_live.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2302
+#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/settings_live.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:604
+#: lib/abuuba_web/live/compose_component.ex:605
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:428
-#: lib/abuuba_web/live/compose_component.ex:689
+#: lib/abuuba_web/live/compose_component.ex:429
+#: lib/abuuba_web/live/compose_component.ex:690
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:790
+#: lib/abuuba_web/live/compose_component.ex:791
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:423
+#: lib/abuuba_web/live/compose_component.ex:424
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:432
+#: lib/abuuba_web/components/status_component.ex:441
 #: lib/abuuba_web/live/admin_live.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:393
+#: lib/abuuba_web/live/compose_component.ex:394
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:644
+#: lib/abuuba_web/live/compose_component.ex:645
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/profile_live.ex:804
+#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/profile_live.ex:792
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/compose_component.ex:1669
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3428
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2308
+#: lib/abuuba_web/live/admin_live.ex:3427
+#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/settings_live.ex:2315
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2303
+#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/settings_live.ex:2310
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/compose_component.ex:1669
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2307
+#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/settings_live.ex:2314
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1432
+#: lib/abuuba_web/live/compose_component.ex:1433
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:673
+#: lib/abuuba_web/live/compose_component.ex:674
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1665
-#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/compose_component.ex:1684
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/compose_component.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:709
+#: lib/abuuba_web/live/compose_component.ex:710
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:616
+#: lib/abuuba_web/live/compose_component.ex:617
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:380
+#: lib/abuuba_web/live/compose_component.ex:381
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1430
+#: lib/abuuba_web/live/compose_component.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3389
-#: lib/abuuba_web/live/compose_component.ex:455
+#: lib/abuuba_web/live/admin_live.ex:3388
+#: lib/abuuba_web/live/compose_component.ex:456
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1093
+#: lib/abuuba_web/live/compose_component.ex:1094
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1155
-#: lib/abuuba_web/live/compose_component.ex:1190
-#: lib/abuuba_web/live/compose_component.ex:1386
+#: lib/abuuba_web/live/compose_component.ex:1156
+#: lib/abuuba_web/live/compose_component.ex:1191
+#: lib/abuuba_web/live/compose_component.ex:1387
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:439
-#: lib/abuuba_web/live/compose_component.ex:445
+#: lib/abuuba_web/live/compose_component.ex:440
+#: lib/abuuba_web/live/compose_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:433
+#: lib/abuuba_web/live/compose_component.ex:434
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:749
+#: lib/abuuba_web/live/compose_component.ex:750
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:729
+#: lib/abuuba_web/live/compose_component.ex:730
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1089
+#: lib/abuuba_web/live/compose_component.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1187
+#: lib/abuuba_web/live/compose_component.ex:1188
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1626
+#: lib/abuuba_web/live/compose_component.ex:1627
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:796
+#: lib/abuuba_web/live/compose_component.ex:797
 #, elixir-autogen, elixir-format
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:828
+#: lib/abuuba_web/live/compose_component.ex:829
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:1135
+#: lib/abuuba_web/live/compose_component.ex:1136
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:859
+#: lib/abuuba_web/live/compose_component.ex:860
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:820
+#: lib/abuuba_web/live/compose_component.ex:821
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:659
+#: lib/abuuba_web/live/compose_component.ex:660
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:810
-#: lib/abuuba_web/live/compose_component.ex:849
+#: lib/abuuba_web/live/compose_component.ex:811
+#: lib/abuuba_web/live/compose_component.ex:850
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1106
-#: lib/abuuba_web/live/compose_component.ex:1377
+#: lib/abuuba_web/live/compose_component.ex:1107
+#: lib/abuuba_web/live/compose_component.ex:1378
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:781
+#: lib/abuuba_web/live/compose_component.ex:782
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1431
+#: lib/abuuba_web/live/compose_component.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:305
+#: lib/abuuba_web/live/compose_component.ex:306
 #, elixir-autogen, elixir-format
 msgid "That draft could not be saved."
 msgstr ""
@@ -1097,109 +1097,109 @@ msgstr ""
 msgid "That post is scheduled."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1140
+#: lib/abuuba_web/live/compose_component.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:301
+#: lib/abuuba_web/live/compose_component.ex:302
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1425
+#: lib/abuuba_web/live/compose_component.ex:1426
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:666
+#: lib/abuuba_web/live/compose_component.ex:667
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1103
+#: lib/abuuba_web/live/compose_component.ex:1104
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:474
+#: lib/abuuba_web/live/compose_component.ex:475
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:569
+#: lib/abuuba_web/live/compose_component.ex:570
 #, elixir-autogen, elixir-format
 msgid "Add a still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:519
+#: lib/abuuba_web/live/compose_component.ex:520
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:536
-#: lib/abuuba_web/live/compose_component.ex:544
+#: lib/abuuba_web/live/compose_component.ex:537
+#: lib/abuuba_web/live/compose_component.ex:545
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:558
+#: lib/abuuba_web/live/compose_component.ex:559
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:573
+#: lib/abuuba_web/live/compose_component.ex:574
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:531
+#: lib/abuuba_web/live/compose_component.ex:532
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:499
+#: lib/abuuba_web/live/compose_component.ex:500
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:584
+#: lib/abuuba_web/live/compose_component.ex:585
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:240
-#: lib/abuuba_web/live/compose_component.ex:1421
+#: lib/abuuba_web/live/compose_component.ex:241
+#: lib/abuuba_web/live/compose_component.ex:1422
 #, elixir-autogen, elixir-format
 msgid "That file could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1418
+#: lib/abuuba_web/live/compose_component.ex:1419
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:227
+#: lib/abuuba_web/live/compose_component.ex:228
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1419
+#: lib/abuuba_web/live/compose_component.ex:1420
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1420
+#: lib/abuuba_web/live/compose_component.ex:1421
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:478
+#: lib/abuuba_web/live/compose_component.ex:479
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:277
+#: lib/abuuba_web/live/status_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "Block"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:112
+#: lib/abuuba_web/live/explore_live.ex:113
 #: lib/abuuba_web/live/profile_live.ex:144
 #: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
@@ -1226,12 +1226,12 @@ msgstr ""
 msgid "Go to the new account"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:99
+#: lib/abuuba_web/live/status_live.ex:121
 #, elixir-autogen, elixir-format
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:803
+#: lib/abuuba_web/live/profile_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
@@ -1252,8 +1252,8 @@ msgstr ""
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:248
-#: lib/abuuba_web/live/profile_live.ex:801
+#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/profile_live.ex:789
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:208
@@ -1261,7 +1261,7 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:802
+#: lib/abuuba_web/live/profile_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
@@ -1272,7 +1272,7 @@ msgstr ""
 msgid "Save the note"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:318
+#: lib/abuuba_web/live/status_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "That server could not be reached, so this is all there is."
 msgstr ""
@@ -1283,7 +1283,7 @@ msgid "This account has moved to %{handle}."
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:196
-#: lib/abuuba_web/live/settings_live.ex:827
+#: lib/abuuba_web/live/settings_live.ex:828
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
@@ -1310,103 +1310,103 @@ msgstr ""
 msgid "What to show"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:101
+#: lib/abuuba_web/live/notifications_live.ex:112
 #, elixir-autogen, elixir-format
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:151
+#: lib/abuuba_web/live/notifications_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:398
+#: lib/abuuba_web/live/notifications_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:402
+#: lib/abuuba_web/live/notifications_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:409
+#: lib/abuuba_web/live/notifications_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:412
+#: lib/abuuba_web/live/notifications_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:136
+#: lib/abuuba_web/live/notifications_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:416
+#: lib/abuuba_web/live/notifications_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:365
+#: lib/abuuba_web/live/notifications_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:363
+#: lib/abuuba_web/live/notifications_live.ex:374
 #, elixir-autogen, elixir-format
 msgid "%{name} boosted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:368
+#: lib/abuuba_web/live/notifications_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:366
+#: lib/abuuba_web/live/notifications_live.ex:377
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:364
+#: lib/abuuba_web/live/notifications_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:362
+#: lib/abuuba_web/live/notifications_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:369
+#: lib/abuuba_web/live/notifications_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "%{name} posted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:370
+#: lib/abuuba_web/live/notifications_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:367
+#: lib/abuuba_web/live/notifications_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr ""
@@ -1431,7 +1431,7 @@ msgstr ""
 msgid "Accounts made very recently"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:448
+#: lib/abuuba_web/live/notifications_live.ex:459
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
@@ -1461,17 +1461,17 @@ msgstr ""
 msgid "Automated accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:457
+#: lib/abuuba_web/live/notifications_live.ex:468
 #, elixir-autogen, elixir-format
 msgid "Boosts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:129
+#: lib/abuuba_web/live/notifications_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:196
+#: lib/abuuba_web/live/notifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -1481,12 +1481,12 @@ msgstr ""
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:462
+#: lib/abuuba_web/live/notifications_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Edits"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:460
+#: lib/abuuba_web/live/notifications_live.ex:471
 #, elixir-autogen, elixir-format
 msgid "Favourites"
 msgstr ""
@@ -1496,15 +1496,15 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:459
+#: lib/abuuba_web/live/notifications_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:458
-#: lib/abuuba_web/live/profile_live.ex:805
-#: lib/abuuba_web/live/settings_live.ex:2104
-#: lib/abuuba_web/live/settings_live.ex:2242
+#: lib/abuuba_web/live/notifications_live.ex:469
+#: lib/abuuba_web/live/profile_live.ex:793
+#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2249
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -1519,28 +1519,28 @@ msgstr ""
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:165
+#: lib/abuuba_web/live/notifications_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:125
+#: lib/abuuba_web/live/notifications_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:448
-#: lib/abuuba_web/live/notifications_live.ex:456
+#: lib/abuuba_web/live/notifications_live.ex:459
+#: lib/abuuba_web/live/notifications_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:174
+#: lib/abuuba_web/live/notifications_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:210
+#: lib/abuuba_web/live/notifications_live.ex:221
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr ""
@@ -1555,7 +1555,7 @@ msgstr ""
 msgid "People you do not follow"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:461
+#: lib/abuuba_web/live/notifications_live.ex:472
 #, elixir-autogen, elixir-format
 msgid "Polls"
 msgstr ""
@@ -1572,27 +1572,27 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
 #: lib/abuuba_web/live/profile_live.ex:262
-#: lib/abuuba_web/live/settings_live.ex:295
-#: lib/abuuba_web/live/settings_live.ex:389
-#: lib/abuuba_web/live/settings_live.ex:426
-#: lib/abuuba_web/live/settings_live.ex:490
-#: lib/abuuba_web/live/settings_live.ex:597
-#: lib/abuuba_web/live/settings_live.ex:642
-#: lib/abuuba_web/live/settings_live.ex:675
-#: lib/abuuba_web/live/settings_live.ex:997
+#: lib/abuuba_web/live/settings_live.ex:296
+#: lib/abuuba_web/live/settings_live.ex:390
+#: lib/abuuba_web/live/settings_live.ex:427
+#: lib/abuuba_web/live/settings_live.ex:491
+#: lib/abuuba_web/live/settings_live.ex:598
+#: lib/abuuba_web/live/settings_live.ex:643
+#: lib/abuuba_web/live/settings_live.ex:676
+#: lib/abuuba_web/live/settings_live.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:245
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:137
+#: lib/abuuba_web/live/settings_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:360
-#: lib/abuuba_web/live/notifications_live.ex:425
+#: lib/abuuba_web/live/notifications_live.ex:371
+#: lib/abuuba_web/live/notifications_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr ""
@@ -1602,7 +1602,7 @@ msgstr ""
 msgid "Somebody a moderator here has already restricted."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:395
+#: lib/abuuba_web/live/notifications_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr ""
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "That could not be saved. Try again."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:90
+#: lib/abuuba_web/live/notifications_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr ""
@@ -1622,13 +1622,13 @@ msgstr ""
 msgid "Who can reach you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:143
+#: lib/abuuba_web/live/notifications_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:186
-#: lib/abuuba_web/live/conversations_live.ex:87
+#: lib/abuuba_web/components/layouts.ex:190
+#: lib/abuuba_web/live/conversations_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "unread"
 msgstr ""
@@ -1639,13 +1639,13 @@ msgid "A name, a #tag, or some words"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2277
-#: lib/abuuba_web/live/admin_live.ex:3587
+#: lib/abuuba_web/live/admin_live.ex:3583
 #: lib/abuuba_web/live/search_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/explore_live.ex:250
 #: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:207
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:122
+#: lib/abuuba_web/live/explore_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:250
+#: lib/abuuba_web/live/explore_live.ex:251
 #: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:206
@@ -1716,8 +1716,8 @@ msgstr ""
 msgid "Registration needs approval: you sign up and an admin reads your request."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:244
-#: lib/abuuba_web/components/layouts.ex:253
+#: lib/abuuba_web/components/layouts.ex:248
+#: lib/abuuba_web/components/layouts.ex:257
 #: lib/abuuba_web/live/search_live.ex:38
 #: lib/abuuba_web/live/search_live.ex:61
 #: lib/abuuba_web/live/search_live.ex:70
@@ -1730,7 +1730,7 @@ msgstr ""
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:64
+#: lib/abuuba_web/live/explore_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "What to explore"
 msgstr ""
@@ -1755,220 +1755,221 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:892
+#: lib/abuuba_web/live/settings_live.ex:893
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:235
+#: lib/abuuba_web/live/settings_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3379
-#: lib/abuuba_web/live/settings_live.ex:2107
+#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/settings_live.ex:2114
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:291
+#: lib/abuuba_web/live/settings_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "Add a field"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:808
+#: lib/abuuba_web/live/settings_live.ex:809
 #, elixir-autogen, elixir-format
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2278
+#: lib/abuuba_web/live/settings_live.ex:2285
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2113
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2138
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:948
+#: lib/abuuba_web/live/settings_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:896
+#: lib/abuuba_web/live/settings_live.ex:897
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
 
+#: lib/abuuba_web/components/status_component.ex:455
 #: lib/abuuba_web/live/admin_live.ex:998
-#: lib/abuuba_web/live/settings_live.ex:755
+#: lib/abuuba_web/live/settings_live.ex:756
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:224
+#: lib/abuuba_web/live/settings_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1601
+#: lib/abuuba_web/live/settings_live.ex:1608
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2136
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:202
+#: lib/abuuba_web/live/settings_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:240
+#: lib/abuuba_web/live/settings_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2103
-#: lib/abuuba_web/live/settings_live.ex:2248
+#: lib/abuuba_web/live/settings_live.ex:2110
+#: lib/abuuba_web/live/settings_live.ex:2255
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2331
+#: lib/abuuba_web/live/settings_live.ex:2338
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2279
+#: lib/abuuba_web/live/settings_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:255
+#: lib/abuuba_web/live/settings_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2277
+#: lib/abuuba_web/live/settings_live.ex:2284
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2282
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2282
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:273
+#: lib/abuuba_web/live/settings_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:977
+#: lib/abuuba_web/live/settings_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:991
+#: lib/abuuba_web/live/settings_live.ex:998
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:450
+#: lib/abuuba_web/live/settings_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2132
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2109
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2322
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2313
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2286
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1978,166 +1979,166 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1786
 #: lib/abuuba_web/live/admin_live.ex:1878
 #: lib/abuuba_web/live/admin_live.ex:2202
-#: lib/abuuba_web/live/conversations_live.ex:112
-#: lib/abuuba_web/live/settings_live.ex:281
-#: lib/abuuba_web/live/settings_live.ex:316
+#: lib/abuuba_web/live/conversations_live.ex:113
+#: lib/abuuba_web/live/settings_live.ex:282
+#: lib/abuuba_web/live/settings_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2112
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:909
+#: lib/abuuba_web/live/settings_live.ex:915
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:905
+#: lib/abuuba_web/live/settings_live.ex:906
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2304
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:971
+#: lib/abuuba_web/live/settings_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3750
-#: lib/abuuba_web/live/settings_live.ex:2094
+#: lib/abuuba_web/live/admin_live.ex:3746
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1576
+#: lib/abuuba_web/live/settings_live.ex:1583
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:469
+#: lib/abuuba_web/live/settings_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2287
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:850
+#: lib/abuuba_web/live/settings_live.ex:851
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:875
+#: lib/abuuba_web/live/settings_live.ex:876
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:242
+#: lib/abuuba_web/live/settings_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/settings_live.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:262
+#: lib/abuuba_web/live/settings_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2290
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:800
+#: lib/abuuba_web/live/settings_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2133
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2178
-#: lib/abuuba_web/live/settings_live.ex:762
+#: lib/abuuba_web/live/settings_live.ex:763
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:767
+#: lib/abuuba_web/live/settings_live.ex:768
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:456
+#: lib/abuuba_web/live/settings_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:437
+#: lib/abuuba_web/live/settings_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:871
+#: lib/abuuba_web/live/settings_live.ex:872
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2283
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:887
+#: lib/abuuba_web/live/settings_live.ex:888
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:988
+#: lib/abuuba_web/live/settings_live.ex:995
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2130
+#: lib/abuuba_web/live/settings_live.ex:2137
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2293,110 +2294,110 @@ msgstr ""
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1859
+#: lib/abuuba_web/live/settings_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2135
+#: lib/abuuba_web/live/settings_live.ex:2142
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1197
+#: lib/abuuba_web/live/settings_live.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2108
+#: lib/abuuba_web/live/settings_live.ex:2115
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1227
+#: lib/abuuba_web/live/settings_live.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1843
+#: lib/abuuba_web/live/settings_live.ex:1850
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1194
+#: lib/abuuba_web/live/settings_live.ex:1201
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1862
+#: lib/abuuba_web/live/settings_live.ex:1869
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1201
-#: lib/abuuba_web/live/settings_live.ex:1839
+#: lib/abuuba_web/live/settings_live.ex:1208
+#: lib/abuuba_web/live/settings_live.ex:1846
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1172
+#: lib/abuuba_web/live/settings_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1861
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1860
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1855
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1863
+#: lib/abuuba_web/live/settings_live.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1864
+#: lib/abuuba_web/live/settings_live.ex:1871
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1861
+#: lib/abuuba_web/live/settings_live.ex:1868
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1180
+#: lib/abuuba_web/live/settings_live.ex:1187
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1218
+#: lib/abuuba_web/live/settings_live.ex:1225
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1207
+#: lib/abuuba_web/live/settings_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1209
+#: lib/abuuba_web/live/settings_live.ex:1216
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
@@ -2411,7 +2412,7 @@ msgstr ""
 msgid "A rule needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/admin_live.ex:3377
 #, elixir-autogen, elixir-format
 msgid "Accounts"
 msgstr ""
@@ -2429,12 +2430,12 @@ msgid "Address people can write to"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:228
-#: lib/abuuba_web/live/admin_live.ex:3396
+#: lib/abuuba_web/live/admin_live.ex:3395
 #, elixir-autogen, elixir-format
 msgid "Administration"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3733
+#: lib/abuuba_web/live/admin_live.ex:3729
 #, elixir-autogen, elixir-format
 msgid "An open server left unattended fills with spam registrations within days. Put sign-ups behind approval unless somebody is watching."
 msgstr ""
@@ -2444,17 +2445,17 @@ msgstr ""
 msgid "Any state"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3718
+#: lib/abuuba_web/live/admin_live.ex:3714
 #, elixir-autogen, elixir-format
 msgid "Anybody may sign up without being checked"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3427
+#: lib/abuuba_web/live/admin_live.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Anybody, after somebody here says yes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3426
+#: lib/abuuba_web/live/admin_live.ex:3425
 #, elixir-autogen, elixir-format
 msgid "Anybody, straight away"
 msgstr ""
@@ -2470,7 +2471,7 @@ msgstr ""
 msgid "Appeals waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3395
+#: lib/abuuba_web/live/admin_live.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Audit log"
 msgstr ""
@@ -2480,7 +2481,7 @@ msgstr ""
 msgid "Change an address only when somebody cannot reach their own."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3377
+#: lib/abuuba_web/live/admin_live.ex:3376
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -2490,7 +2491,7 @@ msgstr ""
 msgid "Deleting posts needs the posts named, which this page cannot do yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3437
+#: lib/abuuba_web/live/admin_live.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Disable: they cannot sign in"
 msgstr ""
@@ -2510,7 +2511,7 @@ msgstr ""
 msgid "Email address"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3723
+#: lib/abuuba_web/live/admin_live.ex:3719
 #, elixir-autogen, elixir-format
 msgid "Everything else on this page is guesswork until that is fixed."
 msgstr ""
@@ -2540,12 +2541,12 @@ msgstr ""
 msgid "Lift it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3419
+#: lib/abuuba_web/live/admin_live.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3438
+#: lib/abuuba_web/live/admin_live.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Mark everything they post sensitive"
 msgstr ""
@@ -2555,12 +2556,12 @@ msgstr ""
 msgid "Name or name@server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3739
+#: lib/abuuba_web/live/admin_live.ex:3735
 #, elixir-autogen, elixir-format
 msgid "Nobody can grant roles or change settings that need it. Give somebody a role holding the administrator permission."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3719
+#: lib/abuuba_web/live/admin_live.ex:3715
 #, elixir-autogen, elixir-format
 msgid "Nobody here is an administrator"
 msgstr ""
@@ -2618,7 +2619,7 @@ msgstr ""
 msgid "Rules people agree to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3434
+#: lib/abuuba_web/live/admin_live.ex:3433
 #, elixir-autogen, elixir-format
 msgid "Send a warning and nothing else"
 msgstr ""
@@ -2629,12 +2630,12 @@ msgstr ""
 msgid "Server name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3394
+#: lib/abuuba_web/live/admin_live.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Server settings"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3727
+#: lib/abuuba_web/live/admin_live.ex:3723
 #, elixir-autogen, elixir-format
 msgid "Servers running authorized fetch will refuse this one. It is created on first use, so this usually means something went wrong writing it."
 msgstr ""
@@ -2649,17 +2650,17 @@ msgstr ""
 msgid "Shown when somebody signs up and when they file a report."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3435
+#: lib/abuuba_web/live/admin_live.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Silence: out of everywhere nobody asked for them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3436
+#: lib/abuuba_web/live/admin_live.ex:3435
 #, elixir-autogen, elixir-format
 msgid "Suspend: hidden, and deleted after the grace window"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3420
+#: lib/abuuba_web/live/admin_live.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr ""
@@ -2669,7 +2670,7 @@ msgstr ""
 msgid "Talk only to servers on the allowlist"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3345
+#: lib/abuuba_web/live/admin_live.ex:3344
 #, elixir-autogen, elixir-format
 msgid "That account outranks yours, so there is nothing here you can do to it."
 msgstr ""
@@ -2691,13 +2692,13 @@ msgid "That is not an address."
 msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
-#: lib/abuuba_web/live/admin_live.ex:3340
-#: lib/abuuba_web/live/settings_live.ex:1629
+#: lib/abuuba_web/live/admin_live.ex:3339
+#: lib/abuuba_web/live/settings_live.ex:1636
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3716
+#: lib/abuuba_web/live/admin_live.ex:3712
 #, elixir-autogen, elixir-format
 msgid "The database is not answering"
 msgstr ""
@@ -2712,7 +2713,7 @@ msgstr ""
 msgid "This deletes the account as well. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3717
+#: lib/abuuba_web/live/admin_live.ex:3713
 #, elixir-autogen, elixir-format
 msgid "This server has no actor of its own"
 msgstr ""
@@ -2722,7 +2723,7 @@ msgstr ""
 msgid "Turn away"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3418
+#: lib/abuuba_web/live/admin_live.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Waiting to be let in"
 msgstr ""
@@ -2816,7 +2817,7 @@ msgstr ""
 msgid "Take it down"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3384
+#: lib/abuuba_web/live/admin_live.ex:3383
 #, elixir-autogen, elixir-format
 msgid "Trends"
 msgstr ""
@@ -2826,17 +2827,17 @@ msgstr ""
 msgid "What is trending now"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:76
+#: lib/abuuba_web/live/explore_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1243
+#: lib/abuuba_web/live/settings_live.ex:1250
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
@@ -2846,12 +2847,12 @@ msgstr ""
 msgid "An announcement needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3385
+#: lib/abuuba_web/live/admin_live.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2144
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2866,7 +2867,7 @@ msgstr ""
 msgid "Earlier versions"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3796
+#: lib/abuuba_web/live/admin_live.ex:3792
 #, elixir-autogen, elixir-format
 msgid "Everybody has already been told about that one."
 msgstr ""
@@ -2876,7 +2877,7 @@ msgstr ""
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1254
+#: lib/abuuba_web/live/settings_live.ex:1261
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
@@ -2891,12 +2892,12 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1238
+#: lib/abuuba_web/live/settings_live.ex:1245
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
@@ -2906,7 +2907,7 @@ msgstr ""
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1261
+#: lib/abuuba_web/live/settings_live.ex:1268
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
@@ -2936,7 +2937,7 @@ msgstr ""
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1275
+#: lib/abuuba_web/live/settings_live.ex:1282
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr ""
@@ -2951,12 +2952,12 @@ msgstr ""
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1259
+#: lib/abuuba_web/live/settings_live.ex:1266
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1250
+#: lib/abuuba_web/live/settings_live.ex:1257
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr ""
@@ -2977,7 +2978,7 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1281
+#: lib/abuuba_web/live/settings_live.ex:1288
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
@@ -2987,7 +2988,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2089
+#: lib/abuuba_web/live/settings_live.ex:2096
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3004,7 +3005,7 @@ msgstr ""
 msgid "Anywhere in a name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3778
+#: lib/abuuba_web/live/admin_live.ex:3774
 #, elixir-autogen, elixir-format
 msgid "Ask for approval"
 msgstr ""
@@ -3031,12 +3032,12 @@ msgstr ""
 msgid "Mail domains"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3780
+#: lib/abuuba_web/live/admin_live.ex:3776
 #, elixir-autogen, elixir-format
 msgid "No access at all"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3779
+#: lib/abuuba_web/live/admin_live.ex:3775
 #, elixir-autogen, elixir-format
 msgid "No sign-ups"
 msgstr ""
@@ -3056,7 +3057,7 @@ msgstr ""
 msgid "Please complete the puzzle so we know you are a person."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3386
+#: lib/abuuba_web/live/admin_live.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Sign-up blocks"
 msgstr ""
@@ -3101,14 +3102,14 @@ msgstr ""
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:338
-#: lib/abuuba_web/live/post_actions.ex:297
-#: lib/abuuba_web/live/status_live.ex:185
+#: lib/abuuba_web/live/home_live.ex:357
+#: lib/abuuba_web/live/post_actions.ex:395
+#: lib/abuuba_web/live/status_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "That could not be translated just now."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:446
+#: lib/abuuba_web/components/status_component.ex:469
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
@@ -3123,245 +3124,245 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1988
+#: lib/abuuba_web/live/settings_live.ex:1995
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1979
+#: lib/abuuba_web/live/settings_live.ex:1986
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1895
+#: lib/abuuba_web/live/settings_live.ex:1902
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2052
+#: lib/abuuba_web/live/settings_live.ex:2059
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1876
+#: lib/abuuba_web/live/settings_live.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2082
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2110
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1901
+#: lib/abuuba_web/live/settings_live.ex:1908
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2140
+#: lib/abuuba_web/live/settings_live.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2076
+#: lib/abuuba_web/live/settings_live.ex:2083
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2048
+#: lib/abuuba_web/live/settings_live.ex:2055
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2063
-#: lib/abuuba_web/live/settings_live.ex:2068
+#: lib/abuuba_web/live/settings_live.ex:2070
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2072
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1885
+#: lib/abuuba_web/live/settings_live.ex:1892
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1882
+#: lib/abuuba_web/live/settings_live.ex:1889
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1890
+#: lib/abuuba_web/live/settings_live.ex:1897
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2079
+#: lib/abuuba_web/live/settings_live.ex:2086
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2088
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2089
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2085
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2090
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1046
+#: lib/abuuba_web/live/settings_live.ex:1053
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1934
+#: lib/abuuba_web/live/settings_live.ex:1941
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1041
+#: lib/abuuba_web/live/settings_live.ex:1048
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1952
+#: lib/abuuba_web/live/settings_live.ex:1959
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1051
+#: lib/abuuba_web/live/settings_live.ex:1058
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1039
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1008
+#: lib/abuuba_web/live/settings_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1965
+#: lib/abuuba_web/live/settings_live.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1942
+#: lib/abuuba_web/live/settings_live.ex:1949
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1065
-#: lib/abuuba_web/live/settings_live.ex:1914
-#: lib/abuuba_web/live/settings_live.ex:2245
+#: lib/abuuba_web/live/settings_live.ex:1072
+#: lib/abuuba_web/live/settings_live.ex:1921
+#: lib/abuuba_web/live/settings_live.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1035
+#: lib/abuuba_web/live/settings_live.ex:1042
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1019
+#: lib/abuuba_web/live/settings_live.ex:1026
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2038
+#: lib/abuuba_web/live/settings_live.ex:2045
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1003
+#: lib/abuuba_web/live/settings_live.ex:1010
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1938
+#: lib/abuuba_web/live/settings_live.ex:1945
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2028
+#: lib/abuuba_web/live/settings_live.ex:2035
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2039
+#: lib/abuuba_web/live/settings_live.ex:2046
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1916
+#: lib/abuuba_web/live/settings_live.ex:1923
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1029
+#: lib/abuuba_web/live/settings_live.ex:1036
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1001
+#: lib/abuuba_web/live/settings_live.ex:1008
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1931
+#: lib/abuuba_web/live/settings_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2034
+#: lib/abuuba_web/live/settings_live.ex:2041
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
@@ -3371,27 +3372,27 @@ msgstr ""
 msgid "No such post here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:245
+#: lib/abuuba_web/live/settings_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:783
+#: lib/abuuba_web/live/settings_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:796
+#: lib/abuuba_web/live/settings_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:780
+#: lib/abuuba_web/live/settings_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1515
+#: lib/abuuba_web/live/settings_live.ex:1522
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
@@ -3401,54 +3402,54 @@ msgstr ""
 msgid "Why they want to join:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:308
+#: lib/abuuba_web/live/settings_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:325
+#: lib/abuuba_web/live/settings_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:328
+#: lib/abuuba_web/live/settings_live.ex:329
 #, elixir-autogen, elixir-format
 msgid "Feature it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:299
+#: lib/abuuba_web/live/settings_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:301
+#: lib/abuuba_web/live/settings_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1498
+#: lib/abuuba_web/live/settings_live.ex:1505
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:332
+#: lib/abuuba_web/live/settings_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1492
+#: lib/abuuba_web/live/settings_live.ex:1499
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:483
+#: lib/abuuba_web/live/settings_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:485
+#: lib/abuuba_web/live/settings_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
@@ -3485,7 +3486,7 @@ msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/collection_live.ex:117
+#: lib/abuuba_web/live/collection_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "A collection by %{name}"
 msgstr ""
@@ -3596,7 +3597,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr ""
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:646
+#: lib/abuuba_web/live/settings_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "Email updates"
 msgstr ""
@@ -3611,7 +3612,7 @@ msgstr ""
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:664
+#: lib/abuuba_web/live/settings_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr ""
@@ -3621,7 +3622,7 @@ msgstr ""
 msgid "No, remove my address"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:666
+#: lib/abuuba_web/live/settings_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3674,7 +3675,7 @@ msgstr ""
 msgid "Let people collect email addresses for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:648
+#: lib/abuuba_web/live/settings_live.ex:649
 #, elixir-autogen, elixir-format
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr ""
@@ -3822,75 +3823,75 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1078
+#: lib/abuuba_web/live/settings_live.ex:1085
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2252
+#: lib/abuuba_web/live/settings_live.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:811
-#: lib/abuuba_web/live/settings_live.ex:2246
+#: lib/abuuba_web/live/settings_live.ex:812
+#: lib/abuuba_web/live/settings_live.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2243
+#: lib/abuuba_web/live/settings_live.ex:2250
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2247
+#: lib/abuuba_web/live/settings_live.ex:2254
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1120
+#: lib/abuuba_web/live/settings_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2254
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1103
+#: lib/abuuba_web/live/settings_live.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2118
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2244
+#: lib/abuuba_web/live/settings_live.ex:2251
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1067
+#: lib/abuuba_web/live/settings_live.ex:1074
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1388
+#: lib/abuuba_web/live/settings_live.ex:1395
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1085
+#: lib/abuuba_web/live/settings_live.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2253
+#: lib/abuuba_web/live/settings_live.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3910,13 +3911,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2251
+#: lib/abuuba_web/live/settings_live.ex:2258
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1109
-#: lib/abuuba_web/live/settings_live.ex:1394
+#: lib/abuuba_web/live/settings_live.ex:1116
+#: lib/abuuba_web/live/settings_live.ex:1401
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3926,7 +3927,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1080
+#: lib/abuuba_web/live/settings_live.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3936,67 +3937,67 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1159
+#: lib/abuuba_web/live/settings_live.ex:1166
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1157
+#: lib/abuuba_web/live/settings_live.ex:1164
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1123
+#: lib/abuuba_web/live/settings_live.ex:1130
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1062
+#: lib/abuuba_web/live/settings_live.ex:1069
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2143
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1140
+#: lib/abuuba_web/live/settings_live.ex:1147
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1421
+#: lib/abuuba_web/live/settings_live.ex:1428
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1418
+#: lib/abuuba_web/live/settings_live.ex:1425
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1130
+#: lib/abuuba_web/live/settings_live.ex:1137
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1414
+#: lib/abuuba_web/live/settings_live.ex:1421
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1145
+#: lib/abuuba_web/live/settings_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1125
+#: lib/abuuba_web/live/settings_live.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1135
+#: lib/abuuba_web/live/settings_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
@@ -4042,99 +4043,99 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1450
+#: lib/abuuba_web/live/settings_live.ex:1457
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:915
+#: lib/abuuba_web/live/settings_live.ex:922
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:524
+#: lib/abuuba_web/live/settings_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:533
+#: lib/abuuba_web/live/settings_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:552
+#: lib/abuuba_web/live/settings_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:579
+#: lib/abuuba_web/live/settings_live.ex:580
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:568
+#: lib/abuuba_web/live/settings_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:564
+#: lib/abuuba_web/live/settings_live.ex:565
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:938
+#: lib/abuuba_web/live/settings_live.ex:945
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:521
+#: lib/abuuba_web/live/settings_live.ex:522
 #, elixir-autogen, elixir-format
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:934
+#: lib/abuuba_web/live/settings_live.ex:941
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:526
+#: lib/abuuba_web/live/settings_live.ex:527
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:590
+#: lib/abuuba_web/live/settings_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:501
+#: lib/abuuba_web/live/settings_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:913
+#: lib/abuuba_web/live/settings_live.ex:920
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:923
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:923
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:515
+#: lib/abuuba_web/live/settings_live.ex:516
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:503
+#: lib/abuuba_web/live/settings_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr ""
@@ -4206,17 +4207,17 @@ msgstr ""
 msgid "No relays yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3681
+#: lib/abuuba_web/live/admin_live.ex:3677
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3683
+#: lib/abuuba_web/live/admin_live.ex:3679
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3387
+#: lib/abuuba_web/live/admin_live.ex:3386
 #, elixir-autogen, elixir-format
 msgid "Relays"
 msgstr ""
@@ -4231,7 +4232,7 @@ msgstr ""
 msgid "That is not an https inbox address, or it is already here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3684
+#: lib/abuuba_web/live/admin_live.ex:3680
 #, elixir-autogen, elixir-format
 msgid "The relay refused"
 msgstr ""
@@ -4253,7 +4254,7 @@ msgstr ""
 msgid "Turn on"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3682
+#: lib/abuuba_web/live/admin_live.ex:3678
 #, elixir-autogen, elixir-format
 msgid "Waiting for the relay to answer"
 msgstr ""
@@ -4293,18 +4294,18 @@ msgstr ""
 msgid "Remove this webhook?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3109
-#: lib/abuuba_web/live/admin_live.ex:3677
+#: lib/abuuba_web/live/admin_live.ex:3108
+#: lib/abuuba_web/live/admin_live.ex:3673
 #, elixir-autogen, elixir-format
 msgid "That did not work."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3674
+#: lib/abuuba_web/live/admin_live.ex:3670
 #, elixir-autogen, elixir-format
 msgid "That is not an event this server sends."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3671
+#: lib/abuuba_web/live/admin_live.ex:3667
 #, elixir-autogen, elixir-format
 msgid "That is not an https address, or it is already here."
 msgstr ""
@@ -4324,7 +4325,7 @@ msgstr ""
 msgid "This server posts to a webhook when something happens that a moderator would want to know about."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3393
+#: lib/abuuba_web/live/admin_live.ex:3392
 #, elixir-autogen, elixir-format
 msgid "Webhooks"
 msgstr ""
@@ -4344,37 +4345,37 @@ msgstr ""
 msgid "Above yours"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3590
+#: lib/abuuba_web/live/admin_live.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Act on accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3594
+#: lib/abuuba_web/live/admin_live.ex:3590
 #, elixir-autogen, elixir-format
 msgid "Answer appeals"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3620
+#: lib/abuuba_web/live/admin_live.ex:3616
 #, elixir-autogen, elixir-format
 msgid "Approve registrations, and turn two-factor off for somebody locked out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3598
+#: lib/abuuba_web/live/admin_live.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Approve what trends"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3628
+#: lib/abuuba_web/live/admin_live.ex:3624
 #, elixir-autogen, elixir-format
 msgid "Block and unblock other servers, and set up relays."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3596
+#: lib/abuuba_web/live/admin_live.ex:3592
 #, elixir-autogen, elixir-format
 msgid "Block sign-ups"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3597
+#: lib/abuuba_web/live/admin_live.ex:3593
 #, elixir-autogen, elixir-format
 msgid "Change the server's settings"
 msgstr ""
@@ -4389,62 +4390,62 @@ msgstr ""
 msgid "Create the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3595
+#: lib/abuuba_web/live/admin_live.ex:3591
 #, elixir-autogen, elixir-format
 msgid "Decide about other servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3634
+#: lib/abuuba_web/live/admin_live.ex:3630
 #, elixir-autogen, elixir-format
 msgid "Decide which hashtags, links and posts may appear in what is trending."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3592
+#: lib/abuuba_web/live/admin_live.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Delete an account's data"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3623
+#: lib/abuuba_web/live/admin_live.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Delete somebody's posts and files. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3609
+#: lib/abuuba_web/live/admin_live.ex:3605
 #, elixir-autogen, elixir-format
 msgid "Every permission below, including ones added later. Give it to very few people."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3593
+#: lib/abuuba_web/live/admin_live.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Handle reports"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3591
+#: lib/abuuba_web/live/admin_live.ex:3587
 #, elixir-autogen, elixir-format
 msgid "Let people in and out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3638
+#: lib/abuuba_web/live/admin_live.ex:3634
 #, elixir-autogen, elixir-format
 msgid "Make and change roles, never above their own and never granting more than they hold."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3603
+#: lib/abuuba_web/live/admin_live.ex:3599
 #, elixir-autogen, elixir-format
 msgid "Manage custom emoji"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3599
+#: lib/abuuba_web/live/admin_live.ex:3595
 #, elixir-autogen, elixir-format
 msgid "Manage everybody's invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3605
+#: lib/abuuba_web/live/admin_live.ex:3601
 #, elixir-autogen, elixir-format
 msgid "Manage roles"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3604
+#: lib/abuuba_web/live/admin_live.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Manage webhooks"
 msgstr ""
@@ -4469,12 +4470,12 @@ msgstr ""
 msgid "Position %{position}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3589
+#: lib/abuuba_web/live/admin_live.ex:3585
 #, elixir-autogen, elixir-format
 msgid "Read the audit log"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3625
+#: lib/abuuba_web/live/admin_live.ex:3621
 #, elixir-autogen, elixir-format
 msgid "Read the queue, resolve and reopen."
 msgstr ""
@@ -4484,7 +4485,7 @@ msgstr ""
 msgid "Remove this role? Anybody holding it keeps their account."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3392
+#: lib/abuuba_web/live/admin_live.ex:3391
 #, elixir-autogen, elixir-format
 msgid "Roles"
 msgstr ""
@@ -4494,23 +4495,23 @@ msgstr ""
 msgid "Save the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3588
+#: lib/abuuba_web/live/admin_live.ex:3584
 #, elixir-autogen, elixir-format
 msgid "See the admin area"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3617
+#: lib/abuuba_web/live/admin_live.ex:3613
 #, elixir-autogen, elixir-format
 msgid "Silence, suspend, approve and reject accounts on this server."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3502
-#: lib/abuuba_web/live/admin_live.ex:3528
+#: lib/abuuba_web/live/admin_live.ex:3501
+#: lib/abuuba_web/live/admin_live.ex:3524
 #, elixir-autogen, elixir-format
 msgid "That role could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3614
+#: lib/abuuba_web/live/admin_live.ex:3610
 #, elixir-autogen, elixir-format
 msgid "What every moderator has done, including this person's own actions."
 msgstr ""
@@ -4520,32 +4521,32 @@ msgstr ""
 msgid "What this role may do"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3631
+#: lib/abuuba_web/live/admin_live.ex:3627
 #, elixir-autogen, elixir-format
 msgid "Who may sign up, the server's name and description, and the rest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3611
+#: lib/abuuba_web/live/admin_live.ex:3607
 #, elixir-autogen, elixir-format
 msgid "Without this the admin area is closed."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3602
+#: lib/abuuba_web/live/admin_live.ex:3598
 #, elixir-autogen, elixir-format
 msgid "Write announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3600
+#: lib/abuuba_web/live/admin_live.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Write invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3601
+#: lib/abuuba_web/live/admin_live.ex:3597
 #, elixir-autogen, elixir-format
 msgid "Write the server rules"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3581
+#: lib/abuuba_web/live/admin_live.ex:3577
 #, elixir-autogen, elixir-format
 msgid "You cannot make a role at or above your own position, or grant a permission you do not hold."
 msgstr ""
@@ -4555,7 +4556,7 @@ msgstr ""
 msgid "You do not hold this yourself, so you cannot grant it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3651
+#: lib/abuuba_web/live/admin_live.ex:3647
 #, elixir-autogen, elixir-format
 msgid "nothing in particular"
 msgstr ""
@@ -4603,7 +4604,7 @@ msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3391
+#: lib/abuuba_web/live/admin_live.ex:3390
 #, elixir-autogen, elixir-format
 msgid "Other servers"
 msgstr ""
@@ -4753,7 +4754,7 @@ msgstr ""
 msgid "Checking for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3390
+#: lib/abuuba_web/live/admin_live.ex:3389
 #, elixir-autogen, elixir-format
 msgid "Domain lists"
 msgstr ""
@@ -4763,7 +4764,7 @@ msgstr ""
 msgid "Domains this server has already decided about are left exactly as they are. An import adds and never removes: one paste should not be able to undo every decision made here, silently and unrecoverably."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3388
+#: lib/abuuba_web/live/admin_live.ex:3387
 #, elixir-autogen, elixir-format
 msgid "Email subscriptions"
 msgstr ""
@@ -4864,17 +4865,17 @@ msgstr[1] ""
 msgid "%{label}, highest %{top}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3705
+#: lib/abuuba_web/live/admin_live.ex:3701
 #, elixir-autogen, elixir-format
 msgid "Favourites, boosts and replies"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3710
+#: lib/abuuba_web/live/admin_live.ex:3706
 #, elixir-autogen, elixir-format
 msgid "Languages people write in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3703
+#: lib/abuuba_web/live/admin_live.ex:3699
 #, elixir-autogen, elixir-format
 msgid "New accounts"
 msgstr ""
@@ -4884,27 +4885,27 @@ msgstr ""
 msgid "Of the people who signed up in a given week, how many were still posting in the weeks after. A number that only means something once the server has been running a while."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3702
+#: lib/abuuba_web/live/admin_live.ex:3698
 #, elixir-autogen, elixir-format
 msgid "People who posted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3704
+#: lib/abuuba_web/live/admin_live.ex:3700
 #, elixir-autogen, elixir-format
 msgid "Posts written here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3706
+#: lib/abuuba_web/live/admin_live.ex:3702
 #, elixir-autogen, elixir-format
 msgid "Reports opened"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3707
+#: lib/abuuba_web/live/admin_live.ex:3703
 #, elixir-autogen, elixir-format
 msgid "Reports resolved"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3712
+#: lib/abuuba_web/live/admin_live.ex:3708
 #, elixir-autogen, elixir-format
 msgid "Servers we hear most from"
 msgstr ""
@@ -4919,12 +4920,12 @@ msgstr ""
 msgid "The same numbers a moderation client draws from the API, so what you see here and what it shows are the same figures rather than two answers to one question."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3713
+#: lib/abuuba_web/live/admin_live.ex:3709
 #, elixir-autogen, elixir-format
 msgid "What those servers run"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3711
+#: lib/abuuba_web/live/admin_live.ex:3707
 #, elixir-autogen, elixir-format
 msgid "Where accounts signed up from"
 msgstr ""
@@ -4946,55 +4947,55 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2221
+#: lib/abuuba_web/live/settings_live.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2222
+#: lib/abuuba_web/live/settings_live.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:347
+#: lib/abuuba_web/live/settings_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:565
-#: lib/abuuba_web/live/settings_live.ex:365
+#: lib/abuuba_web/live/settings_live.ex:366
 #, elixir-autogen, elixir-format
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2062
+#: lib/abuuba_web/live/settings_live.ex:2069
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:345
+#: lib/abuuba_web/live/settings_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:397
+#: lib/abuuba_web/live/settings_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2060
-#: lib/abuuba_web/live/settings_live.ex:2215
+#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2222
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2210
 #: lib/abuuba_web/live/settings_live.ex:2217
+#: lib/abuuba_web/live/settings_live.ex:2224
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2057
+#: lib/abuuba_web/live/settings_live.ex:2064
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
@@ -5025,7 +5026,7 @@ msgstr ""
 msgid "Get updates from %{name} by email"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:681
+#: lib/abuuba_web/live/settings_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
@@ -5035,7 +5036,7 @@ msgstr ""
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:706
+#: lib/abuuba_web/live/settings_live.ex:707
 #, elixir-autogen, elixir-format
 msgid "Send it"
 msgstr ""
@@ -5045,15 +5046,15 @@ msgstr ""
 msgid "Send me updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:715
+#: lib/abuuba_web/live/settings_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:692
-#: lib/abuuba_web/live/settings_live.ex:1789
+#: lib/abuuba_web/live/settings_live.ex:693
+#: lib/abuuba_web/live/settings_live.ex:1796
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
@@ -5063,7 +5064,7 @@ msgstr ""
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1369
+#: lib/abuuba_web/live/settings_live.ex:1376
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5078,12 +5079,12 @@ msgstr ""
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:699
+#: lib/abuuba_web/live/settings_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:679
+#: lib/abuuba_web/live/settings_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr ""
@@ -5093,7 +5094,7 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1374
+#: lib/abuuba_web/live/settings_live.ex:1381
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
@@ -5103,12 +5104,12 @@ msgstr ""
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1790
+#: lib/abuuba_web/live/settings_live.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:722
+#: lib/abuuba_web/live/settings_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr ""
@@ -5159,7 +5160,7 @@ msgstr ""
 msgid "Keep it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3310
+#: lib/abuuba_web/live/admin_live.ex:3309
 #, elixir-autogen, elixir-format
 msgid "Limit them"
 msgstr ""
@@ -5196,7 +5197,7 @@ msgstr ""
 msgid "Ready-made texts a moderator picks instead of retyping. Kept for the server rather than for one moderator, so two people writing about the same thing say the same thing."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3382
+#: lib/abuuba_web/live/admin_live.ex:3381
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr ""
@@ -5206,7 +5207,7 @@ msgstr ""
 msgid "Report %{id}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3380
+#: lib/abuuba_web/live/admin_live.ex:3379
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr ""
@@ -5221,12 +5222,12 @@ msgstr ""
 msgid "Still open"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3312
+#: lib/abuuba_web/live/admin_live.ex:3311
 #, elixir-autogen, elixir-format
 msgid "Stop them signing in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3311
+#: lib/abuuba_web/live/admin_live.ex:3310
 #, elixir-autogen, elixir-format
 msgid "Suspend them"
 msgstr ""
@@ -5294,7 +5295,7 @@ msgstr ""
 msgid "from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3328
+#: lib/abuuba_web/live/admin_live.ex:3327
 #, elixir-autogen, elixir-format
 msgid "somebody who is gone"
 msgstr ""
@@ -5304,14 +5305,14 @@ msgstr ""
 msgid "taken"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3287
+#: lib/abuuba_web/live/admin_live.ex:3286
 #, elixir-autogen, elixir-format
 msgid "One account could not be changed."
 msgid_plural "%{count} accounts could not be changed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3280
+#: lib/abuuba_web/live/admin_live.ex:3279
 #, elixir-autogen, elixir-format
 msgid "One account was left alone because it outranks yours."
 msgid_plural "%{count} accounts were left alone because they outrank yours."
@@ -5323,7 +5324,7 @@ msgstr[1] ""
 msgid "Showing the newest %{count}. Deal with some to see the ones that have waited longest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3245
+#: lib/abuuba_web/live/admin_live.ex:3244
 #, elixir-autogen, elixir-format
 msgid "That is not something this list can do."
 msgstr ""
@@ -5394,7 +5395,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:961
+#: lib/abuuba_web/live/settings_live.ex:968
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5454,24 +5455,24 @@ msgstr ""
 msgid "A PNG or a GIF, at most %{size}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3212
+#: lib/abuuba_web/live/admin_live.ex:3211
 #, elixir-autogen, elixir-format
 msgid "A shortcode is letters, numbers and underscores, and nothing else."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3148
-#: lib/abuuba_web/live/admin_live.ex:3194
+#: lib/abuuba_web/live/admin_live.ex:3147
+#: lib/abuuba_web/live/admin_live.ex:3193
 #, elixir-autogen, elixir-format
 msgid "An emoji has to be a PNG or a GIF."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3138
-#: lib/abuuba_web/live/admin_live.ex:3172
+#: lib/abuuba_web/live/admin_live.ex:3137
+#: lib/abuuba_web/live/admin_live.ex:3171
 #, elixir-autogen, elixir-format
 msgid "Choose a picture for it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/admin_live.ex:3380
 #, elixir-autogen, elixir-format
 msgid "Custom emoji"
 msgstr ""
@@ -5506,23 +5507,23 @@ msgstr ""
 msgid "Stop offering it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3214
+#: lib/abuuba_web/live/admin_live.ex:3213
 #, elixir-autogen, elixir-format
 msgid "That emoji could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3200
+#: lib/abuuba_web/live/admin_live.ex:3199
 #, elixir-autogen, elixir-format
 msgid "That picture could not be stored."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3154
+#: lib/abuuba_web/live/admin_live.ex:3153
 #, elixir-autogen, elixir-format
 msgid "That picture could not be used."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3151
-#: lib/abuuba_web/live/admin_live.ex:3197
+#: lib/abuuba_web/live/admin_live.ex:3150
+#: lib/abuuba_web/live/admin_live.ex:3196
 #, elixir-autogen, elixir-format
 msgid "That picture is too large for an emoji."
 msgstr ""
@@ -5532,7 +5533,7 @@ msgstr ""
 msgid "The picture"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3135
+#: lib/abuuba_web/live/admin_live.ex:3134
 #, elixir-autogen, elixir-format
 msgid "The picture is still uploading. Try again in a moment."
 msgstr ""
@@ -5562,27 +5563,27 @@ msgstr ""
 msgid "What you see from them"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:464
+#: lib/abuuba_web/components/status_component.ex:487
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:476
+#: lib/abuuba_web/components/status_component.ex:499
 #, elixir-autogen, elixir-format
 msgid "Mute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:483
+#: lib/abuuba_web/components/status_component.ex:506
 #, elixir-autogen, elixir-format
 msgid "Stops its notifications and takes it out of your timeline. Nobody is told."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:475
+#: lib/abuuba_web/components/status_component.ex:498
 #, elixir-autogen, elixir-format
 msgid "Unmute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:468
+#: lib/abuuba_web/live/notifications_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr ""
@@ -5592,37 +5593,37 @@ msgstr ""
 msgid "Tell me when they post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:387
+#: lib/abuuba_web/live/notifications_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:391
+#: lib/abuuba_web/live/notifications_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:389
+#: lib/abuuba_web/live/notifications_live.ex:400
 #, elixir-autogen, elixir-format
 msgid "%{name} signed up"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:380
+#: lib/abuuba_web/live/notifications_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:376
+#: lib/abuuba_web/live/notifications_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:384
+#: lib/abuuba_web/live/notifications_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:463
+#: lib/abuuba_web/live/notifications_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Quotes"
 msgstr ""
@@ -5647,24 +5648,24 @@ msgstr ""
 msgid "turned off"
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:98
+#: lib/abuuba_web/live/conversations_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Mark unread"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:239
-#: lib/abuuba_web/live/conversations_live.ex:45
-#: lib/abuuba_web/live/conversations_live.ex:61
+#: lib/abuuba_web/components/layouts.ex:243
+#: lib/abuuba_web/live/conversations_live.ex:46
+#: lib/abuuba_web/live/conversations_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Messages"
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:64
+#: lib/abuuba_web/live/conversations_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. A post addressed to only the people you name arrives as a message, and its replies stay with it."
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:83
+#: lib/abuuba_web/live/conversations_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Open the conversation with %{people}"
 msgstr ""
@@ -5674,7 +5675,7 @@ msgstr ""
 msgid "The last message has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:106
+#: lib/abuuba_web/live/conversations_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "This takes it out of your inbox only. Nobody else loses anything, and a later message brings it back. Go ahead?"
 msgstr ""
@@ -5746,22 +5747,22 @@ msgstr ""
 msgid "Who may read the blocklist"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:636
+#: lib/abuuba_web/live/settings_live.ex:637
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:628
+#: lib/abuuba_web/live/settings_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:840
+#: lib/abuuba_web/live/settings_live.ex:841
 #, elixir-autogen, elixir-format
 msgid "Block a server"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:813
+#: lib/abuuba_web/live/settings_live.ex:814
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr ""
@@ -5771,28 +5772,28 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:147
+#: lib/abuuba_web/live/explore_live.ex:148
 #: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3370
+#: lib/abuuba_web/live/admin_live.ex:3369
 #, elixir-autogen, elixir-format
 msgid "Account disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3373
+#: lib/abuuba_web/live/admin_live.ex:3372
 #, elixir-autogen, elixir-format
 msgid "Account limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3374
+#: lib/abuuba_web/live/admin_live.ex:3373
 #, elixir-autogen, elixir-format
 msgid "Account suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3383
+#: lib/abuuba_web/live/admin_live.ex:3382
 #, elixir-autogen, elixir-format
 msgid "Appeals"
 msgstr ""
@@ -5802,12 +5803,12 @@ msgstr ""
 msgid "Nothing is waiting. Appeals against a strike show up here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3372
+#: lib/abuuba_web/live/admin_live.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Posts deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3371
+#: lib/abuuba_web/live/admin_live.ex:3370
 #, elixir-autogen, elixir-format
 msgid "Posts marked sensitive"
 msgstr ""
@@ -5817,7 +5818,7 @@ msgstr ""
 msgid "Somebody who was warned, silenced or suspended saying it was a mistake. Upholding an appeal undoes the action where it can be undone; where it cannot, the appeal is still recorded as upheld. Either way the account's owner is told."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3085
+#: lib/abuuba_web/live/admin_live.ex:3084
 #, elixir-autogen, elixir-format
 msgid "That appeal is no longer waiting."
 msgstr ""
@@ -5832,13 +5833,13 @@ msgstr ""
 msgid "Uphold and undo"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3369
+#: lib/abuuba_web/live/admin_live.ex:3368
 #, elixir-autogen, elixir-format
 msgid "Warned"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2235
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2242
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr ""
@@ -5848,7 +5849,7 @@ msgstr ""
 msgid "Cancel follow request"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:116
+#: lib/abuuba_web/live/explore_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
@@ -5856,4 +5857,20 @@ msgstr ""
 #: lib/abuuba_web/live/profile_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "This account approves its followers. Your request is waiting for an answer."
+msgstr ""
+
+#: lib/abuuba_web/components/status_component.ex:451
+#, elixir-autogen, elixir-format
+msgid "Delete this post? Other servers are told to forget it too."
+msgstr ""
+
+#: lib/abuuba_web/components/layouts.ex:145
+#: lib/abuuba_web/live/settings_live.ex:911
+#, elixir-autogen, elixir-format
+msgid "Sign out"
+msgstr ""
+
+#: lib/abuuba_web/live/post_actions.ex:428
+#, elixir-autogen, elixir-format
+msgid "That post is gone."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -37,8 +37,8 @@ msgstr[1] ""
 msgid "Actions"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:285
-#: lib/abuuba_web/components/layouts.ex:300
+#: lib/abuuba_web/components/layouts.ex:289
+#: lib/abuuba_web/components/layouts.ex:304
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
@@ -49,12 +49,12 @@ msgid "Change"
 msgstr ""
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:713
+#: lib/abuuba_web/live/compose_component.ex:714
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:292
+#: lib/abuuba_web/components/layouts.ex:296
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
@@ -64,7 +64,7 @@ msgstr ""
 msgid "That language is not available."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:277
+#: lib/abuuba_web/components/layouts.ex:281
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
@@ -285,7 +285,7 @@ msgid "You are signed out."
 msgstr ""
 
 #: lib/abuuba_web/user_auth.ex:88
-#: lib/abuuba_web/user_auth.ex:124
+#: lib/abuuba_web/user_auth.ex:205
 #, elixir-autogen, elixir-format
 msgid "You have to be signed in to see that page."
 msgstr ""
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:901
+#: lib/abuuba_web/live/settings_live.ex:902
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -466,8 +466,8 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:387
-#: lib/abuuba_web/live/compose_component.ex:400
+#: lib/abuuba_web/live/compose_component.ex:388
+#: lib/abuuba_web/live/compose_component.ex:401
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -652,51 +652,51 @@ msgstr ""
 msgid "That request has to be signed."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:243
-#: lib/abuuba_web/components/layouts.ex:252
-#: lib/abuuba_web/live/explore_live.ex:48
+#: lib/abuuba_web/components/layouts.ex:247
+#: lib/abuuba_web/components/layouts.ex:256
+#: lib/abuuba_web/live/explore_live.ex:49
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:230
-#: lib/abuuba_web/components/layouts.ex:251
+#: lib/abuuba_web/components/layouts.ex:234
+#: lib/abuuba_web/components/layouts.ex:255
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2311
+#: lib/abuuba_web/live/settings_live.ex:2318
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:142
+#: lib/abuuba_web/components/layouts.ex:143
 #: lib/abuuba_web/controllers/shortcuts_controller.ex:15
 #: lib/abuuba_web/controllers/shortcuts_html/show.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:254
+#: lib/abuuba_web/components/layouts.ex:258
 #: lib/abuuba_web/live/landing_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:132
-#: lib/abuuba_web/components/layouts.ex:154
+#: lib/abuuba_web/components/layouts.ex:133
+#: lib/abuuba_web/components/layouts.ex:158
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:233
+#: lib/abuuba_web/components/layouts.ex:237
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2312
+#: lib/abuuba_web/live/settings_live.ex:2319
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:245
-#: lib/abuuba_web/live/settings_live.ex:120
-#: lib/abuuba_web/live/settings_live.ex:2120
+#: lib/abuuba_web/components/layouts.ex:249
+#: lib/abuuba_web/live/settings_live.ex:121
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -735,12 +735,12 @@ msgstr ""
 msgid "Attachment"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:421
+#: lib/abuuba_web/components/status_component.ex:430
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:398
+#: lib/abuuba_web/components/status_component.ex:407
 #, elixir-autogen, elixir-format
 msgid "Boost"
 msgstr ""
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Closed"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:410
+#: lib/abuuba_web/components/status_component.ex:419
 #, elixir-autogen, elixir-format
 msgid "Favourite"
 msgstr ""
@@ -761,12 +761,12 @@ msgid "Follow some people and their posts will appear here."
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:267
-#: lib/abuuba_web/live/compose_component.ex:593
+#: lib/abuuba_web/live/compose_component.ex:594
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:386
+#: lib/abuuba_web/components/status_component.ex:395
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
@@ -791,303 +791,303 @@ msgstr ""
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1657
+#: lib/abuuba_web/live/compose_component.ex:1658
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1655
+#: lib/abuuba_web/live/compose_component.ex:1656
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1658
+#: lib/abuuba_web/live/compose_component.ex:1659
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1654
+#: lib/abuuba_web/live/compose_component.ex:1655
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1653
+#: lib/abuuba_web/live/compose_component.ex:1654
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1656
+#: lib/abuuba_web/live/compose_component.ex:1657
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1659
+#: lib/abuuba_web/live/compose_component.ex:1660
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1131
+#: lib/abuuba_web/live/compose_component.ex:1132
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:628
+#: lib/abuuba_web/live/compose_component.ex:629
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:699
+#: lib/abuuba_web/live/compose_component.ex:700
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:640
+#: lib/abuuba_web/live/compose_component.ex:641
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1674
-#: lib/abuuba_web/live/settings_live.ex:2306
+#: lib/abuuba_web/live/compose_component.ex:1675
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1665
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/settings_live.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2302
+#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/settings_live.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:604
+#: lib/abuuba_web/live/compose_component.ex:605
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:428
-#: lib/abuuba_web/live/compose_component.ex:689
+#: lib/abuuba_web/live/compose_component.ex:429
+#: lib/abuuba_web/live/compose_component.ex:690
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:790
+#: lib/abuuba_web/live/compose_component.ex:791
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:423
+#: lib/abuuba_web/live/compose_component.ex:424
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:432
+#: lib/abuuba_web/components/status_component.ex:441
 #: lib/abuuba_web/live/admin_live.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Edit"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:393
+#: lib/abuuba_web/live/compose_component.ex:394
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:644
+#: lib/abuuba_web/live/compose_component.ex:645
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/profile_live.ex:804
+#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/profile_live.ex:792
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/compose_component.ex:1669
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3428
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2308
+#: lib/abuuba_web/live/admin_live.ex:3427
+#: lib/abuuba_web/live/compose_component.ex:1677
+#: lib/abuuba_web/live/settings_live.ex:2315
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2303
+#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/settings_live.ex:2310
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1668
+#: lib/abuuba_web/live/compose_component.ex:1669
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2307
+#: lib/abuuba_web/live/compose_component.ex:1676
+#: lib/abuuba_web/live/settings_live.ex:2314
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1432
+#: lib/abuuba_web/live/compose_component.ex:1433
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:673
+#: lib/abuuba_web/live/compose_component.ex:674
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1665
-#: lib/abuuba_web/live/compose_component.ex:1683
+#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/compose_component.ex:1684
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1666
+#: lib/abuuba_web/live/compose_component.ex:1667
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:709
+#: lib/abuuba_web/live/compose_component.ex:710
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:616
+#: lib/abuuba_web/live/compose_component.ex:617
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:380
+#: lib/abuuba_web/live/compose_component.ex:381
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1430
+#: lib/abuuba_web/live/compose_component.ex:1431
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3389
-#: lib/abuuba_web/live/compose_component.ex:455
+#: lib/abuuba_web/live/admin_live.ex:3388
+#: lib/abuuba_web/live/compose_component.ex:456
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1093
+#: lib/abuuba_web/live/compose_component.ex:1094
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1155
-#: lib/abuuba_web/live/compose_component.ex:1190
-#: lib/abuuba_web/live/compose_component.ex:1386
+#: lib/abuuba_web/live/compose_component.ex:1156
+#: lib/abuuba_web/live/compose_component.ex:1191
+#: lib/abuuba_web/live/compose_component.ex:1387
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:439
-#: lib/abuuba_web/live/compose_component.ex:445
+#: lib/abuuba_web/live/compose_component.ex:440
+#: lib/abuuba_web/live/compose_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:433
+#: lib/abuuba_web/live/compose_component.ex:434
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:749
+#: lib/abuuba_web/live/compose_component.ex:750
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:729
+#: lib/abuuba_web/live/compose_component.ex:730
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1089
+#: lib/abuuba_web/live/compose_component.ex:1090
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1187
+#: lib/abuuba_web/live/compose_component.ex:1188
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1626
+#: lib/abuuba_web/live/compose_component.ex:1627
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:796
+#: lib/abuuba_web/live/compose_component.ex:797
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:828
+#: lib/abuuba_web/live/compose_component.ex:829
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:1135
+#: lib/abuuba_web/live/compose_component.ex:1136
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:859
+#: lib/abuuba_web/live/compose_component.ex:860
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:820
+#: lib/abuuba_web/live/compose_component.ex:821
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:659
+#: lib/abuuba_web/live/compose_component.ex:660
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:810
-#: lib/abuuba_web/live/compose_component.ex:849
+#: lib/abuuba_web/live/compose_component.ex:811
+#: lib/abuuba_web/live/compose_component.ex:850
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1106
-#: lib/abuuba_web/live/compose_component.ex:1377
+#: lib/abuuba_web/live/compose_component.ex:1107
+#: lib/abuuba_web/live/compose_component.ex:1378
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:781
+#: lib/abuuba_web/live/compose_component.ex:782
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1431
+#: lib/abuuba_web/live/compose_component.ex:1432
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:305
+#: lib/abuuba_web/live/compose_component.ex:306
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That draft could not be saved."
 msgstr ""
@@ -1097,109 +1097,109 @@ msgstr ""
 msgid "That post is scheduled."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1140
+#: lib/abuuba_web/live/compose_component.ex:1141
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:301
+#: lib/abuuba_web/live/compose_component.ex:302
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1425
+#: lib/abuuba_web/live/compose_component.ex:1426
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:666
+#: lib/abuuba_web/live/compose_component.ex:667
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1103
+#: lib/abuuba_web/live/compose_component.ex:1104
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:474
+#: lib/abuuba_web/live/compose_component.ex:475
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:569
+#: lib/abuuba_web/live/compose_component.ex:570
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:519
+#: lib/abuuba_web/live/compose_component.ex:520
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:536
-#: lib/abuuba_web/live/compose_component.ex:544
+#: lib/abuuba_web/live/compose_component.ex:537
+#: lib/abuuba_web/live/compose_component.ex:545
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:558
+#: lib/abuuba_web/live/compose_component.ex:559
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:573
+#: lib/abuuba_web/live/compose_component.ex:574
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:531
+#: lib/abuuba_web/live/compose_component.ex:532
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:499
+#: lib/abuuba_web/live/compose_component.ex:500
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:584
+#: lib/abuuba_web/live/compose_component.ex:585
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:240
-#: lib/abuuba_web/live/compose_component.ex:1421
+#: lib/abuuba_web/live/compose_component.ex:241
+#: lib/abuuba_web/live/compose_component.ex:1422
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1418
+#: lib/abuuba_web/live/compose_component.ex:1419
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:227
+#: lib/abuuba_web/live/compose_component.ex:228
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1419
+#: lib/abuuba_web/live/compose_component.ex:1420
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1420
+#: lib/abuuba_web/live/compose_component.ex:1421
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:478
+#: lib/abuuba_web/live/compose_component.ex:479
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:277
+#: lib/abuuba_web/live/status_live.ex:316
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "Block"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:112
+#: lib/abuuba_web/live/explore_live.ex:113
 #: lib/abuuba_web/live/profile_live.ex:144
 #: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format, fuzzy
@@ -1226,12 +1226,12 @@ msgstr ""
 msgid "Go to the new account"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:99
+#: lib/abuuba_web/live/status_live.ex:121
 #, elixir-autogen, elixir-format
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:803
+#: lib/abuuba_web/live/profile_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
@@ -1252,8 +1252,8 @@ msgstr ""
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:248
-#: lib/abuuba_web/live/profile_live.ex:801
+#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/profile_live.ex:789
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:208
@@ -1261,7 +1261,7 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:802
+#: lib/abuuba_web/live/profile_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
@@ -1272,7 +1272,7 @@ msgstr ""
 msgid "Save the note"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:318
+#: lib/abuuba_web/live/status_live.ex:357
 #, elixir-autogen, elixir-format
 msgid "That server could not be reached, so this is all there is."
 msgstr ""
@@ -1283,7 +1283,7 @@ msgid "This account has moved to %{handle}."
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:196
-#: lib/abuuba_web/live/settings_live.ex:827
+#: lib/abuuba_web/live/settings_live.ex:828
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
@@ -1310,103 +1310,103 @@ msgstr ""
 msgid "What to show"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:101
+#: lib/abuuba_web/live/notifications_live.ex:112
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:151
+#: lib/abuuba_web/live/notifications_live.ex:162
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:398
+#: lib/abuuba_web/live/notifications_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:402
+#: lib/abuuba_web/live/notifications_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:409
+#: lib/abuuba_web/live/notifications_live.ex:420
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:412
+#: lib/abuuba_web/live/notifications_live.ex:423
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:136
+#: lib/abuuba_web/live/notifications_live.ex:147
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:416
+#: lib/abuuba_web/live/notifications_live.ex:427
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:365
+#: lib/abuuba_web/live/notifications_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:363
+#: lib/abuuba_web/live/notifications_live.ex:374
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} boosted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:368
+#: lib/abuuba_web/live/notifications_live.ex:379
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:366
+#: lib/abuuba_web/live/notifications_live.ex:377
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:364
+#: lib/abuuba_web/live/notifications_live.ex:375
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:362
+#: lib/abuuba_web/live/notifications_live.ex:373
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:369
+#: lib/abuuba_web/live/notifications_live.ex:380
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} posted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:370
+#: lib/abuuba_web/live/notifications_live.ex:381
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:367
+#: lib/abuuba_web/live/notifications_live.ex:378
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr ""
@@ -1431,7 +1431,7 @@ msgstr ""
 msgid "Accounts made very recently"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:448
+#: lib/abuuba_web/live/notifications_live.ex:459
 #, elixir-autogen, elixir-format, fuzzy
 msgid "All"
 msgstr ""
@@ -1461,17 +1461,17 @@ msgstr ""
 msgid "Automated accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:457
+#: lib/abuuba_web/live/notifications_live.ex:468
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Boosts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:129
+#: lib/abuuba_web/live/notifications_live.ex:140
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:196
+#: lib/abuuba_web/live/notifications_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -1481,12 +1481,12 @@ msgstr ""
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:462
+#: lib/abuuba_web/live/notifications_live.ex:473
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edits"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:460
+#: lib/abuuba_web/live/notifications_live.ex:471
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Favourites"
 msgstr ""
@@ -1496,15 +1496,15 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:459
+#: lib/abuuba_web/live/notifications_live.ex:470
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:458
-#: lib/abuuba_web/live/profile_live.ex:805
-#: lib/abuuba_web/live/settings_live.ex:2104
-#: lib/abuuba_web/live/settings_live.ex:2242
+#: lib/abuuba_web/live/notifications_live.ex:469
+#: lib/abuuba_web/live/profile_live.ex:793
+#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2249
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows"
 msgstr ""
@@ -1519,28 +1519,28 @@ msgstr ""
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:165
+#: lib/abuuba_web/live/notifications_live.ex:176
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:125
+#: lib/abuuba_web/live/notifications_live.ex:136
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:448
-#: lib/abuuba_web/live/notifications_live.ex:456
+#: lib/abuuba_web/live/notifications_live.ex:459
+#: lib/abuuba_web/live/notifications_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:174
+#: lib/abuuba_web/live/notifications_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:210
+#: lib/abuuba_web/live/notifications_live.ex:221
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing has happened yet."
 msgstr ""
@@ -1555,7 +1555,7 @@ msgstr ""
 msgid "People you do not follow"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:461
+#: lib/abuuba_web/live/notifications_live.ex:472
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Polls"
 msgstr ""
@@ -1572,27 +1572,27 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
 #: lib/abuuba_web/live/profile_live.ex:262
-#: lib/abuuba_web/live/settings_live.ex:295
-#: lib/abuuba_web/live/settings_live.ex:389
-#: lib/abuuba_web/live/settings_live.ex:426
-#: lib/abuuba_web/live/settings_live.ex:490
-#: lib/abuuba_web/live/settings_live.ex:597
-#: lib/abuuba_web/live/settings_live.ex:642
-#: lib/abuuba_web/live/settings_live.ex:675
-#: lib/abuuba_web/live/settings_live.ex:997
+#: lib/abuuba_web/live/settings_live.ex:296
+#: lib/abuuba_web/live/settings_live.ex:390
+#: lib/abuuba_web/live/settings_live.ex:427
+#: lib/abuuba_web/live/settings_live.ex:491
+#: lib/abuuba_web/live/settings_live.ex:598
+#: lib/abuuba_web/live/settings_live.ex:643
+#: lib/abuuba_web/live/settings_live.ex:676
+#: lib/abuuba_web/live/settings_live.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:245
 #: lib/abuuba_web/live/notification_settings_live.ex:54
-#: lib/abuuba_web/live/settings_live.ex:137
+#: lib/abuuba_web/live/settings_live.ex:138
 #, elixir-autogen, elixir-format
 msgid "Saved."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:360
-#: lib/abuuba_web/live/notifications_live.ex:425
+#: lib/abuuba_web/live/notifications_live.ex:371
+#: lib/abuuba_web/live/notifications_live.ex:436
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Somebody"
 msgstr ""
@@ -1602,7 +1602,7 @@ msgstr ""
 msgid "Somebody a moderator here has already restricted."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:395
+#: lib/abuuba_web/live/notifications_live.ex:406
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr ""
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "That could not be saved. Try again."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:90
+#: lib/abuuba_web/live/notifications_live.ex:101
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr ""
@@ -1622,13 +1622,13 @@ msgstr ""
 msgid "Who can reach you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:143
+#: lib/abuuba_web/live/notifications_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:186
-#: lib/abuuba_web/live/conversations_live.ex:87
+#: lib/abuuba_web/components/layouts.ex:190
+#: lib/abuuba_web/live/conversations_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "unread"
 msgstr ""
@@ -1639,13 +1639,13 @@ msgid "A name, a #tag, or some words"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2277
-#: lib/abuuba_web/live/admin_live.ex:3587
+#: lib/abuuba_web/live/admin_live.ex:3583
 #: lib/abuuba_web/live/search_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/explore_live.ex:250
 #: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:207
@@ -1678,7 +1678,7 @@ msgstr ""
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:122
+#: lib/abuuba_web/live/explore_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:250
+#: lib/abuuba_web/live/explore_live.ex:251
 #: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:206
@@ -1716,8 +1716,8 @@ msgstr ""
 msgid "Registration needs approval: you sign up and an admin reads your request."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:244
-#: lib/abuuba_web/components/layouts.ex:253
+#: lib/abuuba_web/components/layouts.ex:248
+#: lib/abuuba_web/components/layouts.ex:257
 #: lib/abuuba_web/live/search_live.ex:38
 #: lib/abuuba_web/live/search_live.ex:61
 #: lib/abuuba_web/live/search_live.ex:70
@@ -1730,7 +1730,7 @@ msgstr ""
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:64
+#: lib/abuuba_web/live/explore_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "What to explore"
 msgstr ""
@@ -1755,220 +1755,221 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:892
+#: lib/abuuba_web/live/settings_live.ex:893
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:235
+#: lib/abuuba_web/live/settings_live.ex:236
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3379
-#: lib/abuuba_web/live/settings_live.ex:2107
+#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/settings_live.ex:2114
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:291
+#: lib/abuuba_web/live/settings_live.ex:292
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a field"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:808
+#: lib/abuuba_web/live/settings_live.ex:809
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2278
+#: lib/abuuba_web/live/settings_live.ex:2285
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2113
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2138
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:948
+#: lib/abuuba_web/live/settings_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2273
+#: lib/abuuba_web/live/settings_live.ex:2280
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:896
+#: lib/abuuba_web/live/settings_live.ex:897
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
 
+#: lib/abuuba_web/components/status_component.ex:455
 #: lib/abuuba_web/live/admin_live.ex:998
-#: lib/abuuba_web/live/settings_live.ex:755
+#: lib/abuuba_web/live/settings_live.ex:756
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:224
+#: lib/abuuba_web/live/settings_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1601
+#: lib/abuuba_web/live/settings_live.ex:1608
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2274
+#: lib/abuuba_web/live/settings_live.ex:2281
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2136
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:202
+#: lib/abuuba_web/live/settings_live.ex:203
 #, elixir-autogen, elixir-format
 msgid "Everything about your account is here. Pick a section."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:240
+#: lib/abuuba_web/live/settings_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2103
-#: lib/abuuba_web/live/settings_live.ex:2248
+#: lib/abuuba_web/live/settings_live.ex:2110
+#: lib/abuuba_web/live/settings_live.ex:2255
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2331
+#: lib/abuuba_web/live/settings_live.ex:2338
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2279
+#: lib/abuuba_web/live/settings_live.ex:2286
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:255
+#: lib/abuuba_web/live/settings_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2277
+#: lib/abuuba_web/live/settings_live.ex:2284
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2275
+#: lib/abuuba_web/live/settings_live.ex:2282
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2282
+#: lib/abuuba_web/live/settings_live.ex:2289
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:273
+#: lib/abuuba_web/live/settings_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:977
+#: lib/abuuba_web/live/settings_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:991
+#: lib/abuuba_web/live/settings_live.ex:998
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:450
+#: lib/abuuba_web/live/settings_live.ex:451
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2132
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2109
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2322
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2313
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2286
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1978,166 +1979,166 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1786
 #: lib/abuuba_web/live/admin_live.ex:1878
 #: lib/abuuba_web/live/admin_live.ex:2202
-#: lib/abuuba_web/live/conversations_live.ex:112
-#: lib/abuuba_web/live/settings_live.ex:281
-#: lib/abuuba_web/live/settings_live.ex:316
+#: lib/abuuba_web/live/conversations_live.ex:113
+#: lib/abuuba_web/live/settings_live.ex:282
+#: lib/abuuba_web/live/settings_live.ex:317
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2112
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:909
+#: lib/abuuba_web/live/settings_live.ex:915
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:905
+#: lib/abuuba_web/live/settings_live.ex:906
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2304
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:971
+#: lib/abuuba_web/live/settings_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3750
-#: lib/abuuba_web/live/settings_live.ex:2094
+#: lib/abuuba_web/live/admin_live.ex:3746
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1576
+#: lib/abuuba_web/live/settings_live.ex:1583
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:469
+#: lib/abuuba_web/live/settings_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2287
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2288
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:850
+#: lib/abuuba_web/live/settings_live.ex:851
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:875
+#: lib/abuuba_web/live/settings_live.ex:876
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:242
+#: lib/abuuba_web/live/settings_live.ex:243
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/settings_live.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:262
+#: lib/abuuba_web/live/settings_live.ex:263
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2290
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:800
+#: lib/abuuba_web/live/settings_live.ex:801
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2133
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2178
-#: lib/abuuba_web/live/settings_live.ex:762
+#: lib/abuuba_web/live/settings_live.ex:763
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:767
+#: lib/abuuba_web/live/settings_live.ex:768
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:456
+#: lib/abuuba_web/live/settings_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:437
+#: lib/abuuba_web/live/settings_live.ex:438
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2135
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:871
+#: lib/abuuba_web/live/settings_live.ex:872
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2276
+#: lib/abuuba_web/live/settings_live.ex:2283
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:887
+#: lib/abuuba_web/live/settings_live.ex:888
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:988
+#: lib/abuuba_web/live/settings_live.ex:995
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2130
+#: lib/abuuba_web/live/settings_live.ex:2137
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2293,110 +2294,110 @@ msgstr ""
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1859
+#: lib/abuuba_web/live/settings_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2135
+#: lib/abuuba_web/live/settings_live.ex:2142
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1197
+#: lib/abuuba_web/live/settings_live.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2108
+#: lib/abuuba_web/live/settings_live.ex:2115
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1227
+#: lib/abuuba_web/live/settings_live.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1843
+#: lib/abuuba_web/live/settings_live.ex:1850
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1194
+#: lib/abuuba_web/live/settings_live.ex:1201
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1862
+#: lib/abuuba_web/live/settings_live.ex:1869
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1201
-#: lib/abuuba_web/live/settings_live.ex:1839
+#: lib/abuuba_web/live/settings_live.ex:1208
+#: lib/abuuba_web/live/settings_live.ex:1846
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1172
+#: lib/abuuba_web/live/settings_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1854
+#: lib/abuuba_web/live/settings_live.ex:1861
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1853
+#: lib/abuuba_web/live/settings_live.ex:1860
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1855
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1863
+#: lib/abuuba_web/live/settings_live.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1864
+#: lib/abuuba_web/live/settings_live.ex:1871
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1861
+#: lib/abuuba_web/live/settings_live.ex:1868
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1180
+#: lib/abuuba_web/live/settings_live.ex:1187
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1218
+#: lib/abuuba_web/live/settings_live.ex:1225
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1207
+#: lib/abuuba_web/live/settings_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1209
+#: lib/abuuba_web/live/settings_live.ex:1216
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
@@ -2411,7 +2412,7 @@ msgstr ""
 msgid "A rule needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3378
+#: lib/abuuba_web/live/admin_live.ex:3377
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accounts"
 msgstr ""
@@ -2429,12 +2430,12 @@ msgid "Address people can write to"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:228
-#: lib/abuuba_web/live/admin_live.ex:3396
+#: lib/abuuba_web/live/admin_live.ex:3395
 #, elixir-autogen, elixir-format
 msgid "Administration"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3733
+#: lib/abuuba_web/live/admin_live.ex:3729
 #, elixir-autogen, elixir-format
 msgid "An open server left unattended fills with spam registrations within days. Put sign-ups behind approval unless somebody is watching."
 msgstr ""
@@ -2444,17 +2445,17 @@ msgstr ""
 msgid "Any state"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3718
+#: lib/abuuba_web/live/admin_live.ex:3714
 #, elixir-autogen, elixir-format
 msgid "Anybody may sign up without being checked"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3427
+#: lib/abuuba_web/live/admin_live.ex:3426
 #, elixir-autogen, elixir-format
 msgid "Anybody, after somebody here says yes"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3426
+#: lib/abuuba_web/live/admin_live.ex:3425
 #, elixir-autogen, elixir-format
 msgid "Anybody, straight away"
 msgstr ""
@@ -2470,7 +2471,7 @@ msgstr ""
 msgid "Appeals waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3395
+#: lib/abuuba_web/live/admin_live.ex:3394
 #, elixir-autogen, elixir-format
 msgid "Audit log"
 msgstr ""
@@ -2480,7 +2481,7 @@ msgstr ""
 msgid "Change an address only when somebody cannot reach their own."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3377
+#: lib/abuuba_web/live/admin_live.ex:3376
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -2490,7 +2491,7 @@ msgstr ""
 msgid "Deleting posts needs the posts named, which this page cannot do yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3437
+#: lib/abuuba_web/live/admin_live.ex:3436
 #, elixir-autogen, elixir-format
 msgid "Disable: they cannot sign in"
 msgstr ""
@@ -2510,7 +2511,7 @@ msgstr ""
 msgid "Email address"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3723
+#: lib/abuuba_web/live/admin_live.ex:3719
 #, elixir-autogen, elixir-format
 msgid "Everything else on this page is guesswork until that is fixed."
 msgstr ""
@@ -2540,12 +2541,12 @@ msgstr ""
 msgid "Lift it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3419
+#: lib/abuuba_web/live/admin_live.ex:3418
 #, elixir-autogen, elixir-format
 msgid "Limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3438
+#: lib/abuuba_web/live/admin_live.ex:3437
 #, elixir-autogen, elixir-format
 msgid "Mark everything they post sensitive"
 msgstr ""
@@ -2555,12 +2556,12 @@ msgstr ""
 msgid "Name or name@server"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3739
+#: lib/abuuba_web/live/admin_live.ex:3735
 #, elixir-autogen, elixir-format
 msgid "Nobody can grant roles or change settings that need it. Give somebody a role holding the administrator permission."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3719
+#: lib/abuuba_web/live/admin_live.ex:3715
 #, elixir-autogen, elixir-format
 msgid "Nobody here is an administrator"
 msgstr ""
@@ -2618,7 +2619,7 @@ msgstr ""
 msgid "Rules people agree to"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3434
+#: lib/abuuba_web/live/admin_live.ex:3433
 #, elixir-autogen, elixir-format
 msgid "Send a warning and nothing else"
 msgstr ""
@@ -2629,12 +2630,12 @@ msgstr ""
 msgid "Server name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3394
+#: lib/abuuba_web/live/admin_live.ex:3393
 #, elixir-autogen, elixir-format
 msgid "Server settings"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3727
+#: lib/abuuba_web/live/admin_live.ex:3723
 #, elixir-autogen, elixir-format
 msgid "Servers running authorized fetch will refuse this one. It is created on first use, so this usually means something went wrong writing it."
 msgstr ""
@@ -2649,17 +2650,17 @@ msgstr ""
 msgid "Shown when somebody signs up and when they file a report."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3435
+#: lib/abuuba_web/live/admin_live.ex:3434
 #, elixir-autogen, elixir-format
 msgid "Silence: out of everywhere nobody asked for them"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3436
+#: lib/abuuba_web/live/admin_live.ex:3435
 #, elixir-autogen, elixir-format
 msgid "Suspend: hidden, and deleted after the grace window"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3420
+#: lib/abuuba_web/live/admin_live.ex:3419
 #, elixir-autogen, elixir-format
 msgid "Suspended"
 msgstr ""
@@ -2669,7 +2670,7 @@ msgstr ""
 msgid "Talk only to servers on the allowlist"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3345
+#: lib/abuuba_web/live/admin_live.ex:3344
 #, elixir-autogen, elixir-format
 msgid "That account outranks yours, so there is nothing here you can do to it."
 msgstr ""
@@ -2691,13 +2692,13 @@ msgid "That is not an address."
 msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
-#: lib/abuuba_web/live/admin_live.ex:3340
-#: lib/abuuba_web/live/settings_live.ex:1629
+#: lib/abuuba_web/live/admin_live.ex:3339
+#: lib/abuuba_web/live/settings_live.ex:1636
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3716
+#: lib/abuuba_web/live/admin_live.ex:3712
 #, elixir-autogen, elixir-format
 msgid "The database is not answering"
 msgstr ""
@@ -2712,7 +2713,7 @@ msgstr ""
 msgid "This deletes the account as well. Go ahead?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3717
+#: lib/abuuba_web/live/admin_live.ex:3713
 #, elixir-autogen, elixir-format
 msgid "This server has no actor of its own"
 msgstr ""
@@ -2722,7 +2723,7 @@ msgstr ""
 msgid "Turn away"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3418
+#: lib/abuuba_web/live/admin_live.ex:3417
 #, elixir-autogen, elixir-format
 msgid "Waiting to be let in"
 msgstr ""
@@ -2816,7 +2817,7 @@ msgstr ""
 msgid "Take it down"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3384
+#: lib/abuuba_web/live/admin_live.ex:3383
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Trends"
 msgstr ""
@@ -2826,17 +2827,17 @@ msgstr ""
 msgid "What is trending now"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:76
+#: lib/abuuba_web/live/explore_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1243
+#: lib/abuuba_web/live/settings_live.ex:1250
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
@@ -2846,12 +2847,12 @@ msgstr ""
 msgid "An announcement needs some text."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3385
+#: lib/abuuba_web/live/admin_live.ex:3384
 #, elixir-autogen, elixir-format
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2144
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2866,7 +2867,7 @@ msgstr ""
 msgid "Earlier versions"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3796
+#: lib/abuuba_web/live/admin_live.ex:3792
 #, elixir-autogen, elixir-format
 msgid "Everybody has already been told about that one."
 msgstr ""
@@ -2876,7 +2877,7 @@ msgstr ""
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1254
+#: lib/abuuba_web/live/settings_live.ex:1261
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
@@ -2891,12 +2892,12 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1238
+#: lib/abuuba_web/live/settings_live.ex:1245
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
@@ -2906,7 +2907,7 @@ msgstr ""
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1261
+#: lib/abuuba_web/live/settings_live.ex:1268
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
@@ -2936,7 +2937,7 @@ msgstr ""
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1275
+#: lib/abuuba_web/live/settings_live.ex:1282
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take it back"
 msgstr ""
@@ -2951,12 +2952,12 @@ msgstr ""
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1259
+#: lib/abuuba_web/live/settings_live.ex:1266
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1250
+#: lib/abuuba_web/live/settings_live.ex:1257
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What it is for"
 msgstr ""
@@ -2977,7 +2978,7 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1281
+#: lib/abuuba_web/live/settings_live.ex:1288
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
@@ -2987,7 +2988,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2089
+#: lib/abuuba_web/live/settings_live.ex:2096
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3004,7 +3005,7 @@ msgstr ""
 msgid "Anywhere in a name"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3778
+#: lib/abuuba_web/live/admin_live.ex:3774
 #, elixir-autogen, elixir-format
 msgid "Ask for approval"
 msgstr ""
@@ -3031,12 +3032,12 @@ msgstr ""
 msgid "Mail domains"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3780
+#: lib/abuuba_web/live/admin_live.ex:3776
 #, elixir-autogen, elixir-format
 msgid "No access at all"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3779
+#: lib/abuuba_web/live/admin_live.ex:3775
 #, elixir-autogen, elixir-format
 msgid "No sign-ups"
 msgstr ""
@@ -3056,7 +3057,7 @@ msgstr ""
 msgid "Please complete the puzzle so we know you are a person."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3386
+#: lib/abuuba_web/live/admin_live.ex:3385
 #, elixir-autogen, elixir-format
 msgid "Sign-up blocks"
 msgstr ""
@@ -3101,14 +3102,14 @@ msgstr ""
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:338
-#: lib/abuuba_web/live/post_actions.ex:297
-#: lib/abuuba_web/live/status_live.ex:185
+#: lib/abuuba_web/live/home_live.ex:357
+#: lib/abuuba_web/live/post_actions.ex:395
+#: lib/abuuba_web/live/status_live.ex:226
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be translated just now."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:446
+#: lib/abuuba_web/components/status_component.ex:469
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
@@ -3123,245 +3124,245 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr "This account has been disabled. Contact the moderators."
 
-#: lib/abuuba_web/live/settings_live.ex:1988
+#: lib/abuuba_web/live/settings_live.ex:1995
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1979
+#: lib/abuuba_web/live/settings_live.ex:1986
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1895
+#: lib/abuuba_web/live/settings_live.ex:1902
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2052
+#: lib/abuuba_web/live/settings_live.ex:2059
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1876
+#: lib/abuuba_web/live/settings_live.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2082
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2110
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1901
+#: lib/abuuba_web/live/settings_live.ex:1908
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2074
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2140
+#: lib/abuuba_web/live/settings_live.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2076
+#: lib/abuuba_web/live/settings_live.ex:2083
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2048
+#: lib/abuuba_web/live/settings_live.ex:2055
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2063
-#: lib/abuuba_web/live/settings_live.ex:2068
+#: lib/abuuba_web/live/settings_live.ex:2070
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2072
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2066
+#: lib/abuuba_web/live/settings_live.ex:2073
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1885
+#: lib/abuuba_web/live/settings_live.ex:1892
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2080
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1882
+#: lib/abuuba_web/live/settings_live.ex:1889
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1890
+#: lib/abuuba_web/live/settings_live.ex:1897
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2079
+#: lib/abuuba_web/live/settings_live.ex:2086
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2088
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2089
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2085
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2090
 #, elixir-autogen, elixir-format, fuzzy
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1046
+#: lib/abuuba_web/live/settings_live.ex:1053
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1934
+#: lib/abuuba_web/live/settings_live.ex:1941
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1041
+#: lib/abuuba_web/live/settings_live.ex:1048
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1952
+#: lib/abuuba_web/live/settings_live.ex:1959
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1051
+#: lib/abuuba_web/live/settings_live.ex:1058
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1039
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1008
+#: lib/abuuba_web/live/settings_live.ex:1015
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1965
+#: lib/abuuba_web/live/settings_live.ex:1972
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1942
+#: lib/abuuba_web/live/settings_live.ex:1949
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1065
-#: lib/abuuba_web/live/settings_live.ex:1914
-#: lib/abuuba_web/live/settings_live.ex:2245
+#: lib/abuuba_web/live/settings_live.ex:1072
+#: lib/abuuba_web/live/settings_live.ex:1921
+#: lib/abuuba_web/live/settings_live.ex:2252
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1035
+#: lib/abuuba_web/live/settings_live.ex:1042
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1019
+#: lib/abuuba_web/live/settings_live.ex:1026
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2038
+#: lib/abuuba_web/live/settings_live.ex:2045
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1003
+#: lib/abuuba_web/live/settings_live.ex:1010
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1938
+#: lib/abuuba_web/live/settings_live.ex:1945
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2028
+#: lib/abuuba_web/live/settings_live.ex:2035
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2039
+#: lib/abuuba_web/live/settings_live.ex:2046
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1916
+#: lib/abuuba_web/live/settings_live.ex:1923
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1029
+#: lib/abuuba_web/live/settings_live.ex:1036
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1001
+#: lib/abuuba_web/live/settings_live.ex:1008
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1931
+#: lib/abuuba_web/live/settings_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2034
+#: lib/abuuba_web/live/settings_live.ex:2041
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
@@ -3371,27 +3372,27 @@ msgstr ""
 msgid "No such post here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:245
+#: lib/abuuba_web/live/settings_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:783
+#: lib/abuuba_web/live/settings_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:796
+#: lib/abuuba_web/live/settings_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:780
+#: lib/abuuba_web/live/settings_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1515
+#: lib/abuuba_web/live/settings_live.ex:1522
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
@@ -3401,54 +3402,54 @@ msgstr ""
 msgid "Why they want to join:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:308
+#: lib/abuuba_web/live/settings_live.ex:309
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:325
+#: lib/abuuba_web/live/settings_live.ex:326
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:328
+#: lib/abuuba_web/live/settings_live.ex:329
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feature it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:299
+#: lib/abuuba_web/live/settings_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:301
+#: lib/abuuba_web/live/settings_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1498
+#: lib/abuuba_web/live/settings_live.ex:1505
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:332
+#: lib/abuuba_web/live/settings_live.ex:333
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1492
+#: lib/abuuba_web/live/settings_live.ex:1499
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:483
+#: lib/abuuba_web/live/settings_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:485
+#: lib/abuuba_web/live/settings_live.ex:486
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
@@ -3485,7 +3486,7 @@ msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/collection_live.ex:117
+#: lib/abuuba_web/live/collection_live.ex:114
 #, elixir-autogen, elixir-format
 msgid "A collection by %{name}"
 msgstr ""
@@ -3596,7 +3597,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr ""
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:646
+#: lib/abuuba_web/live/settings_live.ex:647
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email updates"
 msgstr ""
@@ -3611,7 +3612,7 @@ msgstr ""
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:664
+#: lib/abuuba_web/live/settings_live.ex:665
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr ""
@@ -3621,7 +3622,7 @@ msgstr ""
 msgid "No, remove my address"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:666
+#: lib/abuuba_web/live/settings_live.ex:667
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3674,7 +3675,7 @@ msgstr ""
 msgid "Let people collect email addresses for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:648
+#: lib/abuuba_web/live/settings_live.ex:649
 #, elixir-autogen, elixir-format, fuzzy
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr ""
@@ -3822,75 +3823,75 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1078
+#: lib/abuuba_web/live/settings_live.ex:1085
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2252
+#: lib/abuuba_web/live/settings_live.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:811
-#: lib/abuuba_web/live/settings_live.ex:2246
+#: lib/abuuba_web/live/settings_live.ex:812
+#: lib/abuuba_web/live/settings_live.ex:2253
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2243
+#: lib/abuuba_web/live/settings_live.ex:2250
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2247
+#: lib/abuuba_web/live/settings_live.ex:2254
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1120
+#: lib/abuuba_web/live/settings_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2254
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1103
+#: lib/abuuba_web/live/settings_live.ex:1110
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2118
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2244
+#: lib/abuuba_web/live/settings_live.ex:2251
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1067
+#: lib/abuuba_web/live/settings_live.ex:1074
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1388
+#: lib/abuuba_web/live/settings_live.ex:1395
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1085
+#: lib/abuuba_web/live/settings_live.ex:1092
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2253
+#: lib/abuuba_web/live/settings_live.ex:2260
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3910,13 +3911,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2251
+#: lib/abuuba_web/live/settings_live.ex:2258
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1109
-#: lib/abuuba_web/live/settings_live.ex:1394
+#: lib/abuuba_web/live/settings_live.ex:1116
+#: lib/abuuba_web/live/settings_live.ex:1401
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3926,7 +3927,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1080
+#: lib/abuuba_web/live/settings_live.ex:1087
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3936,67 +3937,67 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1159
+#: lib/abuuba_web/live/settings_live.ex:1166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1157
+#: lib/abuuba_web/live/settings_live.ex:1164
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1123
+#: lib/abuuba_web/live/settings_live.ex:1130
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1062
+#: lib/abuuba_web/live/settings_live.ex:1069
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2143
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1140
+#: lib/abuuba_web/live/settings_live.ex:1147
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1421
+#: lib/abuuba_web/live/settings_live.ex:1428
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1418
+#: lib/abuuba_web/live/settings_live.ex:1425
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1130
+#: lib/abuuba_web/live/settings_live.ex:1137
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1414
+#: lib/abuuba_web/live/settings_live.ex:1421
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1145
+#: lib/abuuba_web/live/settings_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1125
+#: lib/abuuba_web/live/settings_live.ex:1132
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1135
+#: lib/abuuba_web/live/settings_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
@@ -4042,99 +4043,99 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1450
+#: lib/abuuba_web/live/settings_live.ex:1457
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:915
+#: lib/abuuba_web/live/settings_live.ex:922
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:524
+#: lib/abuuba_web/live/settings_live.ex:525
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:533
+#: lib/abuuba_web/live/settings_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:552
+#: lib/abuuba_web/live/settings_live.ex:553
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:579
+#: lib/abuuba_web/live/settings_live.ex:580
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:568
+#: lib/abuuba_web/live/settings_live.ex:569
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:564
+#: lib/abuuba_web/live/settings_live.ex:565
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:938
+#: lib/abuuba_web/live/settings_live.ex:945
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:521
+#: lib/abuuba_web/live/settings_live.ex:522
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:934
+#: lib/abuuba_web/live/settings_live.ex:941
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:526
+#: lib/abuuba_web/live/settings_live.ex:527
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:590
+#: lib/abuuba_web/live/settings_live.ex:591
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:501
+#: lib/abuuba_web/live/settings_live.ex:502
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:913
+#: lib/abuuba_web/live/settings_live.ex:920
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:923
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:923
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signed in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:515
+#: lib/abuuba_web/live/settings_live.ex:516
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:503
+#: lib/abuuba_web/live/settings_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr ""
@@ -4206,17 +4207,17 @@ msgstr ""
 msgid "No relays yet."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3681
+#: lib/abuuba_web/live/admin_live.ex:3677
 #, elixir-autogen, elixir-format
 msgid "Off"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3683
+#: lib/abuuba_web/live/admin_live.ex:3679
 #, elixir-autogen, elixir-format
 msgid "On"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3387
+#: lib/abuuba_web/live/admin_live.ex:3386
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Relays"
 msgstr ""
@@ -4231,7 +4232,7 @@ msgstr ""
 msgid "That is not an https inbox address, or it is already here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3684
+#: lib/abuuba_web/live/admin_live.ex:3680
 #, elixir-autogen, elixir-format
 msgid "The relay refused"
 msgstr ""
@@ -4253,7 +4254,7 @@ msgstr ""
 msgid "Turn on"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3682
+#: lib/abuuba_web/live/admin_live.ex:3678
 #, elixir-autogen, elixir-format
 msgid "Waiting for the relay to answer"
 msgstr ""
@@ -4293,18 +4294,18 @@ msgstr ""
 msgid "Remove this webhook?"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3109
-#: lib/abuuba_web/live/admin_live.ex:3677
+#: lib/abuuba_web/live/admin_live.ex:3108
+#: lib/abuuba_web/live/admin_live.ex:3673
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That did not work."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3674
+#: lib/abuuba_web/live/admin_live.ex:3670
 #, elixir-autogen, elixir-format
 msgid "That is not an event this server sends."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3671
+#: lib/abuuba_web/live/admin_live.ex:3667
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not an https address, or it is already here."
 msgstr ""
@@ -4324,7 +4325,7 @@ msgstr ""
 msgid "This server posts to a webhook when something happens that a moderator would want to know about."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3393
+#: lib/abuuba_web/live/admin_live.ex:3392
 #, elixir-autogen, elixir-format
 msgid "Webhooks"
 msgstr ""
@@ -4344,37 +4345,37 @@ msgstr ""
 msgid "Above yours"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3590
+#: lib/abuuba_web/live/admin_live.ex:3586
 #, elixir-autogen, elixir-format
 msgid "Act on accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3594
+#: lib/abuuba_web/live/admin_live.ex:3590
 #, elixir-autogen, elixir-format
 msgid "Answer appeals"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3620
+#: lib/abuuba_web/live/admin_live.ex:3616
 #, elixir-autogen, elixir-format
 msgid "Approve registrations, and turn two-factor off for somebody locked out."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3598
+#: lib/abuuba_web/live/admin_live.ex:3594
 #, elixir-autogen, elixir-format
 msgid "Approve what trends"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3628
+#: lib/abuuba_web/live/admin_live.ex:3624
 #, elixir-autogen, elixir-format
 msgid "Block and unblock other servers, and set up relays."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3596
+#: lib/abuuba_web/live/admin_live.ex:3592
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Block sign-ups"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3597
+#: lib/abuuba_web/live/admin_live.ex:3593
 #, elixir-autogen, elixir-format
 msgid "Change the server's settings"
 msgstr ""
@@ -4389,62 +4390,62 @@ msgstr ""
 msgid "Create the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3595
+#: lib/abuuba_web/live/admin_live.ex:3591
 #, elixir-autogen, elixir-format
 msgid "Decide about other servers"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3634
+#: lib/abuuba_web/live/admin_live.ex:3630
 #, elixir-autogen, elixir-format
 msgid "Decide which hashtags, links and posts may appear in what is trending."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3592
+#: lib/abuuba_web/live/admin_live.ex:3588
 #, elixir-autogen, elixir-format
 msgid "Delete an account's data"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3623
+#: lib/abuuba_web/live/admin_live.ex:3619
 #, elixir-autogen, elixir-format
 msgid "Delete somebody's posts and files. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3609
+#: lib/abuuba_web/live/admin_live.ex:3605
 #, elixir-autogen, elixir-format
 msgid "Every permission below, including ones added later. Give it to very few people."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3593
+#: lib/abuuba_web/live/admin_live.ex:3589
 #, elixir-autogen, elixir-format
 msgid "Handle reports"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3591
+#: lib/abuuba_web/live/admin_live.ex:3587
 #, elixir-autogen, elixir-format
 msgid "Let people in and out"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3638
+#: lib/abuuba_web/live/admin_live.ex:3634
 #, elixir-autogen, elixir-format
 msgid "Make and change roles, never above their own and never granting more than they hold."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3603
+#: lib/abuuba_web/live/admin_live.ex:3599
 #, elixir-autogen, elixir-format
 msgid "Manage custom emoji"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3599
+#: lib/abuuba_web/live/admin_live.ex:3595
 #, elixir-autogen, elixir-format
 msgid "Manage everybody's invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3605
+#: lib/abuuba_web/live/admin_live.ex:3601
 #, elixir-autogen, elixir-format
 msgid "Manage roles"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3604
+#: lib/abuuba_web/live/admin_live.ex:3600
 #, elixir-autogen, elixir-format
 msgid "Manage webhooks"
 msgstr ""
@@ -4469,12 +4470,12 @@ msgstr ""
 msgid "Position %{position}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3589
+#: lib/abuuba_web/live/admin_live.ex:3585
 #, elixir-autogen, elixir-format
 msgid "Read the audit log"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3625
+#: lib/abuuba_web/live/admin_live.ex:3621
 #, elixir-autogen, elixir-format
 msgid "Read the queue, resolve and reopen."
 msgstr ""
@@ -4484,7 +4485,7 @@ msgstr ""
 msgid "Remove this role? Anybody holding it keeps their account."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3392
+#: lib/abuuba_web/live/admin_live.ex:3391
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Roles"
 msgstr ""
@@ -4494,23 +4495,23 @@ msgstr ""
 msgid "Save the role"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3588
+#: lib/abuuba_web/live/admin_live.ex:3584
 #, elixir-autogen, elixir-format
 msgid "See the admin area"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3617
+#: lib/abuuba_web/live/admin_live.ex:3613
 #, elixir-autogen, elixir-format
 msgid "Silence, suspend, approve and reject accounts on this server."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3502
-#: lib/abuuba_web/live/admin_live.ex:3528
+#: lib/abuuba_web/live/admin_live.ex:3501
+#: lib/abuuba_web/live/admin_live.ex:3524
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That role could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3614
+#: lib/abuuba_web/live/admin_live.ex:3610
 #, elixir-autogen, elixir-format
 msgid "What every moderator has done, including this person's own actions."
 msgstr ""
@@ -4520,32 +4521,32 @@ msgstr ""
 msgid "What this role may do"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3631
+#: lib/abuuba_web/live/admin_live.ex:3627
 #, elixir-autogen, elixir-format
 msgid "Who may sign up, the server's name and description, and the rest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3611
+#: lib/abuuba_web/live/admin_live.ex:3607
 #, elixir-autogen, elixir-format
 msgid "Without this the admin area is closed."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3602
+#: lib/abuuba_web/live/admin_live.ex:3598
 #, elixir-autogen, elixir-format
 msgid "Write announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3600
+#: lib/abuuba_web/live/admin_live.ex:3596
 #, elixir-autogen, elixir-format
 msgid "Write invites"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3601
+#: lib/abuuba_web/live/admin_live.ex:3597
 #, elixir-autogen, elixir-format
 msgid "Write the server rules"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3581
+#: lib/abuuba_web/live/admin_live.ex:3577
 #, elixir-autogen, elixir-format
 msgid "You cannot make a role at or above your own position, or grant a permission you do not hold."
 msgstr ""
@@ -4555,7 +4556,7 @@ msgstr ""
 msgid "You do not hold this yourself, so you cannot grant it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3651
+#: lib/abuuba_web/live/admin_live.ex:3647
 #, elixir-autogen, elixir-format
 msgid "nothing in particular"
 msgstr ""
@@ -4603,7 +4604,7 @@ msgid_plural "%{count} accounts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3391
+#: lib/abuuba_web/live/admin_live.ex:3390
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Other servers"
 msgstr ""
@@ -4753,7 +4754,7 @@ msgstr ""
 msgid "Checking for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3390
+#: lib/abuuba_web/live/admin_live.ex:3389
 #, elixir-autogen, elixir-format
 msgid "Domain lists"
 msgstr ""
@@ -4763,7 +4764,7 @@ msgstr ""
 msgid "Domains this server has already decided about are left exactly as they are. An import adds and never removes: one paste should not be able to undo every decision made here, silently and unrecoverably."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3388
+#: lib/abuuba_web/live/admin_live.ex:3387
 #, elixir-autogen, elixir-format
 msgid "Email subscriptions"
 msgstr ""
@@ -4864,17 +4865,17 @@ msgstr[1] ""
 msgid "%{label}, highest %{top}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3705
+#: lib/abuuba_web/live/admin_live.ex:3701
 #, elixir-autogen, elixir-format
 msgid "Favourites, boosts and replies"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3710
+#: lib/abuuba_web/live/admin_live.ex:3706
 #, elixir-autogen, elixir-format
 msgid "Languages people write in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3703
+#: lib/abuuba_web/live/admin_live.ex:3699
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New accounts"
 msgstr ""
@@ -4884,27 +4885,27 @@ msgstr ""
 msgid "Of the people who signed up in a given week, how many were still posting in the weeks after. A number that only means something once the server has been running a while."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3702
+#: lib/abuuba_web/live/admin_live.ex:3698
 #, elixir-autogen, elixir-format
 msgid "People who posted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3704
+#: lib/abuuba_web/live/admin_live.ex:3700
 #, elixir-autogen, elixir-format
 msgid "Posts written here"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3706
+#: lib/abuuba_web/live/admin_live.ex:3702
 #, elixir-autogen, elixir-format
 msgid "Reports opened"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3707
+#: lib/abuuba_web/live/admin_live.ex:3703
 #, elixir-autogen, elixir-format
 msgid "Reports resolved"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3712
+#: lib/abuuba_web/live/admin_live.ex:3708
 #, elixir-autogen, elixir-format
 msgid "Servers we hear most from"
 msgstr ""
@@ -4919,12 +4920,12 @@ msgstr ""
 msgid "The same numbers a moderation client draws from the API, so what you see here and what it shows are the same figures rather than two answers to one question."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3713
+#: lib/abuuba_web/live/admin_live.ex:3709
 #, elixir-autogen, elixir-format
 msgid "What those servers run"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3711
+#: lib/abuuba_web/live/admin_live.ex:3707
 #, elixir-autogen, elixir-format
 msgid "Where accounts signed up from"
 msgstr ""
@@ -4946,55 +4947,55 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2221
+#: lib/abuuba_web/live/settings_live.ex:2228
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2222
+#: lib/abuuba_web/live/settings_live.ex:2229
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:347
+#: lib/abuuba_web/live/settings_live.ex:348
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:565
-#: lib/abuuba_web/live/settings_live.ex:365
+#: lib/abuuba_web/live/settings_live.ex:366
 #, elixir-autogen, elixir-format, fuzzy
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2062
+#: lib/abuuba_web/live/settings_live.ex:2069
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One picture at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:345
+#: lib/abuuba_web/live/settings_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:397
+#: lib/abuuba_web/live/settings_live.ex:398
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2060
-#: lib/abuuba_web/live/settings_live.ex:2215
+#: lib/abuuba_web/live/settings_live.ex:2067
+#: lib/abuuba_web/live/settings_live.ex:2222
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2210
 #: lib/abuuba_web/live/settings_live.ex:2217
+#: lib/abuuba_web/live/settings_live.ex:2224
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2057
+#: lib/abuuba_web/live/settings_live.ex:2064
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
@@ -5025,7 +5026,7 @@ msgstr ""
 msgid "Get updates from %{name} by email"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:681
+#: lib/abuuba_web/live/settings_live.ex:682
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
@@ -5035,7 +5036,7 @@ msgstr ""
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:706
+#: lib/abuuba_web/live/settings_live.ex:707
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send it"
 msgstr ""
@@ -5045,15 +5046,15 @@ msgstr ""
 msgid "Send me updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:715
+#: lib/abuuba_web/live/settings_live.ex:716
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:692
-#: lib/abuuba_web/live/settings_live.ex:1789
+#: lib/abuuba_web/live/settings_live.ex:693
+#: lib/abuuba_web/live/settings_live.ex:1796
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
@@ -5063,7 +5064,7 @@ msgstr ""
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1369
+#: lib/abuuba_web/live/settings_live.ex:1376
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5078,12 +5079,12 @@ msgstr ""
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:699
+#: lib/abuuba_web/live/settings_live.ex:700
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:679
+#: lib/abuuba_web/live/settings_live.ex:680
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr ""
@@ -5093,7 +5094,7 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1374
+#: lib/abuuba_web/live/settings_live.ex:1381
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
@@ -5103,12 +5104,12 @@ msgstr ""
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1790
+#: lib/abuuba_web/live/settings_live.ex:1797
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:722
+#: lib/abuuba_web/live/settings_live.ex:723
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr ""
@@ -5159,7 +5160,7 @@ msgstr ""
 msgid "Keep it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3310
+#: lib/abuuba_web/live/admin_live.ex:3309
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Limit them"
 msgstr ""
@@ -5196,7 +5197,7 @@ msgstr ""
 msgid "Ready-made texts a moderator picks instead of retyping. Kept for the server rather than for one moderator, so two people writing about the same thing say the same thing."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3382
+#: lib/abuuba_web/live/admin_live.ex:3381
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report"
 msgstr ""
@@ -5206,7 +5207,7 @@ msgstr ""
 msgid "Report %{id}"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3380
+#: lib/abuuba_web/live/admin_live.ex:3379
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reports"
 msgstr ""
@@ -5221,12 +5222,12 @@ msgstr ""
 msgid "Still open"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3312
+#: lib/abuuba_web/live/admin_live.ex:3311
 #, elixir-autogen, elixir-format
 msgid "Stop them signing in"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3311
+#: lib/abuuba_web/live/admin_live.ex:3310
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Suspend them"
 msgstr ""
@@ -5294,7 +5295,7 @@ msgstr ""
 msgid "from"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3328
+#: lib/abuuba_web/live/admin_live.ex:3327
 #, elixir-autogen, elixir-format
 msgid "somebody who is gone"
 msgstr ""
@@ -5304,14 +5305,14 @@ msgstr ""
 msgid "taken"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3287
+#: lib/abuuba_web/live/admin_live.ex:3286
 #, elixir-autogen, elixir-format
 msgid "One account could not be changed."
 msgid_plural "%{count} accounts could not be changed."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/admin_live.ex:3280
+#: lib/abuuba_web/live/admin_live.ex:3279
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One account was left alone because it outranks yours."
 msgid_plural "%{count} accounts were left alone because they outrank yours."
@@ -5323,7 +5324,7 @@ msgstr[1] ""
 msgid "Showing the newest %{count}. Deal with some to see the ones that have waited longest."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3245
+#: lib/abuuba_web/live/admin_live.ex:3244
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not something this list can do."
 msgstr ""
@@ -5394,7 +5395,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:961
+#: lib/abuuba_web/live/settings_live.ex:968
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5454,24 +5455,24 @@ msgstr ""
 msgid "A PNG or a GIF, at most %{size}."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3212
+#: lib/abuuba_web/live/admin_live.ex:3211
 #, elixir-autogen, elixir-format
 msgid "A shortcode is letters, numbers and underscores, and nothing else."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3148
-#: lib/abuuba_web/live/admin_live.ex:3194
+#: lib/abuuba_web/live/admin_live.ex:3147
+#: lib/abuuba_web/live/admin_live.ex:3193
 #, elixir-autogen, elixir-format
 msgid "An emoji has to be a PNG or a GIF."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3138
-#: lib/abuuba_web/live/admin_live.ex:3172
+#: lib/abuuba_web/live/admin_live.ex:3137
+#: lib/abuuba_web/live/admin_live.ex:3171
 #, elixir-autogen, elixir-format
 msgid "Choose a picture for it."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/admin_live.ex:3380
 #, elixir-autogen, elixir-format
 msgid "Custom emoji"
 msgstr ""
@@ -5506,23 +5507,23 @@ msgstr ""
 msgid "Stop offering it"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3214
+#: lib/abuuba_web/live/admin_live.ex:3213
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That emoji could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3200
+#: lib/abuuba_web/live/admin_live.ex:3199
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That picture could not be stored."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3154
+#: lib/abuuba_web/live/admin_live.ex:3153
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That picture could not be used."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3151
-#: lib/abuuba_web/live/admin_live.ex:3197
+#: lib/abuuba_web/live/admin_live.ex:3150
+#: lib/abuuba_web/live/admin_live.ex:3196
 #, elixir-autogen, elixir-format
 msgid "That picture is too large for an emoji."
 msgstr ""
@@ -5532,7 +5533,7 @@ msgstr ""
 msgid "The picture"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3135
+#: lib/abuuba_web/live/admin_live.ex:3134
 #, elixir-autogen, elixir-format
 msgid "The picture is still uploading. Try again in a moment."
 msgstr ""
@@ -5562,27 +5563,27 @@ msgstr ""
 msgid "What you see from them"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:464
+#: lib/abuuba_web/components/status_component.ex:487
 #, elixir-autogen, elixir-format, fuzzy
 msgid "More"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:476
+#: lib/abuuba_web/components/status_component.ex:499
 #, elixir-autogen, elixir-format
 msgid "Mute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:483
+#: lib/abuuba_web/components/status_component.ex:506
 #, elixir-autogen, elixir-format
 msgid "Stops its notifications and takes it out of your timeline. Nobody is told."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:475
+#: lib/abuuba_web/components/status_component.ex:498
 #, elixir-autogen, elixir-format
 msgid "Unmute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:468
+#: lib/abuuba_web/live/notifications_live.ex:479
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr ""
@@ -5592,37 +5593,37 @@ msgstr ""
 msgid "Tell me when they post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:387
+#: lib/abuuba_web/live/notifications_live.ex:398
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:391
+#: lib/abuuba_web/live/notifications_live.ex:402
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:389
+#: lib/abuuba_web/live/notifications_live.ex:400
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} signed up"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:380
+#: lib/abuuba_web/live/notifications_live.ex:391
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:376
+#: lib/abuuba_web/live/notifications_live.ex:387
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:384
+#: lib/abuuba_web/live/notifications_live.ex:395
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:463
+#: lib/abuuba_web/live/notifications_live.ex:474
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quotes"
 msgstr ""
@@ -5647,24 +5648,24 @@ msgstr ""
 msgid "turned off"
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:98
+#: lib/abuuba_web/live/conversations_live.ex:99
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mark unread"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:239
-#: lib/abuuba_web/live/conversations_live.ex:45
-#: lib/abuuba_web/live/conversations_live.ex:61
+#: lib/abuuba_web/components/layouts.ex:243
+#: lib/abuuba_web/live/conversations_live.ex:46
+#: lib/abuuba_web/live/conversations_live.ex:62
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Messages"
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:64
+#: lib/abuuba_web/live/conversations_live.ex:65
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. A post addressed to only the people you name arrives as a message, and its replies stay with it."
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:83
+#: lib/abuuba_web/live/conversations_live.ex:84
 #, elixir-autogen, elixir-format
 msgid "Open the conversation with %{people}"
 msgstr ""
@@ -5674,7 +5675,7 @@ msgstr ""
 msgid "The last message has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/conversations_live.ex:106
+#: lib/abuuba_web/live/conversations_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "This takes it out of your inbox only. Nobody else loses anything, and a later message brings it back. Go ahead?"
 msgstr ""
@@ -5746,22 +5747,22 @@ msgstr ""
 msgid "Who may read the blocklist"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:636
+#: lib/abuuba_web/live/settings_live.ex:637
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:628
+#: lib/abuuba_web/live/settings_live.ex:629
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:840
+#: lib/abuuba_web/live/settings_live.ex:841
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Block a server"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:813
+#: lib/abuuba_web/live/settings_live.ex:814
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr ""
@@ -5771,28 +5772,28 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:147
+#: lib/abuuba_web/live/explore_live.ex:148
 #: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3370
+#: lib/abuuba_web/live/admin_live.ex:3369
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3373
+#: lib/abuuba_web/live/admin_live.ex:3372
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account limited"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3374
+#: lib/abuuba_web/live/admin_live.ex:3373
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Account suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3383
+#: lib/abuuba_web/live/admin_live.ex:3382
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Appeals"
 msgstr ""
@@ -5802,12 +5803,12 @@ msgstr ""
 msgid "Nothing is waiting. Appeals against a strike show up here."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3372
+#: lib/abuuba_web/live/admin_live.ex:3371
 #, elixir-autogen, elixir-format
 msgid "Posts deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3371
+#: lib/abuuba_web/live/admin_live.ex:3370
 #, elixir-autogen, elixir-format
 msgid "Posts marked sensitive"
 msgstr ""
@@ -5817,7 +5818,7 @@ msgstr ""
 msgid "Somebody who was warned, silenced or suspended saying it was a mistake. Upholding an appeal undoes the action where it can be undone; where it cannot, the appeal is still recorded as upheld. Either way the account's owner is told."
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3085
+#: lib/abuuba_web/live/admin_live.ex:3084
 #, elixir-autogen, elixir-format
 msgid "That appeal is no longer waiting."
 msgstr ""
@@ -5832,13 +5833,13 @@ msgstr ""
 msgid "Uphold and undo"
 msgstr ""
 
-#: lib/abuuba_web/live/admin_live.ex:3369
+#: lib/abuuba_web/live/admin_live.ex:3368
 #, elixir-autogen, elixir-format
 msgid "Warned"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2235
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2242
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr ""
@@ -5848,7 +5849,7 @@ msgstr ""
 msgid "Cancel follow request"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:116
+#: lib/abuuba_web/live/explore_live.ex:117
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
@@ -5856,4 +5857,20 @@ msgstr ""
 #: lib/abuuba_web/live/profile_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "This account approves its followers. Your request is waiting for an answer."
+msgstr ""
+
+#: lib/abuuba_web/components/status_component.ex:451
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Delete this post? Other servers are told to forget it too."
+msgstr ""
+
+#: lib/abuuba_web/components/layouts.ex:145
+#: lib/abuuba_web/live/settings_live.ex:911
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Sign out"
+msgstr ""
+
+#: lib/abuuba_web/live/post_actions.ex:428
+#, elixir-autogen, elixir-format, fuzzy
+msgid "That post is gone."
 msgstr ""

--- a/test/abuuba_web/conversations_live_test.exs
+++ b/test/abuuba_web/conversations_live_test.exs
@@ -40,6 +40,44 @@ defmodule AbuubaWeb.ConversationsLiveTest do
     status
   end
 
+  # Opening a conversation is opening it to answer it, and it landed on the
+  # last message with an empty box set to public. Typing the obvious reply
+  # there sent a private exchange to everybody.
+  describe "opening a conversation" do
+    test "arrives ready to answer it", %{conn: conn, reader: reader, sender: sender} do
+      message(sender, reader, "just between us")
+
+      {:ok, live, _html} = live(conn, ~p"/conversations")
+      live |> element("button[phx-click='open']") |> render_click()
+
+      {path, _flash} = assert_redirect(live)
+
+      assert path =~ "compose=reply"
+    end
+
+    test "and the box it opens is set to the message's own audience", %{
+      conn: conn,
+      reader: reader,
+      sender: sender
+    } do
+      # The half that matters. An empty public box on a private message is how
+      # somebody answers one to everybody.
+      message(sender, reader, "still just between us")
+
+      {:ok, live, _html} = live(conn, ~p"/conversations")
+      live |> element("button[phx-click='open']") |> render_click()
+
+      {path, _flash} = assert_redirect(live)
+      {:ok, arrived, _html} = live(conn, path)
+
+      assert render(arrived) =~ "Replying to"
+
+      assert arrived
+             |> element(~s(button[phx-click="set_visibility"][phx-value-visibility="direct"]))
+             |> render() =~ ~s(aria-pressed="true")
+    end
+  end
+
   describe "the inbox" do
     test "says so when there is nothing in it", %{conn: conn} do
       html = conn |> get(~p"/conversations") |> html_response(200)
@@ -76,7 +114,7 @@ defmodule AbuubaWeb.ConversationsLiveTest do
       assert {:error, {:live_redirect, %{to: to}}} =
                live |> element("button[phx-click='open']") |> render_click()
 
-      assert to == "/@bob/#{status.id}"
+      assert to == "/@bob/#{status.id}?compose=reply"
       refute Conversations.get(reader, row.id).unread
     end
 

--- a/test/abuuba_web/moderation_takes_effect_test.exs
+++ b/test/abuuba_web/moderation_takes_effect_test.exs
@@ -20,9 +20,12 @@ defmodule AbuubaWeb.ModerationTakesEffectTest do
   use AbuubaWeb.ConnCase, async: false
 
   import Abuuba.AccountsFixtures
+  import Abuuba.StatusesFixtures
+  import Phoenix.LiveViewTest
 
   alias Abuuba.Accounts.Auth
   alias Abuuba.Moderation.Actions
+  alias Abuuba.Statuses
 
   @password "correct horse battery"
 
@@ -117,5 +120,135 @@ defmodule AbuubaWeb.ModerationTakesEffectTest do
 
       assert redirected_to(get(session, ~p"/settings")) == ~p"/login"
     end
+  end
+
+  # Every assertion above is about a fresh request, which runs the plug
+  # pipeline and is refused there. A LiveView asks once, at mount, and then
+  # holds the answer for as long as the socket lives.
+  describe "a page that was already open when the decision was made" do
+    test "is sent away rather than left composing", %{
+      conn: conn,
+      user: user,
+      account: account,
+      moderator: moderator
+    } do
+      {:ok, live, _html} = live(with_session(conn, user), ~p"/home")
+
+      {:ok, _} = Actions.take(moderator, account, "suspend")
+
+      assert_redirect(live, ~p"/login")
+      refute Process.alive?(live.pid)
+    end
+
+    test "and the compose box it was holding is gone with it", %{
+      conn: conn,
+      user: user,
+      account: account,
+      moderator: moderator
+    } do
+      # The sharp end of the one above: this posted, before the socket was told
+      # anything, for as long as nobody reloaded the page.
+      {:ok, live, _html} = live(with_session(conn, user), ~p"/home")
+
+      {:ok, _} = Actions.take(moderator, account, "suspend")
+      assert_redirect(live, ~p"/login")
+
+      catch_exit(
+        live
+        |> form("#compose-form", draft: %{"text" => "still here"})
+        |> render_submit()
+      )
+
+      assert Abuuba.Repo.all(Abuuba.Statuses.Status)
+             |> Enum.filter(&(&1.account_id == account.id)) == []
+    end
+
+    test "and a public page it was on keeps being a public page", %{
+      conn: conn,
+      user: user,
+      account: account,
+      moderator: moderator
+    } do
+      # Closing an open page is not the same as refusing it. Explore answers
+      # anybody, so it is drawn again as a stranger would get it: telling the
+      # reader they have to be signed in to see a page a stranger can see would
+      # be the interface arguing with itself.
+      session = with_session(conn, user)
+      {:ok, live, _html} = live(session, ~p"/explore")
+
+      {:ok, _} = Actions.take(moderator, account, "suspend")
+
+      assert_redirect(live, ~p"/explore")
+
+      # The same browser, holding the same now-dead cookie.
+      {:ok, _again, html} = live(session, ~p"/explore")
+
+      assert html =~ "Log in"
+      refute html =~ "Notifications"
+    end
+
+    test "and cannot go on acting from it", %{
+      conn: conn,
+      user: user,
+      account: account,
+      moderator: moderator
+    } do
+      # The sharp end of the one above. Clearing the reader out of the scope
+      # fixes the navigation and leaves whatever the screen took out of it at
+      # mount -- and it is that, not the scope, which the action bar acts
+      # through, so anything short of a fresh mount leaves the buttons live.
+      author = account_fixture(%{username: "poster"})
+      status = status_fixture(%{account_id: author.id, text: "out here"})
+
+      session = with_session(conn, user)
+      {:ok, live, _html} = live(session, ~p"/explore")
+
+      {:ok, _} = Actions.take(moderator, account, "suspend")
+      assert_redirect(live, ~p"/explore")
+
+      {:ok, _again, html} = live(session, ~p"/explore")
+
+      assert html =~ "out here"
+      refute html =~ ~s(phx-click="favourite")
+      refute Statuses.favourited?(account.id, status.id)
+    end
+
+    test "signing out everywhere takes the page it was pressed on with it", %{
+      conn: conn,
+      user: user
+    } do
+      # The button says "including this one", and the page it was pressed on
+      # went on working until somebody reloaded it.
+      {:ok, live, _html} = live(with_session(conn, user), ~p"/settings/security")
+
+      live |> element("button[phx-click='sign_out_everywhere']") |> render_click()
+
+      assert_redirect(live, ~p"/login")
+    end
+  end
+
+  # `Actions.take/4` does its work in one transaction, and the comment inside it
+  # says why a broadcast may not go from there: it is the one thing that does
+  # not come back on a rollback, and a subscriber on the same node is delivered
+  # to synchronously -- so a page redrawing on the message could read the rows
+  # from before the commit and come back signed in. The announcement is made
+  # after it. Only that it still happens is testable here: the sandbox puts
+  # every process on one connection, so before-commit and after-commit look the
+  # same from a test.
+  describe "the announcement that closes those pages" do
+    test "still goes out, now that it waits for the commit", %{
+      account: account,
+      moderator: moderator
+    } do
+      Phoenix.PubSub.subscribe(Abuuba.PubSub, Auth.sessions_topic(user_id(account)))
+
+      {:ok, _strike} = Actions.take(moderator, account, "suspend")
+
+      assert_receive {:sessions, :revoked}, 500
+    end
+  end
+
+  defp user_id(account) do
+    Abuuba.Repo.get_by!(Abuuba.Accounts.User, account_id: account.id).id
   end
 end

--- a/test/abuuba_web/password_reset_test.exs
+++ b/test/abuuba_web/password_reset_test.exs
@@ -221,6 +221,28 @@ defmodule AbuubaWeb.PasswordResetTest do
       assert %User{} = Auth.get_user_by_email_and_password(user.email, @password)
     end
 
+    # The rows go inside the transaction here rather than through
+    # `delete_all_session_tokens/1`, so this path is the one that would
+    # silently not announce -- and it is the one whose whole purpose is
+    # somebody else being in the account. A page left open is a session that
+    # is still working.
+    test "closes the pages those sessions had open", %{conn: conn, user: user} do
+      intruder =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Plug.Conn.put_session(:user_token, Auth.create_session_token(user))
+
+      {:ok, live, _html} = live(intruder, ~p"/home")
+
+      Phoenix.ConnTest.build_conn()
+      |> post(~p"/reset-password/#{token_for(user)}", %{
+        "user" => %{"password" => @new_password}
+      })
+      |> redirected_to()
+
+      assert_redirect(live, ~p"/login")
+    end
+
     test "burns the link", %{conn: conn, user: user} do
       token = token_for(user)
 

--- a/test/abuuba_web/post_actions_test.exs
+++ b/test/abuuba_web/post_actions_test.exs
@@ -18,6 +18,7 @@ defmodule AbuubaWeb.PostActionsTest do
   alias Abuuba.Accounts.Auth
   alias Abuuba.Notifications
   alias Abuuba.Statuses
+  alias AbuubaWeb.PostActions
 
   setup do
     viewer = account_fixture()
@@ -146,6 +147,271 @@ defmodule AbuubaWeb.PostActionsTest do
     end
   end
 
+  # `Abuuba.Statuses.delete_status/1` has always been there, and the only ways
+  # to reach it were the Mastodon API and the admin screens: nothing in this
+  # server's own interface let somebody take back a post they had written.
+  describe "deleting a post of your own" do
+    test "works on every screen that draws the button", %{
+      conn: conn,
+      user: user,
+      viewer: viewer
+    } do
+      # The author is the viewer here, which is the whole point: the button is
+      # only drawn on your own posts.
+      for {name, make, path} <- screens(viewer) do
+        status = make.()
+
+        {:ok, live, _html} = live(sign_in(conn, user), path.(status))
+
+        live
+        |> element("button[phx-click='delete'][phx-value-id='#{status.id}']")
+        |> render_click()
+
+        assert Statuses.get_status(status.id, viewer) == nil,
+               "deleting did nothing on #{name}"
+      end
+    end
+
+    test "takes the post off the screen it was deleted from", %{
+      conn: conn,
+      user: user,
+      viewer: viewer
+    } do
+      status = status_fixture(%{account_id: viewer.id, text: "a post to take back"})
+
+      {:ok, live, _html} = live(sign_in(conn, user), ~p"/@#{viewer.username}")
+
+      html =
+        live
+        |> element("button[phx-click='delete'][phx-value-id='#{status.id}']")
+        |> render_click()
+
+      refute html =~ "a post to take back"
+    end
+
+    test "sends you away from the page that was only that post", %{
+      conn: conn,
+      user: user,
+      viewer: viewer
+    } do
+      status = status_fixture(%{account_id: viewer.id, text: "the only thing here"})
+
+      {:ok, live, _html} = live(sign_in(conn, user), ~p"/@#{viewer.username}/#{status.id}")
+
+      live
+      |> element("button[phx-click='delete'][phx-value-id='#{status.id}']")
+      |> render_click()
+
+      assert_redirect(live, ~p"/@#{viewer.username}")
+    end
+  end
+
+  test "takes the boost of it off the screen as well", %{
+    conn: conn,
+    user: user,
+    viewer: viewer,
+    author: author
+  } do
+    # The row is the boost's, drawn under the booster; the delete answers with
+    # the post's own id. Matching only the row's id left the words of a
+    # deleted post on screen under a flash saying it was gone.
+    mine = status_fixture(%{account_id: viewer.id, text: "boosted and then taken back"})
+    {:ok, _boost} = Statuses.boost(author, mine)
+
+    {:ok, live, html} = live(sign_in(conn, user), ~p"/@#{author.username}")
+    assert html =~ "boosted and then taken back"
+
+    html =
+      live
+      |> element("button[phx-click='delete'][phx-value-id='#{mine.id}']")
+      |> render_click()
+
+    refute html =~ "boosted and then taken back"
+  end
+
+  test "and off the home timeline, which keys that row by the post's own id", %{
+    conn: conn,
+    user: user,
+    viewer: viewer,
+    author: author
+  } do
+    {:ok, _follow} = Abuuba.Relationships.follow(viewer, author)
+    mine = status_fixture(%{account_id: viewer.id, text: "boosted onto the timeline"})
+    {:ok, _boost} = Statuses.boost(author, mine)
+
+    {:ok, live, html} = live(sign_in(conn, user), ~p"/home")
+    assert html =~ "boosted onto the timeline"
+
+    html =
+      live
+      |> element("button[phx-click='delete'][phx-value-id='#{mine.id}']")
+      |> render_click()
+
+    refute html =~ "boosted onto the timeline"
+  end
+
+  test "and the notifications screen, which keeps posts inside groups", %{
+    conn: conn,
+    user: user,
+    viewer: viewer,
+    author: author
+  } do
+    # The one screen `screens/1` cannot cover: its posts are not in a list, so
+    # it hands `PostActions` its own way of taking one off, and a wrong clause
+    # there would be silent.
+    mine = status_fixture(%{account_id: viewer.id, text: "favourited then withdrawn"})
+    {:ok, _} = Notifications.notify(viewer, author, "favourite", status_id: mine.id)
+
+    {:ok, live, html} = live(sign_in(conn, user), ~p"/notifications")
+    assert html =~ "favourited then withdrawn"
+
+    html =
+      live
+      |> element("button[phx-click='delete'][phx-value-id='#{mine.id}']")
+      |> render_click()
+
+    refute html =~ "favourited then withdrawn"
+    assert Statuses.get_status(mine.id, viewer) == nil
+  end
+
+  test "an id no row could carry is refused rather than fatal", %{conn: conn, user: user} do
+    # Every button on the bar comes through the same lookup, and a number too
+    # big for the column reached Ecto as a cast error that emptied the page.
+    {:ok, live, _html} = live(sign_in(conn, user), ~p"/explore")
+
+    render_hook(live, "delete", %{"id" => "99999999999999999999999999"})
+
+    assert Process.alive?(live.pid)
+  end
+
+  describe "somebody else's post" do
+    test "is not offered a delete button", %{conn: conn, user: user, author: author} do
+      status = status_fixture(%{account_id: author.id, text: "not yours to delete"})
+
+      {:ok, _live, html} = live(sign_in(conn, user), ~p"/@#{author.username}")
+
+      refute html =~ ~s(phx-click="delete")
+      assert Statuses.get_status(status.id, author)
+    end
+
+    test "and is not deleted by asking for it anyway", %{
+      conn: conn,
+      user: user,
+      viewer: viewer,
+      author: author
+    } do
+      # The button being absent is a drawing decision; this is the one that
+      # matters, because the event can be sent without it.
+      status = status_fixture(%{account_id: author.id, text: "still not yours"})
+
+      {:ok, live, _html} = live(sign_in(conn, user), ~p"/@#{author.username}")
+      render_hook(live, "delete", %{"id" => to_string(status.id)})
+
+      assert Statuses.get_status(status.id, viewer)
+    end
+  end
+
+  # A screen with no composer answers reply and edit by sending you to the
+  # post's own page, which has one -- and sent you there with the box closed,
+  # so the button you pressed did nothing once you arrived and you had to
+  # press the same button again. Edit was the worse half: an empty box on the
+  # post you meant to change reads as the post having been lost.
+  describe "reply and edit from a screen with no composer" do
+    test "arrive with the box open on the post you pressed", %{
+      conn: conn,
+      user: user,
+      viewer: viewer,
+      author: author
+    } do
+      status = status_fixture(%{account_id: author.id, text: "worth answering"})
+
+      {:ok, live, _html} = live(sign_in(conn, user), ~p"/@#{author.username}")
+
+      live |> element("button[phx-click='reply'][phx-value-id='#{status.id}']") |> render_click()
+
+      {path, _flash} = assert_redirect(live)
+      {:ok, arrived, _html} = live(sign_in(conn, user), path)
+
+      # Rendered again rather than read off the mount: the composer is a
+      # component and is told what to open through `send_update/2`, which lands
+      # in the message after the one that mounted it.
+      assert render(arrived) =~ "Replying to"
+      refute viewer.id == author.id
+    end
+
+    test "and editing your own arrives with what you wrote in it", %{
+      conn: conn,
+      user: user,
+      viewer: viewer
+    } do
+      status = status_fixture(%{account_id: viewer.id, text: "the words to change"})
+
+      {:ok, live, _html} = live(sign_in(conn, user), ~p"/@#{viewer.username}")
+
+      live |> element("button[phx-click='edit'][phx-value-id='#{status.id}']") |> render_click()
+
+      {path, _flash} = assert_redirect(live)
+      {:ok, arrived, _html} = live(sign_in(conn, user), path)
+      html = render(arrived)
+
+      assert html =~ "the words to change"
+      assert html =~ "Editing a post"
+      assert html =~ "Save changes"
+    end
+  end
+
+  # `PostActions.composers/0` says what a screen with no composer may ask a
+  # post's page to open, and its docstring claims the two ends cannot drift.
+  # This is what makes that true: without it the emitter and the matcher are
+  # two lists of string literals in two files.
+  describe "the compose intents" do
+    test "are all answered by the page they are sent to", %{
+      conn: conn,
+      user: user,
+      viewer: viewer
+    } do
+      status = status_fixture(%{account_id: viewer.id, text: "something to act on"})
+      opened = %{"reply" => "Replying to", "edit" => "Editing a post"}
+
+      for intent <- PostActions.composers() do
+        path = PostActions.page_of(viewer, status.id, compose: intent)
+
+        assert path =~ "compose=#{intent}"
+
+        {:ok, live, _html} = live(sign_in(conn, user), path)
+
+        assert render(live) =~ Map.fetch!(opened, intent),
+               "the page does not answer compose=#{intent}"
+      end
+    end
+
+    test "and anything else is dropped rather than carried", %{viewer: viewer} do
+      status = status_fixture(%{account_id: viewer.id, text: "not for this"})
+
+      for junk <- ["", "boost", "<script>x</script>", "reply "] do
+        refute PostActions.page_of(viewer, status.id, compose: junk) =~ "compose"
+      end
+    end
+
+    test "and edit is refused on a post that is not yours", %{
+      conn: conn,
+      user: user,
+      author: author
+    } do
+      # The address carries the same request the button does, so it is refused
+      # in the same place.
+      status = status_fixture(%{account_id: author.id, text: "not yours to change"})
+
+      {:ok, live, _html} =
+        live(sign_in(conn, user), "/@#{author.username}/#{status.id}?compose=edit")
+
+      html = render(live)
+
+      refute html =~ "Editing a post"
+      refute html =~ "Save changes"
+    end
+  end
+
   describe "boosting and bookmarking" do
     test "work on a profile too", %{conn: conn, user: user, viewer: viewer, author: author} do
       status = status_fixture(%{account_id: author.id, text: "on a profile"})
@@ -189,7 +455,7 @@ defmodule AbuubaWeb.PostActionsTest do
 
       live |> element("button[phx-click='reply'][phx-value-id='#{status.id}']") |> render_click()
 
-      assert_redirect(live, "/@#{author.username}/#{status.id}")
+      assert_redirect(live, "/@#{author.username}/#{status.id}?compose=reply")
     end
   end
 end

--- a/test/abuuba_web/settings_live_test.exs
+++ b/test/abuuba_web/settings_live_test.exs
@@ -768,6 +768,16 @@ defmodule AbuubaWeb.SettingsLiveTest do
 
       refute Auth.get_user_by_session_token(token)
     end
+
+    # The section's own description promises "your password, two-factor, and
+    # signing out", and the only way out it offered ended the session on every
+    # other device as well.
+    test "offers signing out of this device alone, beside signing out of all", %{conn: conn} do
+      {:ok, _live, html} = live(conn, ~p"/settings/security")
+
+      assert html =~ ~s(href="/logout")
+      assert html =~ "Sign out everywhere"
+    end
   end
 
   describe "applications" do

--- a/test/abuuba_web/shell_test.exs
+++ b/test/abuuba_web/shell_test.exs
@@ -80,6 +80,36 @@ defmodule AbuubaWeb.ShellTest do
       assert {:ok, _live, html} = live(conn, ~p"/notifications")
       assert html =~ "Notifications"
     end
+
+    # `DELETE /logout` has always answered; nothing in the interface asked it.
+    # The only way out anybody could find was "Sign out everywhere" on the
+    # security page, which ends the sessions on every other device too -- so
+    # signing off a shared computer cost somebody their phone.
+    test "signed in, it offers a way to sign out", %{conn: conn} do
+      html = conn |> log_in() |> get(~p"/shortcuts") |> html_response(200)
+
+      assert html =~ ~s(href="/logout")
+      assert html =~ "Sign out"
+    end
+
+    test "signed out, there is nothing to sign out of", %{conn: conn} do
+      html = conn |> get(~p"/shortcuts") |> html_response(200)
+
+      refute page(html) =~ "/logout"
+    end
+
+    test "the way out it offers is the one the router answers", %{conn: conn} do
+      # A link that reads "Sign out" and leaves the session alone is worse than
+      # no link, so this follows it rather than trusting the href.
+      conn = log_in(conn)
+
+      assert get_session(conn, :user_token)
+
+      signed_out = conn |> recycle() |> delete(~p"/logout")
+
+      assert redirected_to(signed_out) == ~p"/"
+      refute get_session(signed_out, :user_token)
+    end
   end
 
   describe "keyboard shortcuts" do

--- a/test/abuuba_web/status_component_events_test.exs
+++ b/test/abuuba_web/status_component_events_test.exs
@@ -84,7 +84,7 @@ defmodule AbuubaWeb.StatusComponentEventsTest do
     # A canary on the list itself. A new button added to the component makes
     # this fail before the per-screen check below can be trusted, because a
     # screen cannot answer an event nobody knew about.
-    assert events_raised() == ~w(bookmark boost edit favourite reply translate vote)
+    assert events_raised() == ~w(bookmark boost delete edit favourite reply translate vote)
   end
 
   test "every screen that draws a post is one this checked" do

--- a/test/abuuba_web/timeline_access_test.exs
+++ b/test/abuuba_web/timeline_access_test.exs
@@ -34,9 +34,18 @@ defmodule AbuubaWeb.TimelineAccessTest do
     %{author: author}
   end
 
+  # Approved as well as confirmed: `Auth.check_sign_in/1` refuses an account
+  # still waiting for a moderator, so a fixture without it is not "somebody
+  # signed in" -- it is somebody the sign-in would turn away.
   defp signed_in(conn) do
     account = account_fixture()
-    user = user_fixture(%{account_id: account.id, confirmed_at: DateTime.utc_now()})
+
+    user =
+      user_fixture(%{
+        account_id: account.id,
+        confirmed_at: DateTime.utc_now(),
+        approved: true
+      })
 
     conn
     |> Phoenix.ConnTest.init_test_session(%{})


### PR DESCRIPTION
A pass through the running server in a real browser: two accounts registered, confirmed, approved, and then used the way people use one. Five things came out of it.

**Nothing in the interface signed you out.** `DELETE /logout` answered; no page linked to it. The only way out was **Sign out everywhere**, which ends the session on your phone too. Now in the sidebar and on the security page, whose own description already promised it.

**You could not delete your own post.** `Statuses.delete_status/1` was reachable from the API and the admin screens only. There is now a bin on your own posts, answered on all six screens through `PostActions`, and it takes the row off wherever the post is drawn inside somebody's boost of it.

**Reply and edit dropped what you pressed them for.** On a screen with no composer they navigated to the post and left the box closed, so you pressed the same button twice. Worse where it mattered: opening a private conversation landed on an empty box set to *public*, so the obvious answer to a private message went to everybody. The intent now travels in the address.

**A moderator's decision stopped at pages already open.** A LiveView reads the session once at mount. A suspended account went on posting through the compose box until it reloaded, and a password reset — the one path whose purpose is somebody else being in your account — left them there. Revoking sessions now announces it; signed-in pages go to the sign-in screen and public ones are drawn again as a stranger gets them.

**`on_mount` never asked whether a session may be used**, only whether one existed, while the plug beside it did. That is how `timeline_access: authenticated` was showing its timelines to an account still waiting for approval — a test in the suite was passing on it.

Patch version to 1.0.2. 4,414 tests, `mix precommit` clean, German complete, user and admin docs updated.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01AcqNbR7MQMHFiaJBjD9ExS
