### PR TITLE
Give the pages what the API already answered

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ instead, and went with abuuba.
 
 ## Not for the faint of heart
 
-abuuba is version 1.0.2 and has never served real members on the open internet.
+abuuba is version 1.0.3 and has never served real members on the open internet.
 Every number above is measured and reproducible. None of it has been tested by
 anyone but me.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ instead, and went with abuuba.
 
 ## Not for the faint of heart
 
-abuuba is version 1.0.3 and has never served real members on the open internet.
+abuuba is version 1.1.0 and has never served real members on the open internet.
 Every number above is measured and reproducible. None of it has been tested by
 anyone but me.
 

--- a/docs/de/user/einstellungen.md
+++ b/docs/de/user/einstellungen.md
@@ -165,12 +165,12 @@ die Mastodon-API sprechen, können es.
 
 ## Folge ich
 
-Wenn dein Konto Follower erst bestätigt, steht oben auf dieser Seite, wer
-wartet: **Folgen lassen** oder **Ablehnen**, einzeln. Wer abgelehnt wird,
-erfährt nichts davon und kann erneut anfragen.
+Alle, denen du folgst, mit je einem Kästchen. Mehrere ankreuzen und in einem
+Zug entfolgen, statt einzeln nacheinander.
 
-Darunter alle, denen du folgst, mit je einem Kästchen. Mehrere ankreuzen und
-in einem Zug entfolgen, statt einzeln nacheinander.
+Wer auf *dich* wartet, steht nicht hier, sondern auf einer eigenen Seite, die
+die Navigation mit einer Zahl anzeigt, solange jemand wartet. Siehe
+[Folgeanfragen](sicherheit.md#folgeanfragen).
 
 ## Sicherheit
 

--- a/docs/de/user/einstellungen.md
+++ b/docs/de/user/einstellungen.md
@@ -165,8 +165,12 @@ die Mastodon-API sprechen, können es.
 
 ## Folge ich
 
-Alle, denen du folgst, mit je einem Kästchen. Mehrere ankreuzen und in einem
-Zug entfolgen, statt einzeln nacheinander.
+Wenn dein Konto Follower erst bestätigt, steht oben auf dieser Seite, wer
+wartet: **Folgen lassen** oder **Ablehnen**, einzeln. Wer abgelehnt wird,
+erfährt nichts davon und kann erneut anfragen.
+
+Darunter alle, denen du folgst, mit je einem Kästchen. Mehrere ankreuzen und
+in einem Zug entfolgen, statt einzeln nacheinander.
 
 ## Sicherheit
 

--- a/docs/de/user/sicherheit.md
+++ b/docs/de/user/sicherheit.md
@@ -93,21 +93,40 @@ derselben Seite, wo du sie weiterhin lesen und durchwinken kannst.
 
 Ausführlicher steht das unter [Benachrichtigungen](benachrichtigungen.md).
 
+## Folgeanfragen
+
+Wenn du unter Privatsphäre **Follower erst bestätigen** eingeschaltet hast,
+folgt dir niemand ohne dein Ja. Wer wartet, steht auf einer eigenen Seite, und
+die Navigation zeigt einen Eintrag **Folgeanfragen** mit einer Zahl, solange
+jemand wartet — wenn niemand wartet, ist er nicht da, und das ist bei den
+meisten Konten immer.
+
+**Folgen lassen** oder **Ablehnen**, einzeln. Wer abgelehnt wird, erfährt
+nichts davon und es bleibt keine Spur zurück, die Person kann also erneut
+anfragen; jemanden dauerhaft fernzuhalten geht nur über Blockieren.
+
 ## Jemanden melden
 
 Meldungen gehen an die Moderation dieses Servers und, wenn du willst,
 zusätzlich an die Moderation des Servers, von dem die Person kommt.
 
-**Einen Melde-Knopf gibt es in der Weboberfläche noch nicht.** Melden geht über
-die Programmierschnittstelle, eine Mastodon-kompatible App kann also eine
-Meldung abgeben. Wenn dir keine App zur Verfügung steht, schreib an die Adresse
-auf der [Info-Seite](oeffentliche-seiten.md) des Servers; eine Beschreibung per
-Mail ist langsamer als eine Meldung, aber nicht schlechter.
+**Melden** steht auf einem Profil neben Stummschalten und Blockieren und unter
+dem **…** an jedem Beitrag. Es stellt vier kurze Fragen: um welche Art Problem
+es geht, gegen welche Regeln es verstößt, falls du das ausgewählt hast, welche
+Beiträge die Moderation lesen sollte und was du selbst dazu sagen willst.
+Abgeschickt wird erst mit dem letzten Klick.
 
-Eine Meldung kann mehrere Beiträge benennen, einen Satz dazuschreiben, was daran
-falsch ist, und auf Wunsch eine Kopie an den anderen Server weitergeben. Bei
+Die erste Möglichkeit ist **Ich mag es nicht**, und die schickt gar keine
+Meldung. Sie führt direkt zu Stummschalten und Blockieren, denn genau das ist
+es: etwas, das du nicht sehen willst, und nichts, worüber eine Moderation
+entscheiden kann. Beides wird auch nach einer echten Meldung angeboten — die
+muss jemand lesen, und bis dahin musst du die Person nicht weiter sehen.
+
+Die Frage nach den Regeln erscheint nur, wenn dieser Server welche
+aufgeschrieben hat. Liegt ein Konto auf einem anderen Server, wirst du außerdem
+gefragt, ob eine Kopie der Meldung ohne deinen Namen dorthin gehen soll. Bei
 Spam lohnt das Weitergeben; bei einem persönlichen Streit sollte man es sich
-überlegen, denn es sagt der Gegenseite, wer sich beschwert hat.
+überlegen, denn es sagt der Gegenseite, dass sich hier jemand beschwert hat.
 
 ## Passwort vergessen
 

--- a/docs/de/user/sicherheit.md
+++ b/docs/de/user/sicherheit.md
@@ -26,8 +26,9 @@ Stummschalten entstanden sind, beim nächsten Neuladen. Gelöscht wird nichts,
 deshalb ist beim Aufheben alles sofort wieder da.
 
 Stummschalten wirkt überall dort, wo Beiträge auftauchen, nicht nur in der
-Timeline: auch aus der Suche und aus den Antworten unter einem Thread ist die
-Person verschwunden, und ebenso alles von ihr, was jemand anderes teilt.
+Timeline: auch aus der Suche, aus Entdecken, von jeder Hashtag-Seite und aus
+den Antworten unter einem Thread ist die Person verschwunden, und ebenso alles
+von ihr, was jemand anderes teilt.
 
 ## Blockieren
 

--- a/docs/de/user/timelines.md
+++ b/docs/de/user/timelines.md
@@ -91,6 +91,19 @@ auf den niemand geantwortet hat und der selbst keine Antwort ist, hat keine
 Unterhaltung zum Stummschalten. Du findest es in deiner Startseite und auf der
 Seite des Beitrags.
 
+## Was du dir zur Seite legst
+
+Das Lesezeichen unter einem Beitrag legt ihn unter **Lesezeichen** ab, der
+Stern unter **Favoriten**. Beides steht in der Seitenleiste unter der
+Navigation, und beides ist von der Übersicht der Einstellungen aus verlinkt —
+für das Handy, das keine Seitenleiste hat.
+
+Es sind zwei verschiedene Dinge. Ein Lesezeichen gehört nur dir und niemand
+erfährt davon; ein Favorit ist ein kleiner öffentlicher Applaus, und die
+verfassende Person wird darüber informiert. Nimmst du eines zurück, während du
+die Liste ansiehst, verschwindet der Beitrag daraus — genau das wolltest du ja
+mit dem Klick.
+
 ## Was es sonst zu lesen gibt
 
 Die Startseite ist nicht die einzige Ansicht. [Sachen finden](finden.md) erklärt

--- a/docs/user/safety.md
+++ b/docs/user/safety.md
@@ -24,8 +24,9 @@ drawn, so what they posted before you muted them goes too, on the next reload.
 Nothing is deleted, which is why unmuting brings all of it straight back.
 
 Muting reaches everywhere posts are shown, not only the timeline: they are
-gone from search results and from the replies under a thread as well, and so
-is anything of theirs that somebody else boosts.
+gone from search results, from explore, from every hashtag page and from the
+replies under a thread as well, and so is anything of theirs that somebody
+else boosts.
 
 ## Blocking
 

--- a/docs/user/safety.md
+++ b/docs/user/safety.md
@@ -85,20 +85,39 @@ certain.
 
 Fuller description in [notifications](notifications.md).
 
+## Follow requests
+
+If you turned on **Approve followers first** under privacy, nobody follows you
+without your say-so. Whoever is waiting is on their own page, and the
+navigation shows a **Follow requests** entry with a count for as long as
+somebody is — it is not there when nobody is waiting, which on most accounts
+is always.
+
+**Let them follow** or **Turn them away**, one at a time. Turning somebody away
+tells them nothing and leaves no mark, so they can ask again; there is no way
+to refuse somebody permanently short of blocking them.
+
 ## Reporting somebody
 
 Reports go to the moderators of this server, and — if you choose — to the
 moderators of the sender's server as well.
 
-**The web interface here does not have a report button yet.** Reporting works
-through the API, so a Mastodon-compatible app can file one. If you cannot use
-an app, mail the address on the server's [about page](public-pages.md); a
-moderator reading a description is slower than a report but not worse.
+**Report** is on a profile beside Mute and Block, and under the **…** on any
+post. It asks four short questions: what kind of problem it is, which rules it
+breaks if you picked that, which posts a moderator should read, and anything
+you want to say in your own words. Nothing is sent until the last press.
 
-A report can name several posts, add a sentence about what is wrong, and
-optionally forward a copy to the other server. Forwarding is worth it for
-spam and worth thinking about for a personal dispute, since it tells the other
-side who complained.
+The first option is **I do not like it**, and it files no report at all. It
+goes straight to mute and block, because that is what it is: something you do
+not want to see rather than something a moderator can decide. Mute and block
+are offered after a real report as well — somebody has to read it, and in the
+meantime you do not have to keep seeing the person.
+
+The rules question only appears if this server has written any down. Where an
+account is on another server you are also asked whether to send a copy of the
+report there, without your name. Forwarding is worth it for spam and worth
+thinking about for a personal dispute, since it tells the other side that
+somebody here complained.
 
 ## Forgotten your password
 

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -150,8 +150,12 @@ web interface has no button for that yet; apps that speak the Mastodon API do.
 
 ## Follows
 
-Everybody you follow, with a checkbox each. Tick several and unfollow them in
-one press rather than one at a time.
+If your account approves its followers, whoever is waiting is at the top of
+this page: **Let them follow** or **Turn them away**, one at a time. Somebody
+you turn away is not told, and can ask again.
+
+Below that, everybody you follow, with a checkbox each. Tick several and
+unfollow them in one press rather than one at a time.
 
 ## Security
 

--- a/docs/user/settings.md
+++ b/docs/user/settings.md
@@ -150,12 +150,12 @@ web interface has no button for that yet; apps that speak the Mastodon API do.
 
 ## Follows
 
-If your account approves its followers, whoever is waiting is at the top of
-this page: **Let them follow** or **Turn them away**, one at a time. Somebody
-you turn away is not told, and can ask again.
+Everybody you follow, with a checkbox each. Tick several and unfollow them in
+one press rather than one at a time.
 
-Below that, everybody you follow, with a checkbox each. Tick several and
-unfollow them in one press rather than one at a time.
+People waiting for *you* are not here: they are on their own page, which the
+navigation shows with a count while anybody is waiting. See
+[follow requests](safety.md#follow-requests).
 
 ## Security
 

--- a/docs/user/timelines.md
+++ b/docs/user/timelines.md
@@ -83,6 +83,17 @@ It is on the menu of a post that is part of a thread — a post nobody has
 replied to and that replies to nothing has no conversation to mute. You will
 find it on your home timeline and on the post's own page.
 
+## What you put aside
+
+The bookmark under a post files it under **Bookmarks**, and the star files it
+under **Favourites**. Both are in the sidebar, below the navigation, and both
+are linked from the settings overview for a phone, which has no sidebar.
+
+They are not the same thing. A bookmark is yours alone and tells nobody; a
+favourite is a small public applause and its author is told about it. Taking
+one back while you are looking at the list takes the post off the list, which
+is what you meant by pressing it.
+
 ## What else there is to read
 
 Home is not the only view. [Finding things](finding-things.md) covers explore

--- a/lib/abuuba/relationships.ex
+++ b/lib/abuuba/relationships.ex
@@ -990,6 +990,23 @@ defmodule Abuuba.Relationships do
   end
 
   @doc """
+  How many people are waiting on this account to answer.
+
+  Counted rather than listed because the navigation draws the entry only while
+  the number is above zero, and it asks on every render of every page: a list
+  of a hundred accounts to find out whether there is one is a hundred rows
+  loaded to render a badge.
+  """
+  @spec pending_follower_count(Account.t() | integer()) :: non_neg_integer()
+  def pending_follower_count(%Account{id: id}), do: pending_follower_count(id)
+
+  def pending_follower_count(account_id) do
+    FollowRequest
+    |> where([r], r.target_account_id == ^account_id)
+    |> Repo.aggregate(:count)
+  end
+
+  @doc """
   Accepts every follow request waiting on this account.
 
   For the morning after a move. Every follower's server acts on the `Move` at

--- a/lib/abuuba_web/components/layouts.ex
+++ b/lib/abuuba_web/components/layouts.ex
@@ -140,6 +140,16 @@ defmodule AbuubaWeb.Layouts do
       <.nav_link :for={item <- @items} item={item} />
 
       <div class="mt-auto flex flex-col gap-1 px-3 py-2 text-sm">
+        <%!-- Below the six rather than among them: the list above is also the
+        bar along the bottom of a phone, and these two are the reader's own
+        filing rather than a place they go. A narrow screen reaches them from
+        the settings overview. --%>
+        <.link :if={@signed_in} navigate={~p"/bookmarks"} class="link link-hover">
+          {gettext("Bookmarks")}
+        </.link>
+        <.link :if={@signed_in} navigate={~p"/favourites"} class="link link-hover">
+          {gettext("Favourites")}
+        </.link>
         <a href={~p"/shortcuts"} class="link link-hover">{gettext("Keyboard shortcuts")}</a>
         <.link :if={@signed_in} href={~p"/logout"} method="delete" class="link link-hover">
           {gettext("Sign out")}
@@ -227,9 +237,23 @@ defmodule AbuubaWeb.Layouts do
 
   defp unread_conversations(_user), do: 0
 
+  # Drawn only while somebody is waiting, which is how the reference
+  # implementation does it and is the only way it earns a place in a
+  # navigation this short: on a server where nobody approves their followers
+  # a permanent entry is a permanent reminder of nothing. It is also the one
+  # entry that has to be here rather than in the settings, because a request
+  # is somebody waiting on an answer.
+  defp follow_requests(%{account_id: account_id}) when not is_nil(account_id) do
+    Abuuba.Relationships.pending_follower_count(account_id)
+  end
+
+  defp follow_requests(_user), do: 0
+
   # Signed out, the only useful destinations are the public ones. Showing a
   # "Home" that answers 422 would be an interface arguing with itself.
   defp nav_items(%{user: user}) when not is_nil(user) do
+    waiting = follow_requests(user)
+
     [
       %{path: ~p"/home", label: gettext("Home"), icon: "hero-home"},
       %{
@@ -247,7 +271,7 @@ defmodule AbuubaWeb.Layouts do
       %{path: ~p"/explore", label: gettext("Explore"), icon: "hero-hashtag"},
       %{path: ~p"/search", label: gettext("Search"), icon: "hero-magnifying-glass"},
       %{path: ~p"/settings", label: gettext("Settings"), icon: "hero-cog-6-tooth"}
-    ]
+    ] ++ waiting_item(waiting)
   end
 
   defp nav_items(_scope) do
@@ -256,6 +280,19 @@ defmodule AbuubaWeb.Layouts do
       %{path: ~p"/explore", label: gettext("Explore"), icon: "hero-hashtag"},
       %{path: ~p"/search", label: gettext("Search"), icon: "hero-magnifying-glass"},
       %{path: ~p"/login", label: gettext("Log in"), icon: "hero-arrow-right-on-rectangle"}
+    ]
+  end
+
+  defp waiting_item(0), do: []
+
+  defp waiting_item(count) do
+    [
+      %{
+        path: ~p"/follow-requests",
+        label: gettext("Follow requests"),
+        icon: "hero-user-plus",
+        badge: count
+      }
     ]
   end
 

--- a/lib/abuuba_web/components/status_component.ex
+++ b/lib/abuuba_web/components/status_component.ex
@@ -343,6 +343,14 @@ defmodule AbuubaWeb.StatusComponent do
     """
   end
 
+  # Somebody else's post, and somebody signed in to say so. Reporting your own
+  # is a report a moderator can do nothing with.
+  defp reportable?(status, viewer_id), do: not is_nil(viewer_id) and not own?(status, viewer_id)
+
+  defp report_path(status) do
+    "/report/@#{status["account"]["acct"]}?status=#{status["id"]}"
+  end
+
   # Which controls are the author's own. Once, rather than on each button that
   # asks: two spellings of "is this mine" in one template is two to keep in
   # step. What it decides is what is drawn; whether the event is allowed is
@@ -469,7 +477,16 @@ defmodule AbuubaWeb.StatusComponent do
         <span class="sr-only">{gettext("Translate")}</span>
       </button>
 
-      <.overflow :if={@menu and in_a_thread?(@status)} status={@status} />
+      <%!-- Drawn whenever it would hold something. `@menu` is a screen saying
+      it answers the events in here, which only the two with a composer do;
+      reporting is a link and needs no answering, so it appears on every
+      screen that draws a post. --%>
+      <.overflow
+        :if={(@menu and in_a_thread?(@status)) or reportable?(@status, @viewer_id)}
+        status={@status}
+        menu={@menu}
+        viewer_id={@viewer_id}
+      />
     </div>
     """
   end
@@ -479,6 +496,9 @@ defmodule AbuubaWeb.StatusComponent do
   # `details` rather than a scripted popover: it opens, closes on a second
   # press and reaches by keyboard with nothing of ours running, which is three
   # behaviours not to write or to break.
+  attr :viewer_id, :any, default: nil
+  attr :menu, :boolean, default: false
+
   defp overflow(assigns) do
     ~H"""
     <details class="dropdown dropdown-end ml-auto">
@@ -489,6 +509,7 @@ defmodule AbuubaWeb.StatusComponent do
 
       <div class="dropdown-content z-10 w-56 rounded-box bg-base-200 p-2 shadow">
         <button
+          :if={@menu and in_a_thread?(@status)}
           type="button"
           phx-click={if @status["muted"], do: "unmute_thread", else: "mute_thread"}
           phx-value-id={@status["id"]}
@@ -502,9 +523,20 @@ defmodule AbuubaWeb.StatusComponent do
         <%!-- Said here rather than in a tooltip, because "mute" next to
         somebody's post reads as muting the person, and that is a much bigger
         thing to do by accident. --%>
-        <p class="px-2 pt-1 text-xs text-base-content/60">
+        <p :if={@menu and in_a_thread?(@status)} class="px-2 pt-1 text-xs text-base-content/60">
           {gettext("Stops its notifications and takes it out of your timeline. Nobody is told.")}
         </p>
+
+        <%!-- A link rather than an event: the questions a report asks do not
+        fit in a dropdown, and every screen that draws a post would otherwise
+        have to answer them. --%>
+        <.link
+          :if={reportable?(@status, @viewer_id)}
+          navigate={report_path(@status)}
+          class="btn btn-ghost btn-sm btn-block justify-start"
+        >
+          {gettext("Report this post")}
+        </.link>
       </div>
     </details>
     """

--- a/lib/abuuba_web/live/explore_live.ex
+++ b/lib/abuuba_web/live/explore_live.ex
@@ -34,6 +34,7 @@ defmodule AbuubaWeb.ExploreLive do
   alias Abuuba.Settings
   alias Abuuba.Statuses
   alias Abuuba.Statuses.Formatter
+  alias Abuuba.Timelines
   alias Abuuba.Trends
   alias AbuubaWeb.API.Entities
   alias AbuubaWeb.Meta
@@ -192,9 +193,15 @@ defmodule AbuubaWeb.ExploreLive do
       |> Enum.map(& &1.subject)
       |> Statuses.get_statuses()
 
-    recent = if readable?(viewer), do: Statuses.public_timeline(limit: @page_size), else: []
+    recent =
+      if readable?(viewer), do: Timelines.public(viewer, %{limit: @page_size}), else: []
 
+    # `Timelines.public/2` answers the reader's blocks and mutes; what is
+    # trending arrives from a counter that knows nobody, so the same question
+    # is asked of those rows one at a time. Without it this page showed a
+    # reader the posts of people they had blocked.
     dedupe(trending ++ recent)
+    |> Enum.reject(&Statuses.hidden_for?(&1, viewer))
     |> Entities.statuses(viewer, filter_context: "public")
     |> Enum.reject(&hidden?/1)
   end

--- a/lib/abuuba_web/live/follow_requests_live.ex
+++ b/lib/abuuba_web/live/follow_requests_live.ex
@@ -1,0 +1,116 @@
+defmodule AbuubaWeb.FollowRequestsLive do
+  @moduledoc """
+  The people waiting to follow a locked account, and the two answers.
+
+  ## Why it is a screen of its own
+
+  Locking is one switch on the privacy page, and everything that switch
+  produces has to land somewhere a person can answer it. It arrived as a
+  notification, which is a record that something happened rather than a thing
+  to act on, and the only control anywhere in the interface was an accept-all
+  in the account-migration section worded for a move. So the switch could be
+  turned on and its consequences could not be dealt with.
+
+  Beside the follows rather than inside them, because these are not people the
+  reader follows: they are people asking, and the answer is a decision rather
+  than a list to tick through.
+
+  ## Turning somebody away tells them nothing
+
+  `Abuuba.Relationships.reject_follow_request/1` removes the row and leaves no
+  trace on the asker's side, so they can ask again. That is deliberate, and the
+  page says so: somebody who expects a rejection to be final would otherwise
+  read a second request as the server having lost the first.
+  """
+
+  use AbuubaWeb, :live_view
+
+  alias Abuuba.Accounts
+  alias Abuuba.Accounts.Account
+  alias Abuuba.Relationships
+  alias Abuuba.Snowflake
+
+  @page_size 100
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok, socket |> assign(page_title: gettext("Follow requests")) |> load()}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope} page_title={@page_title}>
+      <h1 class="p-4 text-xl font-semibold">{gettext("Follow requests")}</h1>
+
+      <p :if={@requests != []} class="px-4 pb-2 text-base-content/70">
+        {gettext(
+          "Your account asks before letting somebody follow it. Turning one away tells them nothing, and they can ask again."
+        )}
+      </p>
+
+      <p :if={@requests == []} class="px-4 pb-6 text-base-content/70">
+        {gettext("Nobody is waiting. Anybody who asks to follow you turns up here.")}
+      </p>
+
+      <ul class="divide-y divide-base-300">
+        <li :for={person <- @requests} class="flex flex-wrap items-center gap-3 p-4">
+          <span class="min-w-0 flex-1">
+            <.link navigate={~p"/@#{Account.acct(person)}"} class="font-medium">
+              {Account.display_name(person)}
+            </.link>
+            <span class="block text-sm text-base-content/60">@{Account.acct(person)}</span>
+          </span>
+
+          <span class="flex shrink-0 gap-2">
+            <button
+              type="button"
+              phx-click="accept"
+              phx-value-id={person.id}
+              class="btn btn-sm btn-primary"
+            >
+              {gettext("Let them follow")}
+            </button>
+
+            <button type="button" phx-click="reject" phx-value-id={person.id} class="btn btn-sm">
+              {gettext("Turn them away")}
+            </button>
+          </span>
+        </li>
+      </ul>
+    </Layouts.app>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("accept", %{"id" => id}, socket) do
+    {:noreply, answer(socket, id, &Relationships.accept_follow_request/1)}
+  end
+
+  def handle_event("reject", %{"id" => id}, socket) do
+    {:noreply, answer(socket, id, &Relationships.reject_follow_request/1)}
+  end
+
+  def handle_event(_event, _params, socket), do: {:noreply, socket}
+
+  # Read back through the reader's own pending list rather than trusted from
+  # the button: the id arrives from the page, and the only request this account
+  # may answer is one that is waiting on it.
+  defp answer(socket, id, decide) do
+    account = current_account(socket)
+
+    with {:ok, asker_id} <- Snowflake.cast(id),
+         %Account{} = asker <- Accounts.get_account(asker_id),
+         %{} = request <- Relationships.get_follow_request(asker, account) do
+      decide.(request)
+    end
+
+    load(socket)
+  end
+
+  defp load(socket) do
+    account = current_account(socket)
+
+    assign(socket, requests: Relationships.pending_followers(account, %{limit: @page_size}))
+  end
+end

--- a/lib/abuuba_web/live/profile_live.ex
+++ b/lib/abuuba_web/live/profile_live.ex
@@ -195,6 +195,12 @@ defmodule AbuubaWeb.ProfileLive do
           >
             {if @relationship.blocking, do: gettext("Unblock"), else: gettext("Block")}
           </button>
+
+          <%!-- Beside mute and block because it is the third answer to the same
+          question, and the one that involves somebody else. --%>
+          <.link navigate={~p"/report/@#{Account.acct(@subject)}"} class="btn btn-ghost btn-sm">
+            {gettext("Report")}
+          </.link>
         </div>
 
         <div

--- a/lib/abuuba_web/live/report_live.ex
+++ b/lib/abuuba_web/live/report_live.ex
@@ -1,0 +1,425 @@
+defmodule AbuubaWeb.ReportLive do
+  @moduledoc """
+  Telling a moderator about somebody.
+
+  ## Why the pages needed one at all
+
+  `POST /api/v1/reports` has always answered and `/admin/reports` is a full
+  triage queue with categories, evidence, rule attribution and forwarding. No
+  page here could put anything into it, so the queue could only be filled from
+  an app and a person reading a post on this server had no way to say anything
+  about it.
+
+  ## The steps are the moderator's, not the reporter's
+
+  Somebody who has just read something upsetting will type one sentence and
+  press send. A moderator then has to decide something, and what makes that
+  possible is the shape around the sentence: which kind of problem, which posts,
+  which rules. So the questions are asked one at a time and in that order,
+  which is what the reference implementation settled on, and each one narrows
+  what the next has to ask.
+
+  One page rather than a stack of them: the whole thing is four short questions,
+  and a wizard whose steps are each one radio group is four page loads to send
+  one sentence. Back is the browser's Back, and nothing is written until the
+  last press.
+
+  ## The first option files nothing
+
+  "I do not like it" is not a moderation problem, and a queue that fills with
+  those is a queue where the real ones wait behind them. Choosing it jumps
+  straight to mute and block, which is what the reader actually wanted, and the
+  moderators never hear about it. Those two are offered after a real report as
+  well: the report is a decision somebody else has to make, and in the meantime
+  the reader still has to get through their day.
+  """
+
+  use AbuubaWeb, :live_view
+
+  import AbuubaWeb.StatusComponent
+
+  alias Abuuba.Accounts
+  alias Abuuba.Accounts.Account
+  alias Abuuba.Moderation.Reports
+  alias Abuuba.Relationships
+  alias Abuuba.Settings
+  alias Abuuba.Snowflake
+  alias Abuuba.Statuses
+  alias AbuubaWeb.API.Entities
+  alias AbuubaWeb.Meta
+
+  # `dislike` is not one of them: it is the way out of here, not a report.
+  @evidence_limit 20
+
+  @impl Phoenix.LiveView
+  def mount(%{"username" => username} = params, _session, socket) do
+    viewer = current_account(socket)
+
+    case Accounts.lookup(username) do
+      nil ->
+        raise AbuubaWeb.NotFound, "no such account"
+
+      %Account{id: id} when id == :erlang.map_get(:id, viewer) ->
+        # Nothing a moderator could do with it, and the mute and block it ends
+        # in would be somebody blocking themselves.
+        {:ok, push_navigate(socket, to: ~p"/@#{Account.acct(viewer)}")}
+
+      subject ->
+        {:ok,
+         socket
+         |> assign(
+           page_title: gettext("Report"),
+           robots: Meta.noindex(),
+           viewer: viewer,
+           subject: subject,
+           rules: Settings.rules(),
+           step: :category,
+           category: nil,
+           rule_ids: [],
+           forward: false,
+           filed?: false,
+           relationship: relationship(viewer, subject),
+           posts: evidence(subject, viewer),
+           chosen: chosen(params)
+         )}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope} page_title={@page_title}>
+      <header class="border-b border-base-300 p-4">
+        <h1 class="text-xl font-semibold">
+          {gettext("Report %{name}", name: Account.display_name(@subject))}
+        </h1>
+        <p class="text-sm text-base-content/60">@{Account.acct(@subject)}</p>
+      </header>
+
+      <.category :if={@step == :category} rules={@rules} />
+      <.rules :if={@step == :rules} rules={@rules} rule_ids={@rule_ids} />
+      <.evidence :if={@step == :evidence} posts={@posts} chosen={@chosen} viewer={@viewer} />
+      <.comment :if={@step == :comment} subject={@subject} forward={@forward} />
+      <.done :if={@step == :done} subject={@subject} filed?={@filed?} relationship={@relationship} />
+    </Layouts.app>
+    """
+  end
+
+  attr :rules, :list, required: true
+
+  defp category(assigns) do
+    ~H"""
+    <div class="p-4">
+      <h2 class="font-semibold">{gettext("What is going on?")}</h2>
+
+      <ul class="mt-3 space-y-2">
+        <li :for={{value, label, hint} <- categories(@rules)}>
+          <button
+            type="button"
+            phx-click="category"
+            phx-value-category={value}
+            class="w-full rounded border border-base-300 p-3 text-left hover:bg-base-200"
+          >
+            <span class="block font-medium">{label}</span>
+            <span class="block text-sm text-base-content/60">{hint}</span>
+          </button>
+        </li>
+      </ul>
+    </div>
+    """
+  end
+
+  attr :rules, :list, required: true
+  attr :rule_ids, :list, required: true
+
+  defp rules(assigns) do
+    ~H"""
+    <form id="rules-form" phx-submit="rules" class="p-4">
+      <h2 class="font-semibold">{gettext("Which rules?")}</h2>
+      <p class="mt-1 text-sm text-base-content/60">{gettext("Tick every one that applies.")}</p>
+
+      <ul class="mt-3 space-y-2">
+        <li :for={rule <- @rules} class="flex items-start gap-3">
+          <input
+            type="checkbox"
+            name="report[rule_ids][]"
+            value={rule.id}
+            checked={to_string(rule.id) in @rule_ids}
+            class="checkbox checkbox-sm mt-1"
+            id={"rule-#{rule.id}"}
+          />
+          <label for={"rule-#{rule.id}"} class="flex-1">{rule.text}</label>
+        </li>
+      </ul>
+
+      <button type="submit" class="btn btn-primary mt-4">{gettext("Next")}</button>
+    </form>
+    """
+  end
+
+  attr :posts, :list, required: true
+  attr :chosen, :list, required: true
+  attr :viewer, :map, required: true
+
+  defp evidence(assigns) do
+    ~H"""
+    <form id="evidence-form" phx-submit="evidence" class="p-4">
+      <h2 class="font-semibold">{gettext("Are there posts that show it?")}</h2>
+      <p class="mt-1 text-sm text-base-content/60">
+        {gettext("Tick every one a moderator should read. You can tick none.")}
+      </p>
+
+      <ul class="mt-3 divide-y divide-base-300">
+        <li :for={post <- @posts} class="flex items-start gap-3 py-2">
+          <input
+            type="checkbox"
+            name="report[status_ids][]"
+            value={post["id"]}
+            checked={post["id"] in @chosen}
+            class="checkbox checkbox-sm mt-3"
+            aria-label={gettext("Include this post")}
+          />
+          <div class="min-w-0 flex-1">
+            <.status
+              id={"evidence-#{post["id"]}"}
+              status={post}
+              viewer_id={viewer_id(@viewer)}
+              interactive={false}
+              menu={false}
+            />
+          </div>
+        </li>
+      </ul>
+
+      <p :if={@posts == []} class="py-4 text-base-content/60">
+        {gettext("Nothing of theirs is here to point at.")}
+      </p>
+
+      <button type="submit" phx-click="to_comment" class="btn btn-primary mt-4">
+        {gettext("Next")}
+      </button>
+    </form>
+    """
+  end
+
+  attr :subject, :map, required: true
+  attr :forward, :boolean, required: true
+
+  defp comment(assigns) do
+    ~H"""
+    <form id="report-form" phx-submit="file" class="p-4">
+      <h2 class="font-semibold">{gettext("Anything else a moderator should know?")}</h2>
+
+      <textarea
+        name="report[comment]"
+        rows="4"
+        class="textarea mt-3 w-full"
+        placeholder={gettext("In your own words. This is optional.")}
+      ></textarea>
+
+      <label :if={@subject.domain} class="mt-3 flex items-start gap-3">
+        <input type="hidden" name="report[forward]" value="false" />
+        <input
+          type="checkbox"
+          name="report[forward]"
+          value="true"
+          checked={@forward}
+          class="checkbox checkbox-sm mt-1"
+        />
+        <span class="flex-1 text-sm">
+          {gettext(
+            "This account is on %{domain}. Send a copy of this report there as well, without your name.",
+            domain: @subject.domain
+          )}
+        </span>
+      </label>
+
+      <button type="submit" class="btn btn-primary mt-4">{gettext("Send the report")}</button>
+    </form>
+    """
+  end
+
+  attr :subject, :map, required: true
+  attr :filed?, :boolean, required: true
+  attr :relationship, :map, required: true
+
+  defp done(assigns) do
+    ~H"""
+    <div class="p-4">
+      <h2 class="font-semibold">
+        {if @filed?,
+          do: gettext("Thank you. A moderator will read this."),
+          else: gettext("Then here is what you can do yourself.")}
+      </h2>
+
+      <p class="mt-1 text-sm text-base-content/60">
+        {if @filed?,
+          do: gettext("While you wait, you do not have to keep seeing them."),
+          else: gettext("Neither of these tells a moderator anything.")}
+      </p>
+
+      <div class="mt-4 space-y-4">
+        <div :if={@relationship.following}>
+          <h3 class="font-medium">{gettext("Unfollow")}</h3>
+          <p class="text-sm text-base-content/60">
+            {gettext("Their posts leave your home timeline. They keep following you.")}
+          </p>
+          <button type="button" phx-click="unfollow" class="btn btn-sm mt-2">
+            {gettext("Unfollow")}
+          </button>
+        </div>
+
+        <div>
+          <h3 class="font-medium">{gettext("Mute")}</h3>
+          <p class="text-sm text-base-content/60">
+            {gettext("You stop seeing them everywhere. They can still follow you and are not told.")}
+          </p>
+          <button
+            type="button"
+            phx-click="mute"
+            disabled={@relationship.muting}
+            class="btn btn-sm mt-2"
+          >
+            {if @relationship.muting, do: gettext("Muted"), else: gettext("Mute")}
+          </button>
+        </div>
+
+        <div>
+          <h3 class="font-medium">{gettext("Block")}</h3>
+          <p class="text-sm text-base-content/60">
+            {gettext(
+              "Everything mute does, and they cannot follow you or read your posts. They can tell."
+            )}
+          </p>
+          <button
+            type="button"
+            phx-click="block"
+            disabled={@relationship.blocking}
+            class="btn btn-sm mt-2"
+          >
+            {if @relationship.blocking, do: gettext("Blocked"), else: gettext("Block")}
+          </button>
+        </div>
+      </div>
+
+      <.link navigate={~p"/@#{Account.acct(@subject)}"} class="btn btn-primary mt-6">
+        {gettext("Done")}
+      </.link>
+    </div>
+    """
+  end
+
+  ## Events
+
+  @impl Phoenix.LiveView
+  def handle_event("category", %{"category" => "dislike"}, socket) do
+    # No report, and the moderators never hear about it.
+    {:noreply, assign(socket, category: "dislike", step: :done, filed?: false)}
+  end
+
+  def handle_event("category", %{"category" => "violation"}, socket) do
+    {:noreply, assign(socket, category: "violation", step: :rules)}
+  end
+
+  def handle_event("category", %{"category" => category}, socket) do
+    {:noreply, assign(socket, category: category, step: :evidence)}
+  end
+
+  def handle_event("rules", params, socket) do
+    ids = params |> get_in(["report", "rule_ids"]) |> List.wrap()
+
+    {:noreply, assign(socket, rule_ids: ids, step: :evidence)}
+  end
+
+  def handle_event("evidence", params, socket) do
+    chosen = params |> get_in(["report", "status_ids"]) |> List.wrap()
+
+    {:noreply, assign(socket, chosen: chosen, step: :comment)}
+  end
+
+  # The submit button on the evidence form carries this so that a screen with
+  # nothing to tick still has a way forward.
+  def handle_event("to_comment", _params, socket), do: {:noreply, assign(socket, step: :comment)}
+
+  def handle_event("file", params, socket) do
+    attrs = params["report"] || %{}
+
+    Reports.create(socket.assigns.viewer, %{
+      "target_account_id" => socket.assigns.subject.id,
+      "category" => socket.assigns.category,
+      "comment" => attrs["comment"] || "",
+      "rule_ids" => socket.assigns.rule_ids,
+      "status_ids" => socket.assigns.chosen,
+      "forward" => attrs["forward"] == "true"
+    })
+
+    {:noreply, assign(socket, step: :done, filed?: true)}
+  end
+
+  def handle_event("unfollow", _params, socket),
+    do: {:noreply, act(socket, &Relationships.unfollow/2)}
+
+  def handle_event("mute", _params, socket), do: {:noreply, act(socket, &Relationships.mute/2)}
+  def handle_event("block", _params, socket), do: {:noreply, act(socket, &Relationships.block/2)}
+
+  def handle_event(_event, _params, socket), do: {:noreply, socket}
+
+  defp act(socket, decide) do
+    decide.(socket.assigns.viewer, socket.assigns.subject)
+
+    assign(socket, relationship: relationship(socket.assigns.viewer, socket.assigns.subject))
+  end
+
+  ## Reading
+
+  # `violation` only where there are rules to name: an option that leads to an
+  # empty list of rules is a question nobody can answer.
+  defp categories(rules) do
+    [
+      {"dislike", gettext("I do not like it"),
+       gettext("It is not something you want to see. This tells nobody.")},
+      {"spam", gettext("It is spam"),
+       gettext("Malicious links, fake engagement, or the same thing over and over.")},
+      {"legal", gettext("It is illegal"),
+       gettext("You believe it breaks the law here or where you are.")}
+    ] ++
+      rules_option(rules) ++
+      [
+        {"other", gettext("Something else"), gettext("It does not fit any of the above.")}
+      ]
+  end
+
+  defp rules_option([]), do: []
+
+  defp rules_option(_rules) do
+    [
+      {"violation", gettext("It breaks the rules of this server"),
+       gettext("You know which rule it breaks.")}
+    ]
+  end
+
+  defp relationship(viewer, subject) do
+    %{
+      following: Relationships.following?(viewer.id, subject.id),
+      muting: Relationships.muting?(viewer.id, subject.id),
+      blocking: Relationships.blocking?(viewer.id, subject.id)
+    }
+  end
+
+  # Only what the reporter can already see. A report screen is not a way to
+  # read somebody's followers-only posts.
+  defp evidence(subject, viewer) do
+    subject
+    |> Statuses.account_timeline(viewer, %{limit: @evidence_limit})
+    |> Entities.statuses(viewer)
+  end
+
+  defp chosen(%{"status" => id}) do
+    case Snowflake.cast(id) do
+      {:ok, number} -> [to_string(number)]
+      :error -> []
+    end
+  end
+
+  defp chosen(_params), do: []
+end

--- a/lib/abuuba_web/live/saved_live.ex
+++ b/lib/abuuba_web/live/saved_live.ex
@@ -1,0 +1,145 @@
+defmodule AbuubaWeb.SavedLive do
+  @moduledoc """
+  The two lists a reader builds by pressing buttons on posts.
+
+  ## Why the pages exist at all
+
+  `AbuubaWeb.StatusComponent` draws a bookmark and a favourite on every post on
+  every screen, and `GET /api/v1/bookmarks` and `/api/v1/favourites` have always
+  answered them. Nothing in this server's own interface showed either, so a
+  reader could file a post away and never find it again -- which is the same
+  thing to them as a button that does nothing.
+
+  ## One module, two lists
+
+  They differ in one query and two sentences. Two modules would be two places
+  to fix the next thing the action bar learns to do, which is the copy-and-drift
+  `AbuubaWeb.PostActions` was written to end.
+
+  ## Acting on a post takes it off the list it is on
+
+  Unbookmarking a post while reading the bookmarks is the reader saying "not
+  this one", so it goes. Leaving it there until a reload would read as the
+  button not having worked, and putting it back rendered is worse: a list of
+  bookmarks with an unbookmarked post on it is a list that is lying.
+  """
+
+  use AbuubaWeb, :live_view
+
+  import AbuubaWeb.StatusComponent
+
+  alias Abuuba.Statuses
+  alias AbuubaWeb.API.Entities
+  alias AbuubaWeb.Meta
+  alias AbuubaWeb.PostActions
+
+  @page_size 40
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(robots: Meta.noindex(), viewer: current_account(socket))
+     |> PostActions.attach(lists: [:posts], remove: &drop/2, put_back: &put_back/2)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(_params, _uri, socket) do
+    {:noreply, socket |> assign(page_title: title(socket.assigns.live_action)) |> load()}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_scope={@current_scope} page_title={@page_title}>
+      <h1 class="p-4 text-xl font-semibold">{@page_title}</h1>
+
+      <nav class="flex border-b border-base-300" aria-label={gettext("Which list")}>
+        <.link
+          :for={{action, label} <- tabs()}
+          navigate={path(action)}
+          aria-current={@live_action == action && "page"}
+          class={[
+            "px-4 py-2",
+            @live_action == action && "border-b-2 border-primary font-semibold"
+          ]}
+        >
+          {label}
+        </.link>
+      </nav>
+
+      <div id="saved-posts">
+        <.status
+          :for={post <- @posts}
+          id={"saved-#{post["id"]}"}
+          status={post}
+          viewer_id={viewer_id(@viewer)}
+        />
+      </div>
+
+      <p :if={@posts == []} class="p-8 text-center text-base-content/60">
+        {empty_message(@live_action)}
+      </p>
+    </Layouts.app>
+    """
+  end
+
+  defp tabs do
+    [{:bookmarks, gettext("Bookmarks")}, {:favourites, gettext("Favourites")}]
+  end
+
+  defp path(:bookmarks), do: ~p"/bookmarks"
+  defp path(:favourites), do: ~p"/favourites"
+
+  defp title(:bookmarks), do: gettext("Bookmarks")
+  defp title(:favourites), do: gettext("Favourites")
+
+  # Named after the button that fills the list rather than after the list, so
+  # somebody who arrived here without knowing what a bookmark is on this server
+  # finds out.
+  defp empty_message(:bookmarks) do
+    gettext("Nothing bookmarked yet. The bookmark under a post files it here, and tells nobody.")
+  end
+
+  defp empty_message(:favourites) do
+    gettext("Nothing favourited yet. The star under a post lands here, and its author is told.")
+  end
+
+  # The collections come back as the mark and the post it names, because what a
+  # client pages through is the order things were saved in rather than the
+  # order they were written. Only the post is drawn.
+  defp load(socket) do
+    viewer = socket.assigns.viewer
+
+    posts =
+      socket.assigns.live_action
+      |> collection(viewer)
+      |> Enum.map(& &1.status)
+      |> Entities.statuses(viewer, filter_context: "home")
+
+    assign(socket, posts: posts)
+  end
+
+  defp collection(:bookmarks, viewer), do: Statuses.bookmarks(viewer, %{limit: @page_size})
+  defp collection(:favourites, viewer), do: Statuses.favourites(viewer, %{limit: @page_size})
+
+  # A post the reader has just taken off this list, and one they have only
+  # redrawn. The action bar cannot know which list it is being pressed on, so
+  # the decision is here.
+  defp put_back(socket, rendered) do
+    if still_listed?(socket.assigns.live_action, rendered) do
+      Phoenix.Component.update(socket, :posts, &PostActions.swap(&1, rendered))
+    else
+      drop(socket, rendered["id"])
+    end
+  end
+
+  defp drop(socket, id) do
+    Phoenix.Component.update(socket, :posts, fn posts ->
+      Enum.reject(posts, &PostActions.about?(&1, id))
+    end)
+  end
+
+  defp still_listed?(:bookmarks, rendered), do: rendered["bookmarked"] == true
+  defp still_listed?(:favourites, rendered), do: rendered["favourited"] == true
+end

--- a/lib/abuuba_web/live/settings_live.ex
+++ b/lib/abuuba_web/live/settings_live.ex
@@ -169,7 +169,7 @@ defmodule AbuubaWeb.SettingsLive do
           filters={@filters}
           blocked_domains={@blocked_domains}
         />
-        <.follows :if={@section == :follows} following={@following} />
+        <.follows :if={@section == :follows} following={@following} requests={@requests} />
         <.security :if={@section == :security} logins={@logins} />
         <.applications :if={@section == :applications} applications={@applications} />
         <.account :if={@section == :account} account={@account} />
@@ -845,8 +845,50 @@ defmodule AbuubaWeb.SettingsLive do
 
   attr :following, :list, required: true
 
+  attr :requests, :list, required: true
+
   defp follows(assigns) do
     ~H"""
+    <section :if={@requests != []} class="mt-4 rounded border border-base-300 p-3">
+      <h3 class="font-semibold">{gettext("Waiting for your answer")}</h3>
+      <p class="mt-1 text-sm text-base-content/70">
+        {gettext(
+          "Your account asks before letting somebody follow it. Turning one away tells them nothing, and they can ask again."
+        )}
+      </p>
+
+      <ul class="mt-3 divide-y divide-base-300">
+        <li :for={person <- @requests} class="flex flex-wrap items-center gap-3 py-2">
+          <span class="min-w-0 flex-1">
+            <a href={"/@" <> Account.acct(person)} class="font-medium">
+              {Account.display_name(person)}
+            </a>
+            <span class="block text-sm text-base-content/60">@{Account.acct(person)}</span>
+          </span>
+
+          <span class="flex shrink-0 gap-2">
+            <button
+              type="button"
+              phx-click="accept_request"
+              phx-value-id={person.id}
+              class="btn btn-sm btn-primary"
+            >
+              {gettext("Let them follow")}
+            </button>
+
+            <button
+              type="button"
+              phx-click="reject_request"
+              phx-value-id={person.id}
+              class="btn btn-sm"
+            >
+              {gettext("Turn them away")}
+            </button>
+          </span>
+        </li>
+      </ul>
+    </section>
+
     <p class="mt-2 text-base-content/70">
       {gettext("Tick anybody you want to stop following, then press the button once.")}
     </p>
@@ -1312,6 +1354,14 @@ defmodule AbuubaWeb.SettingsLive do
     socket |> assign(account: account, saved?: true) |> then(&{:noreply, &1})
   end
 
+  def handle_event("accept_request", %{"id" => id}, socket) do
+    {:noreply, answer_request(socket, id, &Relationships.accept_follow_request/1)}
+  end
+
+  def handle_event("reject_request", %{"id" => id}, socket) do
+    {:noreply, answer_request(socket, id, &Relationships.reject_follow_request/1)}
+  end
+
   def handle_event("accept_all_requests", _params, socket) do
     Relationships.accept_all_follow_requests(socket.assigns.account)
 
@@ -1653,6 +1703,21 @@ defmodule AbuubaWeb.SettingsLive do
 
   def handle_event(_event, _params, socket), do: {:noreply, socket}
 
+  # Read back through `pending_followers/2` rather than trusted from the
+  # button: the id arrives from the page, and the only request this account
+  # may answer is one that is waiting on it.
+  defp answer_request(socket, id, answer) do
+    account = socket.assigns.account
+
+    with {:ok, asker_id} <- Snowflake.cast(id),
+         %{} = asker <- Abuuba.Accounts.get_account(asker_id),
+         %{} = request <- Relationships.get_follow_request(asker, account) do
+      answer.(request)
+    end
+
+    socket |> assign(saved?: true) |> load(:follows)
+  end
+
   ## Plumbing
 
   # The section that was saved, not always the profile: privacy and aliases save
@@ -1737,6 +1802,11 @@ defmodule AbuubaWeb.SettingsLive do
     [
       following:
         if(section == :follows, do: Relationships.following(account, %{limit: 200}), else: []),
+      requests:
+        if(section == :follows,
+          do: Relationships.pending_followers(account, %{limit: 200}),
+          else: []
+        ),
       applications:
         if(section == :applications, do: OAuth.authorized_applications(user), else: []),
       severances: if(section == :strikes, do: Domains.severance_summary(account), else: []),

--- a/lib/abuuba_web/live/settings_live.ex
+++ b/lib/abuuba_web/live/settings_live.ex
@@ -169,7 +169,7 @@ defmodule AbuubaWeb.SettingsLive do
           filters={@filters}
           blocked_domains={@blocked_domains}
         />
-        <.follows :if={@section == :follows} following={@following} requests={@requests} />
+        <.follows :if={@section == :follows} following={@following} />
         <.security :if={@section == :security} logins={@logins} />
         <.applications :if={@section == :applications} applications={@applications} />
         <.account :if={@section == :account} account={@account} />
@@ -209,6 +209,16 @@ defmodule AbuubaWeb.SettingsLive do
         <p class="text-sm text-base-content/60">{section_hint(action)}</p>
       </li>
     </ul>
+
+    <%!-- Not settings, and here anyway: the two lists live in the sidebar,
+    which a phone does not draw, and this is the page somebody on a phone
+    opens when they are looking for something about their own account. --%>
+    <p class="mt-6 text-sm text-base-content/60">
+      {gettext("Looking for what you saved?")}
+      <.link navigate={~p"/bookmarks"} class="link">{gettext("Bookmarks")}</.link>
+      {gettext("and")}
+      <.link navigate={~p"/favourites"} class="link">{gettext("Favourites")}</.link>.
+    </p>
     """
   end
 
@@ -845,50 +855,8 @@ defmodule AbuubaWeb.SettingsLive do
 
   attr :following, :list, required: true
 
-  attr :requests, :list, required: true
-
   defp follows(assigns) do
     ~H"""
-    <section :if={@requests != []} class="mt-4 rounded border border-base-300 p-3">
-      <h3 class="font-semibold">{gettext("Waiting for your answer")}</h3>
-      <p class="mt-1 text-sm text-base-content/70">
-        {gettext(
-          "Your account asks before letting somebody follow it. Turning one away tells them nothing, and they can ask again."
-        )}
-      </p>
-
-      <ul class="mt-3 divide-y divide-base-300">
-        <li :for={person <- @requests} class="flex flex-wrap items-center gap-3 py-2">
-          <span class="min-w-0 flex-1">
-            <a href={"/@" <> Account.acct(person)} class="font-medium">
-              {Account.display_name(person)}
-            </a>
-            <span class="block text-sm text-base-content/60">@{Account.acct(person)}</span>
-          </span>
-
-          <span class="flex shrink-0 gap-2">
-            <button
-              type="button"
-              phx-click="accept_request"
-              phx-value-id={person.id}
-              class="btn btn-sm btn-primary"
-            >
-              {gettext("Let them follow")}
-            </button>
-
-            <button
-              type="button"
-              phx-click="reject_request"
-              phx-value-id={person.id}
-              class="btn btn-sm"
-            >
-              {gettext("Turn them away")}
-            </button>
-          </span>
-        </li>
-      </ul>
-    </section>
-
     <p class="mt-2 text-base-content/70">
       {gettext("Tick anybody you want to stop following, then press the button once.")}
     </p>
@@ -1354,14 +1322,6 @@ defmodule AbuubaWeb.SettingsLive do
     socket |> assign(account: account, saved?: true) |> then(&{:noreply, &1})
   end
 
-  def handle_event("accept_request", %{"id" => id}, socket) do
-    {:noreply, answer_request(socket, id, &Relationships.accept_follow_request/1)}
-  end
-
-  def handle_event("reject_request", %{"id" => id}, socket) do
-    {:noreply, answer_request(socket, id, &Relationships.reject_follow_request/1)}
-  end
-
   def handle_event("accept_all_requests", _params, socket) do
     Relationships.accept_all_follow_requests(socket.assigns.account)
 
@@ -1703,21 +1663,6 @@ defmodule AbuubaWeb.SettingsLive do
 
   def handle_event(_event, _params, socket), do: {:noreply, socket}
 
-  # Read back through `pending_followers/2` rather than trusted from the
-  # button: the id arrives from the page, and the only request this account
-  # may answer is one that is waiting on it.
-  defp answer_request(socket, id, answer) do
-    account = socket.assigns.account
-
-    with {:ok, asker_id} <- Snowflake.cast(id),
-         %{} = asker <- Abuuba.Accounts.get_account(asker_id),
-         %{} = request <- Relationships.get_follow_request(asker, account) do
-      answer.(request)
-    end
-
-    socket |> assign(saved?: true) |> load(:follows)
-  end
-
   ## Plumbing
 
   # The section that was saved, not always the profile: privacy and aliases save
@@ -1802,11 +1747,6 @@ defmodule AbuubaWeb.SettingsLive do
     [
       following:
         if(section == :follows, do: Relationships.following(account, %{limit: 200}), else: []),
-      requests:
-        if(section == :follows,
-          do: Relationships.pending_followers(account, %{limit: 200}),
-          else: []
-        ),
       applications:
         if(section == :applications, do: OAuth.authorized_applications(user), else: []),
       severances: if(section == :strikes, do: Domains.severance_summary(account), else: []),

--- a/lib/abuuba_web/live/tag_live.ex
+++ b/lib/abuuba_web/live/tag_live.ex
@@ -23,6 +23,7 @@ defmodule AbuubaWeb.TagLive do
   alias Abuuba.Settings
   alias Abuuba.Statuses
   alias Abuuba.Statuses.Tag
+  alias Abuuba.Timelines
   alias AbuubaWeb.API.Entities
   alias AbuubaWeb.Meta
   alias AbuubaWeb.PostActions
@@ -121,9 +122,13 @@ defmodule AbuubaWeb.TagLive do
     if Settings.public_timelines_readable?(viewer), do: tag_posts(tag, viewer), else: []
   end
 
+  # Through `Timelines.tag/3`, which is what the API answers this question
+  # with. `Statuses.tag_timeline/2` is the bare query and is never told who
+  # is reading, so this page showed a reader the posts of people they had
+  # blocked or muted -- hidden everywhere else, and sitting here.
   defp tag_posts(tag, viewer) do
-    tag
-    |> Statuses.tag_timeline(limit: @page_size)
+    tag.name
+    |> Timelines.tag(viewer, %{limit: @page_size})
     |> Entities.statuses(viewer, filter_context: "public")
     |> Enum.reject(&hidden?/1)
   end

--- a/lib/abuuba_web/router.ex
+++ b/lib/abuuba_web/router.ex
@@ -299,6 +299,10 @@ defmodule AbuubaWeb.Router do
 
     live_session :signed_in,
       on_mount: [{AbuubaWeb.UserAuth, :ensure_authenticated}, AbuubaWeb.LocaleHook] do
+      live "/follow-requests", FollowRequestsLive
+      live "/report/@:username", ReportLive
+      live "/bookmarks", SavedLive, :bookmarks
+      live "/favourites", SavedLive, :favourites
       live "/settings/two-factor", TwoFactorSettingsLive
       live "/settings", SettingsLive, :index
       live "/settings/profile", SettingsLive, :profile

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.3",
+      version: "1.1.0",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.2",
+      version: "1.0.3",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -39,8 +39,8 @@ msgstr[1] "vor %{count} Minuten"
 msgid "Actions"
 msgstr "Aktionen"
 
-#: lib/abuuba_web/components/layouts.ex:289
-#: lib/abuuba_web/components/layouts.ex:304
+#: lib/abuuba_web/components/layouts.ex:326
+#: lib/abuuba_web/components/layouts.ex:341
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr "Verbindung wird wiederhergestellt"
@@ -56,7 +56,7 @@ msgstr "Ändern"
 msgid "Language"
 msgstr "Sprache"
 
-#: lib/abuuba_web/components/layouts.ex:296
+#: lib/abuuba_web/components/layouts.ex:333
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr "Da ist etwas schiefgelaufen"
@@ -66,7 +66,7 @@ msgstr "Da ist etwas schiefgelaufen"
 msgid "That language is not available."
 msgstr "Diese Sprache steht nicht zur Verfügung."
 
-#: lib/abuuba_web/components/layouts.ex:281
+#: lib/abuuba_web/components/layouts.ex:318
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr "Keine Internetverbindung"
@@ -420,7 +420,7 @@ msgstr "Einschalten"
 msgid "Turn off two-factor authentication?"
 msgstr "Zwei-Faktor-Authentifizierung ausschalten?"
 
-#: lib/abuuba_web/live/settings_live.ex:944
+#: lib/abuuba_web/live/settings_live.ex:912
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -654,51 +654,51 @@ msgstr "Ein Server darf nur nach seinen eigenen Followern fragen."
 msgid "That request has to be signed."
 msgstr "Diese Anfrage muss signiert sein."
 
-#: lib/abuuba_web/components/layouts.ex:247
-#: lib/abuuba_web/components/layouts.ex:256
+#: lib/abuuba_web/components/layouts.ex:271
+#: lib/abuuba_web/components/layouts.ex:280
 #: lib/abuuba_web/live/explore_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr "Entdecken"
 
-#: lib/abuuba_web/components/layouts.ex:234
-#: lib/abuuba_web/components/layouts.ex:255
+#: lib/abuuba_web/components/layouts.ex:258
+#: lib/abuuba_web/components/layouts.ex:279
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2388
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
 
-#: lib/abuuba_web/components/layouts.ex:143
+#: lib/abuuba_web/components/layouts.ex:153
 #: lib/abuuba_web/controllers/shortcuts_controller.ex:15
 #: lib/abuuba_web/controllers/shortcuts_html/show.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr "Tastaturkürzel"
 
-#: lib/abuuba_web/components/layouts.ex:258
+#: lib/abuuba_web/components/layouts.ex:282
 #: lib/abuuba_web/live/landing_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Anmelden"
 
 #: lib/abuuba_web/components/layouts.ex:133
-#: lib/abuuba_web/components/layouts.ex:158
+#: lib/abuuba_web/components/layouts.ex:168
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr "Hauptnavigation"
 
-#: lib/abuuba_web/components/layouts.ex:237
+#: lib/abuuba_web/components/layouts.ex:261
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2389
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr "Mitteilungen"
 
-#: lib/abuuba_web/components/layouts.ex:249
+#: lib/abuuba_web/components/layouts.ex:273
 #: lib/abuuba_web/live/settings_live.ex:121
-#: lib/abuuba_web/live/settings_live.ex:2197
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -737,12 +737,12 @@ msgstr "%{name} hat geteilt"
 msgid "Attachment"
 msgstr "Anhang"
 
-#: lib/abuuba_web/components/status_component.ex:430
+#: lib/abuuba_web/components/status_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr "Lesezeichen setzen"
 
-#: lib/abuuba_web/components/status_component.ex:407
+#: lib/abuuba_web/components/status_component.ex:415
 #, elixir-autogen, elixir-format
 msgid "Boost"
 msgstr "Teilen"
@@ -752,7 +752,7 @@ msgstr "Teilen"
 msgid "Closed"
 msgstr "Beendet"
 
-#: lib/abuuba_web/components/status_component.ex:419
+#: lib/abuuba_web/components/status_component.ex:427
 #, elixir-autogen, elixir-format
 msgid "Favourite"
 msgstr "Favorisieren"
@@ -768,7 +768,7 @@ msgstr "Folge ein paar Menschen, dann erscheinen ihre Beiträge hier."
 msgid "Poll"
 msgstr "Umfrage"
 
-#: lib/abuuba_web/components/status_component.ex:395
+#: lib/abuuba_web/components/status_component.ex:403
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr "Antworten"
@@ -849,19 +849,19 @@ msgid "Allow more than one choice"
 msgstr "Mehrfachauswahl erlauben"
 
 #: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2383
+#: lib/abuuba_web/live/settings_live.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr "Alle"
 
 #: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2378
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr "Alle, und überall gelistet"
 
 #: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2379
+#: lib/abuuba_web/live/settings_live.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr "Alle, aber nicht in öffentlichen Timelines"
@@ -887,7 +887,7 @@ msgstr "Strg + Enter veröffentlicht"
 msgid "Do not reply to this person"
 msgstr "Diese Person nicht mit anschreiben"
 
-#: lib/abuuba_web/components/status_component.ex:441
+#: lib/abuuba_web/components/status_component.ex:449
 #: lib/abuuba_web/live/admin_live.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -904,7 +904,7 @@ msgid "Ends after"
 msgstr "Endet nach"
 
 #: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/profile_live.ex:792
+#: lib/abuuba_web/live/profile_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr "Follower"
@@ -916,13 +916,13 @@ msgstr "Erwähnte Personen"
 
 #: lib/abuuba_web/live/admin_live.ex:3427
 #: lib/abuuba_web/live/compose_component.ex:1677
-#: lib/abuuba_web/live/settings_live.ex:2385
+#: lib/abuuba_web/live/settings_live.ex:2327
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr "Niemand"
 
 #: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/settings_live.ex:2380
+#: lib/abuuba_web/live/settings_live.ex:2322
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr "Nur die Leute, die dir folgen"
@@ -933,7 +933,7 @@ msgid "Only the people you name"
 msgstr "Nur die Leute, die du nennst"
 
 #: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2384
+#: lib/abuuba_web/live/settings_live.ex:2326
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr "Leute, die dir folgen"
@@ -1206,12 +1206,14 @@ msgstr "oder zieh eine ins Feld oder füg sie ein"
 msgid "%{name} on %{server}"
 msgstr "%{name} auf %{server}"
 
-#: lib/abuuba_web/live/profile_live.ex:299
+#: lib/abuuba_web/live/profile_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr "Eine Notiz, die nur du liest"
 
 #: lib/abuuba_web/live/profile_live.ex:196
+#: lib/abuuba_web/live/report_live.ex:285
+#: lib/abuuba_web/live/report_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr "Blockieren"
@@ -1233,29 +1235,31 @@ msgstr "Zum neuen Konto"
 msgid "Look for more replies on the other server"
 msgstr "Auf dem anderen Server nach weiteren Antworten suchen"
 
-#: lib/abuuba_web/live/profile_live.ex:791
+#: lib/abuuba_web/live/profile_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr "Medien"
 
 #: lib/abuuba_web/live/profile_live.ex:188
+#: lib/abuuba_web/live/report_live.ex:273
+#: lib/abuuba_web/live/report_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr "Stummschalten"
 
-#: lib/abuuba_web/live/profile_live.ex:370
+#: lib/abuuba_web/live/profile_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr "Hier ist noch nichts."
 
-#: lib/abuuba_web/live/profile_live.ex:345
-#: lib/abuuba_web/live/profile_live.ex:346
+#: lib/abuuba_web/live/profile_live.ex:351
+#: lib/abuuba_web/live/profile_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr "Angeheftet"
 
 #: lib/abuuba_web/live/explore_live.ex:256
-#: lib/abuuba_web/live/profile_live.ex:789
+#: lib/abuuba_web/live/profile_live.ex:795
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:208
@@ -1263,13 +1267,13 @@ msgstr "Angeheftet"
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/abuuba_web/live/profile_live.ex:790
+#: lib/abuuba_web/live/profile_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr "Beiträge und Antworten"
 
 #: lib/abuuba_web/live/admin_live.ex:944
-#: lib/abuuba_web/live/profile_live.ex:303
+#: lib/abuuba_web/live/profile_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr "Notiz speichern"
@@ -1285,12 +1289,14 @@ msgid "This account has moved to %{handle}."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
 #: lib/abuuba_web/live/profile_live.ex:196
-#: lib/abuuba_web/live/settings_live.ex:828
+#: lib/abuuba_web/live/settings_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr "Blockierung aufheben"
 
 #: lib/abuuba_web/live/profile_live.ex:162
+#: lib/abuuba_web/live/report_live.ex:263
+#: lib/abuuba_web/live/report_live.ex:268
 #: lib/abuuba_web/live/tag_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -1306,7 +1312,7 @@ msgstr "Stummschaltung aufheben"
 msgid "Verified"
 msgstr "Bestätigt"
 
-#: lib/abuuba_web/live/profile_live.ex:307
+#: lib/abuuba_web/live/profile_live.ex:313
 #: lib/abuuba_web/live/search_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "What to show"
@@ -1488,7 +1494,11 @@ msgstr "Jede Zeile beschreibt eine Art von Absender. Annehmen lässt sie durch, 
 msgid "Edits"
 msgstr "Bearbeitungen"
 
+#: lib/abuuba_web/components/layouts.ex:151
 #: lib/abuuba_web/live/notifications_live.ex:471
+#: lib/abuuba_web/live/saved_live.ex:88
+#: lib/abuuba_web/live/saved_live.ex:95
+#: lib/abuuba_web/live/settings_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Favourites"
 msgstr "Favoriten"
@@ -1498,15 +1508,18 @@ msgstr "Favoriten"
 msgid "Filter"
 msgstr "Filtern"
 
+#: lib/abuuba_web/components/layouts.ex:292
+#: lib/abuuba_web/live/follow_requests_live.ex:37
+#: lib/abuuba_web/live/follow_requests_live.ex:44
 #: lib/abuuba_web/live/notifications_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr "Folgeanfragen"
 
 #: lib/abuuba_web/live/notifications_live.ex:469
-#: lib/abuuba_web/live/profile_live.ex:793
-#: lib/abuuba_web/live/settings_live.ex:2181
-#: lib/abuuba_web/live/settings_live.ex:2319
+#: lib/abuuba_web/live/profile_live.ex:799
+#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folge ich"
@@ -1573,15 +1586,15 @@ msgstr "Private Erwähnungen aus dem Nichts"
 #: lib/abuuba_web/live/admin_live.ex:1587
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:262
-#: lib/abuuba_web/live/settings_live.ex:296
-#: lib/abuuba_web/live/settings_live.ex:390
-#: lib/abuuba_web/live/settings_live.ex:427
-#: lib/abuuba_web/live/settings_live.ex:491
-#: lib/abuuba_web/live/settings_live.ex:598
-#: lib/abuuba_web/live/settings_live.ex:643
-#: lib/abuuba_web/live/settings_live.ex:676
-#: lib/abuuba_web/live/settings_live.ex:1046
+#: lib/abuuba_web/live/profile_live.ex:268
+#: lib/abuuba_web/live/settings_live.ex:306
+#: lib/abuuba_web/live/settings_live.ex:400
+#: lib/abuuba_web/live/settings_live.ex:437
+#: lib/abuuba_web/live/settings_live.ex:501
+#: lib/abuuba_web/live/settings_live.ex:608
+#: lib/abuuba_web/live/settings_live.ex:653
+#: lib/abuuba_web/live/settings_live.ex:686
+#: lib/abuuba_web/live/settings_live.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Speichern"
@@ -1629,7 +1642,7 @@ msgstr "Wer dich erreichen kann"
 msgid "Your settings filed these instead of showing them."
 msgstr "Deine Einstellungen haben diese abgelegt, statt sie zu zeigen."
 
-#: lib/abuuba_web/components/layouts.ex:190
+#: lib/abuuba_web/components/layouts.ex:200
 #: lib/abuuba_web/live/conversations_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "unread"
@@ -1718,8 +1731,8 @@ msgstr "Die Registrierung ist offen: jeder darf sich anmelden."
 msgid "Registration needs approval: you sign up and an admin reads your request."
 msgstr "Die Registrierung braucht eine Freigabe: du meldest dich an und eine Administration liest deine Anfrage."
 
-#: lib/abuuba_web/components/layouts.ex:248
-#: lib/abuuba_web/components/layouts.ex:257
+#: lib/abuuba_web/components/layouts.ex:272
+#: lib/abuuba_web/components/layouts.ex:281
 #: lib/abuuba_web/live/search_live.ex:38
 #: lib/abuuba_web/live/search_live.ex:61
 #: lib/abuuba_web/live/search_live.ex:70
@@ -1757,95 +1770,95 @@ msgstr "Beiträge nach einem Datum"
 msgid "posts older than a date"
 msgstr "Beiträge vor einem Datum"
 
-#: lib/abuuba_web/live/settings_live.ex:935
+#: lib/abuuba_web/live/settings_live.ex:903
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr "Ein neues Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:236
+#: lib/abuuba_web/live/settings_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr "Über dich"
 
 #: lib/abuuba_web/live/admin_live.ex:3378
-#: lib/abuuba_web/live/settings_live.ex:2184
+#: lib/abuuba_web/live/settings_live.ex:2126
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Konto"
 
-#: lib/abuuba_web/live/settings_live.ex:292
+#: lib/abuuba_web/live/settings_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "Add a field"
 msgstr "Feld hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:809
+#: lib/abuuba_web/live/settings_live.ex:819
 #, elixir-autogen, elixir-format
 msgid "Add a filter"
 msgstr "Filter hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:2177
+#: lib/abuuba_web/live/settings_live.ex:2119
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/abuuba_web/live/settings_live.ex:2355
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr "Gilt nur für deine öffentlichen Beiträge."
 
-#: lib/abuuba_web/live/settings_live.ex:2183
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/abuuba_web/live/settings_live.ex:2208
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr "Apps, die in dein Konto gelassen wurden."
 
-#: lib/abuuba_web/live/settings_live.ex:997
+#: lib/abuuba_web/live/settings_live.ex:965
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr "Apps, bei denen du angemeldet bist. Eine wieder hinauszunehmen meldet sie sofort ab."
 
-#: lib/abuuba_web/live/settings_live.ex:2350
+#: lib/abuuba_web/live/settings_live.ex:2292
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr "Vor jedem Follow fragen"
 
-#: lib/abuuba_web/live/settings_live.ex:939
+#: lib/abuuba_web/live/settings_live.ex:907
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr "Passwort ändern"
 
-#: lib/abuuba_web/components/status_component.ex:455
+#: lib/abuuba_web/components/status_component.ex:463
 #: lib/abuuba_web/live/admin_live.ex:998
-#: lib/abuuba_web/live/settings_live.ex:756
+#: lib/abuuba_web/live/settings_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:225
+#: lib/abuuba_web/live/settings_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr "Anzeigename"
 
-#: lib/abuuba_web/live/settings_live.ex:2366
+#: lib/abuuba_web/live/settings_live.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr "Medien nicht von selbst abspielen"
 
-#: lib/abuuba_web/live/settings_live.ex:1658
+#: lib/abuuba_web/live/settings_live.ex:1618
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr "Jede Zeile muss eine Webadresse sein, eine pro Zeile."
 
-#: lib/abuuba_web/live/settings_live.ex:2351
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr "Jeder Follow wird zu einer Anfrage, die du beantwortest."
 
-#: lib/abuuba_web/live/settings_live.ex:2206
+#: lib/abuuba_web/live/settings_live.ex:2148
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr "Allen, denen du folgst, und ein Weg, damit aufzuhören."
@@ -1855,123 +1868,123 @@ msgstr "Allen, denen du folgst, und ein Weg, damit aufzuhören."
 msgid "Everything about your account is here. Pick a section."
 msgstr "Alles zu deinem Konto ist hier. Wähl einen Bereich."
 
-#: lib/abuuba_web/live/settings_live.ex:241
+#: lib/abuuba_web/live/settings_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr "Felder"
 
-#: lib/abuuba_web/live/settings_live.ex:2180
-#: lib/abuuba_web/live/settings_live.ex:2325
+#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/abuuba_web/live/settings_live.ex:2407
+#: lib/abuuba_web/live/settings_live.ex:2349
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr "Hinter einer Warnung zusammenklappen"
 
-#: lib/abuuba_web/live/settings_live.ex:2408
+#: lib/abuuba_web/live/settings_live.ex:2350
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr "Ganz ausblenden"
 
-#: lib/abuuba_web/live/settings_live.ex:2356
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr "Verbergen, wem ich folge und wer mir folgt"
 
-#: lib/abuuba_web/live/settings_live.ex:2364
+#: lib/abuuba_web/live/settings_live.ex:2306
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr "Mehr Kontrast"
 
-#: lib/abuuba_web/live/settings_live.ex:2202
+#: lib/abuuba_web/live/settings_live.ex:2144
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr "Wie sich die Oberfläche verhält und liest."
 
-#: lib/abuuba_web/live/settings_live.ex:256
+#: lib/abuuba_web/live/settings_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2354
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr "Suchmaschinen meine Beiträge indexieren lassen"
 
-#: lib/abuuba_web/live/settings_live.ex:2352
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr "Mich im Verzeichnis listen"
 
-#: lib/abuuba_web/live/settings_live.ex:2359
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr "Markiert das Konto als Bot, worauf manche Leute filtern."
 
-#: lib/abuuba_web/live/settings_live.ex:274
+#: lib/abuuba_web/live/settings_live.ex:284
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/abuuba_web/live/settings_live.ex:1026
+#: lib/abuuba_web/live/settings_live.ex:994
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr "Es wurde keine App hereingelassen."
 
-#: lib/abuuba_web/live/settings_live.ex:1040
+#: lib/abuuba_web/live/settings_live.ex:1008
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr "Eine Webadresse pro Zeile. Ein Konto hier zu nennen erlaubt dir später den Umzug dorthin, und es muss dieses hier zurücknennen."
 
-#: lib/abuuba_web/live/settings_live.ex:451
+#: lib/abuuba_web/live/settings_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr "Nur die genannten Leute fehlt mit Absicht: als Voreinstellung wird jeder Beitrag, den du zu ändern vergisst, zu einer Nachricht an niemanden."
 
-#: lib/abuuba_web/live/settings_live.ex:2209
+#: lib/abuuba_web/live/settings_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr "Deine anderen Konten und der Umzug zwischen ihnen."
 
-#: lib/abuuba_web/live/settings_live.ex:2371
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr "Überschreibt deine Systemeinstellung, wenn sie für dich falsch ist."
 
-#: lib/abuuba_web/live/settings_live.ex:2175
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Überblick"
 
-#: lib/abuuba_web/live/settings_live.ex:2178
+#: lib/abuuba_web/live/settings_live.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/settings_live.ex:2179
+#: lib/abuuba_web/live/settings_live.ex:2121
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/abuuba_web/live/settings_live.ex:2176
+#: lib/abuuba_web/live/settings_live.ex:2118
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/abuuba_web/live/settings_live.ex:2392
+#: lib/abuuba_web/live/settings_live.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
-#: lib/abuuba_web/live/settings_live.ex:2390
+#: lib/abuuba_web/live/settings_live.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr "Öffentliche Timelines"
 
-#: lib/abuuba_web/live/settings_live.ex:2363
+#: lib/abuuba_web/live/settings_live.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr "Bewegung reduzieren"
@@ -1982,165 +1995,165 @@ msgstr "Bewegung reduzieren"
 #: lib/abuuba_web/live/admin_live.ex:1878
 #: lib/abuuba_web/live/admin_live.ex:2202
 #: lib/abuuba_web/live/conversations_live.ex:113
-#: lib/abuuba_web/live/settings_live.ex:282
-#: lib/abuuba_web/live/settings_live.ex:317
+#: lib/abuuba_web/live/settings_live.ex:292
+#: lib/abuuba_web/live/settings_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2182
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr "Sicherheit"
 
-#: lib/abuuba_web/live/settings_live.ex:957
+#: lib/abuuba_web/live/settings_live.ex:925
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr "Überall abmelden"
 
-#: lib/abuuba_web/live/settings_live.ex:948
+#: lib/abuuba_web/live/settings_live.ex:916
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr "Überall abmelden beendet jede Sitzung, auch diese."
 
-#: lib/abuuba_web/live/settings_live.ex:2374
+#: lib/abuuba_web/live/settings_live.ex:2316
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr "Hält das erste Absenden an, wenn ein Bild keine Beschreibung hat."
 
-#: lib/abuuba_web/live/settings_live.ex:1020
+#: lib/abuuba_web/live/settings_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr "Wieder hinausnehmen"
 
 #: lib/abuuba_web/live/admin_live.ex:3746
-#: lib/abuuba_web/live/settings_live.ex:2171
+#: lib/abuuba_web/live/settings_live.ex:2113
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr "Das konnte nicht gespeichert werden. Prüf, was du eingegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1633
+#: lib/abuuba_web/live/settings_live.ex:1593
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr "Das aktuelle Passwort stimmt nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:470
+#: lib/abuuba_web/live/settings_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr "Die Sprache, in der du meistens schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:2357
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr "Die Listen sind nicht mehr öffentlich; die Follows selbst funktionieren weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:2358
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr "Dieses Konto veröffentlicht automatisch"
 
-#: lib/abuuba_web/live/settings_live.ex:2391
+#: lib/abuuba_web/live/settings_live.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr "Threads"
 
-#: lib/abuuba_web/live/settings_live.ex:893
+#: lib/abuuba_web/live/settings_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr "Hak alle an, denen du nicht mehr folgen willst, und drück dann einmal den Knopf."
 
-#: lib/abuuba_web/live/settings_live.ex:918
+#: lib/abuuba_web/live/settings_live.ex:886
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr "Den angehakten entfolgen"
 
-#: lib/abuuba_web/live/settings_live.ex:243
+#: lib/abuuba_web/live/settings_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr "Bis zu vier Zeilen auf deinem Profil. Die Reihenfolge hier ist die Reihenfolge dort."
 
-#: lib/abuuba_web/live/settings_live.ex:2365
+#: lib/abuuba_web/live/settings_live.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr "Die Schrift meines Systems verwenden"
 
-#: lib/abuuba_web/live/settings_live.ex:263
+#: lib/abuuba_web/live/settings_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr "Wert"
 
-#: lib/abuuba_web/live/settings_live.ex:2367
+#: lib/abuuba_web/live/settings_live.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr "Mich auf fehlende Beschreibungen hinweisen"
 
-#: lib/abuuba_web/live/settings_live.ex:801
+#: lib/abuuba_web/live/settings_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr "Was er tut"
 
-#: lib/abuuba_web/live/settings_live.ex:2203
+#: lib/abuuba_web/live/settings_live.ex:2145
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr "Womit das Schreibfeld beginnt."
 
 #: lib/abuuba_web/live/admin_live.ex:2178
-#: lib/abuuba_web/live/settings_live.ex:763
+#: lib/abuuba_web/live/settings_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr "Wie er heißen soll"
 
-#: lib/abuuba_web/live/settings_live.ex:768
+#: lib/abuuba_web/live/settings_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr "Wo er gilt"
 
-#: lib/abuuba_web/live/settings_live.ex:2204
+#: lib/abuuba_web/live/settings_live.ex:2146
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr "Wer dich finden kann und wer fragen muss, um zu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:457
+#: lib/abuuba_web/live/settings_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr "Wer neue Beiträge zitieren darf"
 
-#: lib/abuuba_web/live/settings_live.ex:438
+#: lib/abuuba_web/live/settings_live.ex:448
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr "An wen neue Beiträge gehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2205
+#: lib/abuuba_web/live/settings_live.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr "Wörter und Wendungen, die du lieber nicht siehst."
 
-#: lib/abuuba_web/live/settings_live.ex:914
+#: lib/abuuba_web/live/settings_live.ex:882
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr "Du folgst noch niemandem."
 
-#: lib/abuuba_web/live/settings_live.ex:2353
+#: lib/abuuba_web/live/settings_live.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr "Dein Konto erscheint auf der öffentlichen Verzeichnisseite dieses Servers."
 
-#: lib/abuuba_web/live/settings_live.ex:930
+#: lib/abuuba_web/live/settings_live.ex:898
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr "Dein aktuelles Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:2201
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr "Dein Name, was du über dich sagst, deine Felder."
 
-#: lib/abuuba_web/live/settings_live.ex:1037
+#: lib/abuuba_web/live/settings_live.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr "Deine anderen Konten"
 
-#: lib/abuuba_web/live/settings_live.ex:2207
+#: lib/abuuba_web/live/settings_live.ex:2149
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr "Dein Passwort, Zwei-Faktor und das Abmelden."
@@ -2296,110 +2309,110 @@ msgstr "Beiträge"
 msgid "servers known"
 msgstr "bekannte Server"
 
-#: lib/abuuba_web/live/settings_live.ex:1936
+#: lib/abuuba_web/live/settings_live.ex:1878
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr "Eine Verwarnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2212
+#: lib/abuuba_web/live/settings_live.ex:2154
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr "Alles, was eine Moderatorin oder ein Moderator hier über dein Konto entschieden hat."
 
-#: lib/abuuba_web/live/settings_live.ex:1246
+#: lib/abuuba_web/live/settings_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr "Einspruch einlegen"
 
-#: lib/abuuba_web/live/settings_live.ex:2185
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr "Moderation"
 
-#: lib/abuuba_web/live/settings_live.ex:1276
+#: lib/abuuba_web/live/settings_live.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr "Hier ist nichts. Niemand aus der Moderation hat etwas gegen dein Konto unternommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1920
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr "Schreib bitte etwas dazu, warum du das für falsch hältst."
 
-#: lib/abuuba_web/live/settings_live.ex:1243
+#: lib/abuuba_web/live/settings_live.ex:1211
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr "Warum hältst du das für falsch?"
 
-#: lib/abuuba_web/live/settings_live.ex:1939
+#: lib/abuuba_web/live/settings_live.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr "Einige deiner Beiträge wurden gelöscht"
 
-#: lib/abuuba_web/live/settings_live.ex:1250
-#: lib/abuuba_web/live/settings_live.ex:1916
+#: lib/abuuba_web/live/settings_live.ex:1218
+#: lib/abuuba_web/live/settings_live.ex:1858
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr "Die Frist für einen Einspruch ist abgelaufen."
 
-#: lib/abuuba_web/live/settings_live.ex:1221
+#: lib/abuuba_web/live/settings_live.ex:1189
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr "Was die Moderation hier über dein Konto entschieden hat und was dir dazu gesagt wurde."
 
-#: lib/abuuba_web/live/settings_live.ex:1931
+#: lib/abuuba_web/live/settings_live.ex:1873
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr "Du hast Einspruch eingelegt, er wurde abgelehnt."
 
-#: lib/abuuba_web/live/settings_live.ex:1930
+#: lib/abuuba_web/live/settings_live.ex:1872
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr "Du hast Einspruch eingelegt, ihm wurde stattgegeben."
 
-#: lib/abuuba_web/live/settings_live.ex:1932
+#: lib/abuuba_web/live/settings_live.ex:1874
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr "Du hast Einspruch eingelegt. Entschieden ist noch nichts."
 
-#: lib/abuuba_web/live/settings_live.ex:1937
+#: lib/abuuba_web/live/settings_live.ex:1879
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr "Dein Konto wurde deaktiviert"
 
-#: lib/abuuba_web/live/settings_live.ex:1940
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr "Dein Konto wurde eingeschränkt"
 
-#: lib/abuuba_web/live/settings_live.ex:1941
+#: lib/abuuba_web/live/settings_live.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr "Dein Konto wurde gesperrt"
 
-#: lib/abuuba_web/live/settings_live.ex:1938
+#: lib/abuuba_web/live/settings_live.ex:1880
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr "Deine Beiträge wurden als sensibel markiert"
 
-#: lib/abuuba_web/live/settings_live.ex:1229
+#: lib/abuuba_web/live/settings_live.ex:1197
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr "inzwischen aufgehoben"
 
-#: lib/abuuba_web/live/settings_live.ex:1267
+#: lib/abuuba_web/live/settings_live.ex:1235
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] "%{count} Verbindung verloren"
 msgstr[1] "%{count} Verbindungen verloren"
 
-#: lib/abuuba_web/live/settings_live.ex:1256
+#: lib/abuuba_web/live/settings_live.ex:1224
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr "Verbindungen, die dich die Entscheidungen dieses Servers gekostet haben"
 
-#: lib/abuuba_web/live/settings_live.ex:1258
+#: lib/abuuba_web/live/settings_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr "Wenn dieser Server die Verbindung zu einem anderen abbricht, gehen die Folgebeziehungen zwischen dir und den Leuten dort verloren. Von hier aus lassen sie sich nicht wiederherstellen, weil die andere Seite nicht mehr erreichbar ist."
@@ -2695,7 +2708,7 @@ msgstr "Das ist keine Adresse."
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3339
-#: lib/abuuba_web/live/settings_live.ex:1686
+#: lib/abuuba_web/live/settings_live.ex:1646
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr "Das kann dein Konto nicht."
@@ -2834,12 +2847,12 @@ msgstr "Was gerade im Trend liegt"
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr "Worüber gerade mehr Leute als sonst schreiben, danach alles Übrige, das Neueste zuerst."
 
-#: lib/abuuba_web/live/settings_live.ex:2169
+#: lib/abuuba_web/live/settings_live.ex:2111
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr "%{uses} von %{max} genutzt"
 
-#: lib/abuuba_web/live/settings_live.ex:1292
+#: lib/abuuba_web/live/settings_live.ex:1260
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr "Ein Code, mit dem sich jemand anmelden kann, auch wenn Anmeldungen geschlossen sind. Lass die Anzahl leer für beliebig viele."
@@ -2854,7 +2867,7 @@ msgstr "Eine Ankündigung braucht einen Text."
 msgid "Announcements"
 msgstr "Ankündigungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2214
+#: lib/abuuba_web/live/settings_live.ex:2156
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr "Codes, mit denen sich Bekannte von dir anmelden können."
@@ -2879,7 +2892,7 @@ msgstr "Darüber wurden bereits alle informiert."
 msgid "Goes up"
 msgstr "Erscheint"
 
-#: lib/abuuba_web/live/settings_live.ex:1303
+#: lib/abuuba_web/live/settings_live.ex:1271
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr "Wie viele Personen"
@@ -2894,12 +2907,12 @@ msgstr "Gültig ab"
 msgid "In effect from %{date}"
 msgstr "Gültig ab %{date}"
 
-#: lib/abuuba_web/live/settings_live.ex:2186
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr "Einladungen"
 
-#: lib/abuuba_web/live/settings_live.ex:1287
+#: lib/abuuba_web/live/settings_live.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
@@ -2909,7 +2922,7 @@ msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
 msgid "Leave this empty to publish it now."
 msgstr "Leer lassen, um sofort zu veröffentlichen."
 
-#: lib/abuuba_web/live/settings_live.ex:1310
+#: lib/abuuba_web/live/settings_live.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr "Erstellen"
@@ -2939,7 +2952,7 @@ msgstr "Veröffentlicht"
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr "Etwas, das hier alle lesen sollten. Mit einer Uhrzeit veröffentlicht es sich selbst, sodass ein Hinweis auf Sonntag schon am Donnerstag geschrieben werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1324
+#: lib/abuuba_web/live/settings_live.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr "Zurücknehmen"
@@ -2954,12 +2967,12 @@ msgstr "Alle informieren"
 msgid "Terms need some text and a day they take effect."
 msgstr "Nutzungsbedingungen brauchen einen Text und einen Tag, ab dem sie gelten."
 
-#: lib/abuuba_web/live/settings_live.ex:1308
+#: lib/abuuba_web/live/settings_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr "Sie folgen dir"
 
-#: lib/abuuba_web/live/settings_live.ex:1299
+#: lib/abuuba_web/live/settings_live.ex:1267
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr "Wofür sie ist"
@@ -2980,7 +2993,7 @@ msgstr "Wann es veröffentlicht wird"
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr "Du meldest dich auf eine Einladung hin an, eine Freigabe brauchst du deshalb nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:1330
+#: lib/abuuba_web/live/settings_live.ex:1298
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr "Du hast noch keine erstellt."
@@ -2990,7 +3003,7 @@ msgstr "Du hast noch keine erstellt."
 msgid "everybody was told"
 msgstr "alle wurden informiert"
 
-#: lib/abuuba_web/live/settings_live.ex:2166
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3111,7 +3124,7 @@ msgstr "von %{name}"
 msgid "That could not be translated just now."
 msgstr "Das ließ sich gerade nicht übersetzen."
 
-#: lib/abuuba_web/components/status_component.ex:469
+#: lib/abuuba_web/components/status_component.ex:477
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr "Übersetzen"
@@ -3126,245 +3139,245 @@ msgstr "Übersetzt von %{provider}. Lade die Seite neu für das Original."
 msgid "This account has been disabled. Contact the moderators."
 msgstr "Dieses Konto wurde deaktiviert. Wende dich an die Moderation."
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2007
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr "%{count} konnten nicht übernommen werden"
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:1998
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr "%{done} von %{total} gelesen, %{imported} übernommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1972
+#: lib/abuuba_web/live/settings_live.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr "Boosts und Umfragen. Ein Boost verweist auf den Beitrag einer anderen Person, den das Archiv nicht enthält, und die Stimmen einer Umfrage wären hier nicht mehr richtig."
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr "Wähle zuerst ein Archiv aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1953
+#: lib/abuuba_web/live/settings_live.ex:1895
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr "Jeder Fediverse-Server gibt dir ein ZIP mit allem, was du geschrieben hast. Lade es hier hoch, und deine Beiträge kommen zurück, mit ihren Bildern und ihrem ursprünglichen Datum."
 
-#: lib/abuuba_web/live/settings_live.ex:2152
+#: lib/abuuba_web/live/settings_live.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr "Fertig."
 
-#: lib/abuuba_web/live/settings_live.ex:2187
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
 
-#: lib/abuuba_web/live/settings_live.ex:1978
+#: lib/abuuba_web/live/settings_live.ex:1920
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr "Importierte Beiträge tauchen in keiner Timeline auf und gehen nicht ins Netzwerk. Sie stehen in deinem Profil, in der Reihenfolge, in der du sie geschrieben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:2144
+#: lib/abuuba_web/live/settings_live.ex:2086
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr "Ein Archiv auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:2217
+#: lib/abuuba_web/live/settings_live.ex:2159
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr "Ein Archiv deiner Beiträge von einem anderen Server wieder einlesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2151
+#: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr "Dein Archiv wird gelesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2153
+#: lib/abuuba_web/live/settings_live.ex:2095
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr "Das Archiv konnte nicht gelesen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr "Das konnte nicht gelesen werden. Lade das Archiv hoch, das dir dein alter Server gegeben hat."
 
-#: lib/abuuba_web/live/settings_live.ex:2140
-#: lib/abuuba_web/live/settings_live.ex:2145
+#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2087
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr "Das konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/settings_live.ex:2143
+#: lib/abuuba_web/live/settings_live.ex:2085
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr "Das ist keine Archivdatei."
 
-#: lib/abuuba_web/live/settings_live.ex:1962
+#: lib/abuuba_web/live/settings_live.ex:1904
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr "Die alten Adressen. Deine Beiträge lagen auf einer anderen Domain und können dort nicht wieder liegen, also bleibt jeder Link darauf tot."
 
-#: lib/abuuba_web/live/settings_live.ex:2150
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr "Wartet auf den Start."
 
-#: lib/abuuba_web/live/settings_live.ex:1959
+#: lib/abuuba_web/live/settings_live.ex:1901
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr "Was nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:1967
+#: lib/abuuba_web/live/settings_live.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr "Deine Follower. Ein Follow ist eine Abmachung zwischen zwei Servern, und einer davon ist weg; sie müssen diesem Konto neu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:2156
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr "ein Boost, der nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2158
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr "eine Umfrage, die nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2159
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr "kein Datum, also kein Platz dafür"
 
-#: lib/abuuba_web/live/settings_live.ex:2162
+#: lib/abuuba_web/live/settings_live.ex:2104
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr "die Datei ist kein Archiv"
 
-#: lib/abuuba_web/live/settings_live.ex:2160
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr "der Beitrag wurde nicht gefunden"
 
-#: lib/abuuba_web/live/settings_live.ex:2161
+#: lib/abuuba_web/live/settings_live.ex:2103
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr "dieser Server hat ihn nicht angenommen"
 
-#: lib/abuuba_web/live/settings_live.ex:1095
+#: lib/abuuba_web/live/settings_live.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr "Alle annehmen"
 
-#: lib/abuuba_web/live/settings_live.ex:2011
+#: lib/abuuba_web/live/settings_live.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr "Dazu hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:1090
+#: lib/abuuba_web/live/settings_live.ex:1058
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr "Nach einem Umzug kommen alle, die dir gefolgt sind, auf einmal an. Das nimmt sie alle an, was dieselbe Antwort ist, die du ihnen schon gegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:2029
+#: lib/abuuba_web/live/settings_live.ex:1971
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr "Ein Archiv deiner Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:1100
+#: lib/abuuba_web/live/settings_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr "Für den Export deiner Daten und das Löschen des Kontos steht die Arbeit noch aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1088
+#: lib/abuuba_web/live/settings_live.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr "Wartende Folgeanfragen"
 
-#: lib/abuuba_web/live/settings_live.ex:1057
+#: lib/abuuba_web/live/settings_live.ex:1025
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr "Ich bin zurück"
 
-#: lib/abuuba_web/live/settings_live.ex:2042
+#: lib/abuuba_web/live/settings_live.ex:1984
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr "Archiv importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:2019
+#: lib/abuuba_web/live/settings_live.ex:1961
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr "Liste importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1114
-#: lib/abuuba_web/live/settings_live.ex:1991
-#: lib/abuuba_web/live/settings_live.ex:2322
+#: lib/abuuba_web/live/settings_live.ex:1082
+#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:2264
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr "Listen"
 
-#: lib/abuuba_web/live/settings_live.ex:1084
+#: lib/abuuba_web/live/settings_live.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr "Umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:1068
+#: lib/abuuba_web/live/settings_live.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr "Zu einem anderen Konto umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr "Unter dieser Adresse war niemand zu finden."
 
-#: lib/abuuba_web/live/settings_live.ex:1052
+#: lib/abuuba_web/live/settings_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr "Anderen Servern wird gesagt, dass sie stattdessen dem neuen Konto folgen sollen. Wer dir von diesem Server aus folgt, ist bereits umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:2015
+#: lib/abuuba_web/live/settings_live.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr "Durch die Datei ersetzen"
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2047
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr "Dieses Konto nennt dieses hier nicht als eines von deinen. Trage die Adresse dieses Kontos zuerst dort bei den Aliassen ein."
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2058
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr "Das ist dieses Konto."
 
-#: lib/abuuba_web/live/settings_live.ex:1993
+#: lib/abuuba_web/live/settings_live.ex:1935
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr "Die CSV-Dateien, die dir dein alter Server gibt: Follows, Blocks, Stummschaltungen, Domain-Blocks, Listen, Lesezeichen, Filter. Lade sie einzeln hoch, unter dem Namen, unter dem sie kamen."
 
-#: lib/abuuba_web/live/settings_live.ex:1078
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr "Das andere Konto muss dieses hier zuerst in seinen eigenen Aliassen nennen. Deine Follower hier ziehen mit um, und alle anderen Server werden benachrichtigt; ein Konto kann nur alle %{days} Tage umziehen."
 
-#: lib/abuuba_web/live/settings_live.ex:1050
+#: lib/abuuba_web/live/settings_live.ex:1018
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:2008
+#: lib/abuuba_web/live/settings_live.ex:1950
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr "Was mit dem passieren soll, was schon da ist"
 
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2053
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr "Du bist vor Kurzem umgezogen. Ein Konto kann nur alle %{days} Tage umziehen."
@@ -3374,27 +3387,27 @@ msgstr "Du bist vor Kurzem umgezogen. Ein Konto kann nur alle %{days} Tage umzie
 msgid "No such post here."
 msgstr "So einen Beitrag gibt es hier nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:246
+#: lib/abuuba_web/live/settings_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr "Ein Link bekommt einen Haken, sobald die Seite, auf die er zeigt, mit rel=\"me\" auf dein Profil zurückverweist. Wir schauen etwa einmal pro Woche wieder nach."
 
-#: lib/abuuba_web/live/settings_live.ex:784
+#: lib/abuuba_web/live/settings_live.ex:794
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr "Ein Wort pro Zeile. Ein Beitrag passt, wenn eines davon darin vorkommt."
 
-#: lib/abuuba_web/live/settings_live.ex:797
+#: lib/abuuba_web/live/settings_live.ex:807
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr "Nur ganze Wörter, damit „Katze“ nicht auf „Katzenklo“ passt"
 
-#: lib/abuuba_web/live/settings_live.ex:781
+#: lib/abuuba_web/live/settings_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr "Wonach gesucht wird"
 
-#: lib/abuuba_web/live/settings_live.ex:1572
+#: lib/abuuba_web/live/settings_live.ex:1532
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr "Ein Filter braucht mindestens ein Wort, nach dem er suchen soll."
@@ -3404,54 +3417,54 @@ msgstr "Ein Filter braucht mindestens ein Wort, nach dem er suchen soll."
 msgid "Why they want to join:"
 msgstr "Warum die Person mitmachen möchte:"
 
-#: lib/abuuba_web/live/settings_live.ex:309
+#: lib/abuuba_web/live/settings_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] "%{count} Beitrag"
 msgstr[1] "%{count} Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:326
+#: lib/abuuba_web/live/settings_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr "Ein Hashtag, ohne das #"
 
-#: lib/abuuba_web/live/settings_live.ex:329
+#: lib/abuuba_web/live/settings_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Feature it"
 msgstr "Hervorheben"
 
-#: lib/abuuba_web/live/settings_live.ex:300
+#: lib/abuuba_web/live/settings_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr "Hervorgehobene Hashtags"
 
-#: lib/abuuba_web/live/settings_live.ex:302
+#: lib/abuuba_web/live/settings_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr "Stehen auf deinem Profil als Abkürzung zu dem, worüber du schreibst."
 
-#: lib/abuuba_web/live/settings_live.ex:1555
+#: lib/abuuba_web/live/settings_live.ex:1515
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr "Das ist kein Hashtag, den man benutzen kann."
 
-#: lib/abuuba_web/live/settings_live.ex:333
+#: lib/abuuba_web/live/settings_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr "Du schreibst oft über:"
 
-#: lib/abuuba_web/live/settings_live.ex:1549
+#: lib/abuuba_web/live/settings_live.ex:1509
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr "Ein Profil kann %{count} Hashtags tragen. Nimm zuerst einen weg."
 
-#: lib/abuuba_web/live/settings_live.ex:484
+#: lib/abuuba_web/live/settings_live.ex:494
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr "Sagen, aus welcher App du schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:486
+#: lib/abuuba_web/live/settings_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr "Steht für alle anderen unter deinen Beiträgen. An deinen eigenen siehst du es immer."
@@ -3599,7 +3612,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr "Jede Person muss es zusätzlich für sich selbst einschalten, und jede Adresse muss bestätigen, bevor irgendetwas dorthin geht."
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:647
+#: lib/abuuba_web/live/settings_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Email updates"
 msgstr "Neuigkeiten per E-Mail"
@@ -3614,7 +3627,7 @@ msgstr "Neuigkeiten per E-Mail von %{name}"
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr "Wenn du das nicht warst, kannst du diese Nachricht ignorieren. An diese Adresse geht dann nichts weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:665
+#: lib/abuuba_web/live/settings_live.ex:675
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr "Leute dürfen meine Neuigkeiten per E-Mail abonnieren"
@@ -3624,7 +3637,7 @@ msgstr "Leute dürfen meine Neuigkeiten per E-Mail abonnieren"
 msgid "No, remove my address"
 msgstr "Nein, meine Adresse löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:667
+#: lib/abuuba_web/live/settings_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3677,7 +3690,7 @@ msgstr "jemand hat diese Adresse angegeben, um Neuigkeiten von %{name} auf %{sit
 msgid "Let people collect email addresses for updates"
 msgstr "Erlaube es, E-Mail-Adressen für Neuigkeiten zu sammeln"
 
-#: lib/abuuba_web/live/settings_live.ex:649
+#: lib/abuuba_web/live/settings_live.ex:659
 #, elixir-autogen, elixir-format
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr "Wer hier kein Konto möchte, kann stattdessen eine E-Mail-Adresse angeben. Die Adresse bestätigt selbst und kann die Neuigkeiten aus jeder Nachricht heraus wieder abbestellen. Verschickt wird noch nichts; das hier sammelt die Liste."
@@ -3825,75 +3838,79 @@ msgstr "jemand hat für dein Konto auf %{site} ein neues Passwort angefordert. W
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr "das Passwort deines Kontos auf %{site} wurde gerade geändert, und überall, wo du angemeldet warst, wurdest du abgemeldet."
 
-#: lib/abuuba_web/live/settings_live.ex:1127
+#: lib/abuuba_web/live/settings_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr "Eine Kopie von allem"
 
-#: lib/abuuba_web/live/settings_live.ex:2329
+#: lib/abuuba_web/live/settings_live.ex:2271
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr "Wird gebaut"
 
-#: lib/abuuba_web/live/settings_live.ex:812
-#: lib/abuuba_web/live/settings_live.ex:2323
+#: lib/abuuba_web/live/settings_live.ex:822
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr "Blockierte Server"
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2320
+#: lib/abuuba_web/live/settings_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr "Blockierte"
 
-#: lib/abuuba_web/live/settings_live.ex:2324
+#: lib/abuuba_web/components/layouts.ex:148
+#: lib/abuuba_web/live/saved_live.ex:88
+#: lib/abuuba_web/live/saved_live.ex:94
+#: lib/abuuba_web/live/settings_live.ex:218
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/abuuba_web/live/settings_live.ex:1169
+#: lib/abuuba_web/live/settings_live.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr "Bau mir eine Kopie"
 
-#: lib/abuuba_web/live/settings_live.ex:2331
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr "Hat nicht geklappt"
 
-#: lib/abuuba_web/live/settings_live.ex:1152
+#: lib/abuuba_web/live/settings_live.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr "Herunterladen"
 
-#: lib/abuuba_web/live/settings_live.ex:2188
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr "Exportieren"
 
-#: lib/abuuba_web/live/settings_live.ex:2321
+#: lib/abuuba_web/live/settings_live.ex:2263
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr "Stummgeschaltete"
 
-#: lib/abuuba_web/live/settings_live.ex:1116
+#: lib/abuuba_web/live/settings_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr "Je eine Datei, im Format, das der Import dieses Servers liest. Ein Export von hier ist ein Import anderswo."
 
-#: lib/abuuba_web/live/settings_live.ex:1445
+#: lib/abuuba_web/live/settings_live.ex:1405
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr "Eine wird gerade schon gebaut."
 
-#: lib/abuuba_web/live/settings_live.ex:1134
+#: lib/abuuba_web/live/settings_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr "Bilder und Videos sind nicht in der Datei. Sie enthält ihre Adressen, die funktionieren, solange dieser Server läuft."
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr "Fertig"
@@ -3913,13 +3930,13 @@ msgstr "Die Datei wird nach %{days} Tagen gelöscht, weil sie dein ganzes Konto 
 msgid "There is nothing of that kind to export."
 msgstr "So etwas gibt es hier nicht zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:2328
+#: lib/abuuba_web/live/settings_live.ex:2270
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr "Wartet auf den Start"
 
-#: lib/abuuba_web/live/settings_live.ex:1158
-#: lib/abuuba_web/live/settings_live.ex:1451
+#: lib/abuuba_web/live/settings_live.ex:1126
+#: lib/abuuba_web/live/settings_live.ex:1411
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr "Ab %{date} kannst du eine neue anfordern."
@@ -3929,7 +3946,7 @@ msgstr "Ab %{date} kannst du eine neue anfordern."
 msgid "Your archive is ready"
 msgstr "Deine Kopie ist fertig"
 
-#: lib/abuuba_web/live/settings_live.ex:1129
+#: lib/abuuba_web/live/settings_live.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wird im Hintergrund gebaut; wir schicken dir eine E-Mail, wenn sie fertig ist."
@@ -3939,67 +3956,67 @@ msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wi
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr "die Kopie deines Kontos auf %{site}, die du angefordert hast, ist fertig. Hier herunterladen:"
 
-#: lib/abuuba_web/live/settings_live.ex:1208
+#: lib/abuuba_web/live/settings_live.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr "Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1206
+#: lib/abuuba_web/live/settings_live.ex:1174
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr "Das Konto endgültig schließen? Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1172
+#: lib/abuuba_web/live/settings_live.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr "Dieses Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1111
+#: lib/abuuba_web/live/settings_live.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr "Alles hier gehört dir, und das Konto zu schließen ist deine Entscheidung."
 
-#: lib/abuuba_web/live/settings_live.ex:2220
+#: lib/abuuba_web/live/settings_live.ex:2162
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr "Eine Kopie von allem mitnehmen, oder das Konto endgültig schließen."
 
-#: lib/abuuba_web/live/settings_live.ex:1189
+#: lib/abuuba_web/live/settings_live.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr "Hol dir vorher deine Kopie. Danach gibt es nichts mehr zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:1478
+#: lib/abuuba_web/live/settings_live.ex:1438
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr "Das hat nicht geklappt. Es wurde nichts gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:1475
+#: lib/abuuba_web/live/settings_live.ex:1435
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr "Das ist nicht dein Passwort."
 
-#: lib/abuuba_web/live/settings_live.ex:1179
+#: lib/abuuba_web/live/settings_live.ex:1147
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr "Das Konto verschwindet sofort. Die Datensätze werden kurz danach gelöscht, damit die Nachricht an die anderen Server noch signiert und verschickt werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1471
+#: lib/abuuba_web/live/settings_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr "Das Konto ist geschlossen. Danke, dass du hier warst."
 
-#: lib/abuuba_web/live/settings_live.ex:1194
+#: lib/abuuba_web/live/settings_live.ex:1162
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr "Dein Passwort, damit sicher ist, dass du es bist"
 
-#: lib/abuuba_web/live/settings_live.ex:1174
+#: lib/abuuba_web/live/settings_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr "Deine Beiträge, Folge-Beziehungen, Listen, Filter, Lesezeichen und Einstellungen werden gelöscht, und andere Server werden aufgefordert, ihre Kopien zu löschen. Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1184
+#: lib/abuuba_web/live/settings_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr "Dein Benutzername bleibt und niemand kann ihn je bekommen, damit alte Links und Erwähnungen von dir nie auf jemand anderen zeigen."
@@ -4009,7 +4026,7 @@ msgstr "Dein Benutzername bleibt und niemand kann ihn je bekommen, damit alte Li
 msgid "A post"
 msgstr "Ein Beitrag"
 
-#: lib/abuuba_web/live/profile_live.ex:397
+#: lib/abuuba_web/live/profile_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Nobody yet."
 msgstr "Noch niemand."
@@ -4019,7 +4036,7 @@ msgstr "Noch niemand."
 msgid "Public posts tagged #%{tag}"
 msgstr "Öffentliche Beiträge mit #%{tag}"
 
-#: lib/abuuba_web/live/profile_live.ex:374
+#: lib/abuuba_web/live/profile_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr "Dieses Konto behält für sich, wem es folgt und wer ihm folgt."
@@ -4045,99 +4062,99 @@ msgstr "Diese Einladung kennen wir nicht."
 msgid "You can still sign up without one."
 msgstr "Du kannst dich trotzdem ohne eine anmelden."
 
-#: lib/abuuba_web/live/settings_live.ex:1507
+#: lib/abuuba_web/live/settings_live.ex:1467
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr "Ein Alter muss mindestens 7 Tage betragen, und die Anzahlen dürfen nicht negativ sein."
 
-#: lib/abuuba_web/live/settings_live.ex:964
+#: lib/abuuba_web/live/settings_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr "Gescheiterte Versuche stehen hier ebenfalls. Dass jemand anderes dein Passwort probiert, sollte man früh mitbekommen, und nichts sonst würde es dir sagen."
 
-#: lib/abuuba_web/live/settings_live.ex:525
+#: lib/abuuba_web/live/settings_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr "Meine alten Beiträge löschen"
 
-#: lib/abuuba_web/live/settings_live.ex:534
+#: lib/abuuba_web/live/settings_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr "Beiträge löschen, die älter sind als, in Tagen"
 
-#: lib/abuuba_web/live/settings_live.ex:553
+#: lib/abuuba_web/live/settings_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr "Angeheftete Beiträge behalten"
 
-#: lib/abuuba_web/live/settings_live.ex:580
+#: lib/abuuba_web/live/settings_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr "Beiträge behalten, die mindestens so oft geboostet wurden"
 
-#: lib/abuuba_web/live/settings_live.ex:569
+#: lib/abuuba_web/live/settings_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr "Beiträge behalten, die mindestens so oft favorisiert wurden"
 
-#: lib/abuuba_web/live/settings_live.ex:565
+#: lib/abuuba_web/live/settings_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr "Beiträge mit Bildern oder Video behalten"
 
-#: lib/abuuba_web/live/settings_live.ex:987
+#: lib/abuuba_web/live/settings_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr "Wird %{days} Tage aufgehoben und dann gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:522
+#: lib/abuuba_web/live/settings_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Nothing pinned."
 msgstr "Nichts angeheftet."
 
-#: lib/abuuba_web/live/settings_live.ex:983
+#: lib/abuuba_web/live/settings_live.ex:951
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr "Noch nichts aufgezeichnet."
 
-#: lib/abuuba_web/live/settings_live.ex:527
+#: lib/abuuba_web/live/settings_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr "Aus, solange du es nicht einschaltest. Lass das Alter leer, um es wieder auszuschalten; bis du eines setzt, wird nichts gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:591
+#: lib/abuuba_web/live/settings_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] "Ein Beitrag passt gerade auf diese Einstellungen."
 msgstr[1] "%{count} Beiträge passen gerade auf diese Einstellungen."
 
-#: lib/abuuba_web/live/settings_live.ex:502
+#: lib/abuuba_web/live/settings_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Pinned posts"
 msgstr "Angeheftete Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:962
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr "Letzte Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:972
+#: lib/abuuba_web/live/settings_live.ex:940
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr "Abgelehnt"
 
-#: lib/abuuba_web/live/settings_live.ex:972
+#: lib/abuuba_web/live/settings_live.ex:940
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr "Angemeldet"
 
-#: lib/abuuba_web/live/settings_live.ex:516
+#: lib/abuuba_web/live/settings_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr "Lösen"
 
-#: lib/abuuba_web/live/settings_live.ex:504
+#: lib/abuuba_web/live/settings_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr "Was oben auf deinem Profil steht. Angeheftet wird vom Beitrag aus."
@@ -4846,6 +4863,7 @@ msgid "There is no list of that kind."
 msgstr "So eine Liste gibt es nicht."
 
 #: lib/abuuba_web/live/admin_live.ex:1329
+#: lib/abuuba_web/live/saved_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Which list"
 msgstr "Welche Liste"
@@ -4949,55 +4967,55 @@ msgid_plural "%{count} signed up"
 msgstr[0] "eine Anmeldung"
 msgstr[1] "%{count} Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr "Profilbild"
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr "Titelbild"
 
-#: lib/abuuba_web/live/settings_live.ex:348
+#: lib/abuuba_web/live/settings_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr "JPEG, PNG, GIF oder WebP, bis %{size}. Größere werden schon vor dem Hochladen abgelehnt und nicht erst danach, und was du schickst, wird hier verkleinert, damit niemand ein ganzes Foto lädt, um es bei vierzig Pixeln zu sehen."
 
 #: lib/abuuba_web/live/admin_live.ex:565
-#: lib/abuuba_web/live/settings_live.ex:366
+#: lib/abuuba_web/live/settings_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "None yet."
 msgstr "Noch keins."
 
-#: lib/abuuba_web/live/settings_live.ex:2139
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr "Ein Bild auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:346
+#: lib/abuuba_web/live/settings_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr "Bilder"
 
-#: lib/abuuba_web/live/settings_live.ex:398
+#: lib/abuuba_web/live/settings_live.ex:408
 #, elixir-autogen, elixir-format
 msgid "Take it off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2137
-#: lib/abuuba_web/live/settings_live.ex:2292
+#: lib/abuuba_web/live/settings_live.ex:2079
+#: lib/abuuba_web/live/settings_live.ex:2234
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr "Damit kann dieser Server nichts anfangen. Versuch es mit JPEG, PNG, GIF oder WebP."
 
-#: lib/abuuba_web/live/settings_live.ex:2287
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2236
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr "Dieses Bild konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2076
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr "Dieses Bild ist zu groß. Die Grenze steht eine Zeile weiter oben."
@@ -5007,8 +5025,8 @@ msgstr "Dieses Bild ist zu groß. Die Grenze steht eine Zeile weiter oben."
 msgid "Feature on my profile"
 msgstr "Auf meinem Profil hervorheben"
 
-#: lib/abuuba_web/live/profile_live.ex:320
-#: lib/abuuba_web/live/profile_live.ex:324
+#: lib/abuuba_web/live/profile_live.ex:326
+#: lib/abuuba_web/live/profile_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "Featured accounts"
 msgstr "Hervorgehobene Konten"
@@ -5018,55 +5036,55 @@ msgstr "Hervorgehobene Konten"
 msgid "Stop featuring"
 msgstr "Nicht mehr hervorheben"
 
-#: lib/abuuba_web/live/profile_live.ex:493
+#: lib/abuuba_web/live/profile_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr "Schau in dieses Postfach: Dort liegt eine Nachricht mit der Bitte um Bestätigung."
 
-#: lib/abuuba_web/live/profile_live.ex:274
+#: lib/abuuba_web/live/profile_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr "Neuigkeiten von %{name} per E-Mail"
 
-#: lib/abuuba_web/live/settings_live.ex:682
+#: lib/abuuba_web/live/settings_live.ex:692
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr "Geht an jede bestätigte Adresse, mit einem Link, der die Neuigkeiten beendet. Bis zu %{count} Nachrichten am Tag."
 
-#: lib/abuuba_web/live/profile_live.ex:277
+#: lib/abuuba_web/live/profile_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr "Kein Konto nötig. Wir schreiben einmal an die Adresse, um zu prüfen, ob sie dir gehört, und in jeder Nachricht steht ein Link, der die Neuigkeiten beendet."
 
-#: lib/abuuba_web/live/settings_live.ex:707
+#: lib/abuuba_web/live/settings_live.ex:717
 #, elixir-autogen, elixir-format
 msgid "Send it"
 msgstr "Abschicken"
 
-#: lib/abuuba_web/live/profile_live.ex:293
+#: lib/abuuba_web/live/profile_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr "Neuigkeiten schicken"
 
-#: lib/abuuba_web/live/settings_live.ex:716
+#: lib/abuuba_web/live/settings_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] "Am %{date} an eine Adresse geschickt."
 msgstr[1] "Am %{date} an %{count} Adressen geschickt."
 
-#: lib/abuuba_web/live/settings_live.ex:693
-#: lib/abuuba_web/live/settings_live.ex:1866
+#: lib/abuuba_web/live/settings_live.ex:703
+#: lib/abuuba_web/live/settings_live.ex:1808
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Betreff"
 
-#: lib/abuuba_web/live/profile_live.ex:496
+#: lib/abuuba_web/live/profile_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr "Das sieht nicht nach einer gültigen E-Mail-Adresse aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1426
+#: lib/abuuba_web/live/settings_live.ex:1386
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr "Diese Liste ist nicht offen."
@@ -5076,17 +5094,17 @@ msgstr "Diese Liste ist nicht offen."
 msgid "To stop them, open this link:"
 msgstr "Zum Beenden diesen Link öffnen:"
 
-#: lib/abuuba_web/live/profile_live.ex:483
+#: lib/abuuba_web/live/profile_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr "Gerade zu viele Versuche von hier. Bitte später noch einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:700
+#: lib/abuuba_web/live/settings_live.ex:710
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr "Was du ihnen sagen möchtest"
 
-#: lib/abuuba_web/live/settings_live.ex:680
+#: lib/abuuba_web/live/settings_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr "An sie schreiben"
@@ -5096,22 +5114,22 @@ msgstr "An sie schreiben"
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr "Du bekommst das, weil du auf %{site} um Neuigkeiten von %{name} gebeten hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1431
+#: lib/abuuba_web/live/settings_live.ex:1391
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr "Du hast heute schon so viele Nachrichten geschickt, wie du kannst."
 
-#: lib/abuuba_web/live/profile_live.ex:286
+#: lib/abuuba_web/live/profile_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr "du@example.com"
 
-#: lib/abuuba_web/live/settings_live.ex:1867
+#: lib/abuuba_web/live/settings_live.ex:1809
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
 
-#: lib/abuuba_web/live/settings_live.ex:723
+#: lib/abuuba_web/live/settings_live.ex:733
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr "Unterwegs."
@@ -5200,6 +5218,8 @@ msgid "Ready-made texts a moderator picks instead of retyping. Kept for the serv
 msgstr "Fertige Texte, die man auswählt, statt sie neu zu tippen. Sie gehören zum Server und nicht zu einer einzelnen moderierenden Person, damit zwei Leute zur selben Sache dasselbe schreiben."
 
 #: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/profile_live.ex:202
+#: lib/abuuba_web/live/report_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr "Meldung"
@@ -5397,7 +5417,7 @@ msgstr "Deine Unterhaltungen als gelesen markieren"
 msgid "Mute and unmute people for you"
 msgstr "Leute für dich stummschalten und wieder lautstellen"
 
-#: lib/abuuba_web/live/settings_live.ex:1010
+#: lib/abuuba_web/live/settings_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr "Nichts. Sie sieht nur, dass du angemeldet bist, sonst nichts."
@@ -5545,42 +5565,42 @@ msgstr "Das Bild wird noch hochgeladen. Gleich noch einmal versuchen."
 msgid "not offered"
 msgstr "nicht angeboten"
 
-#: lib/abuuba_web/live/profile_live.ex:243
+#: lib/abuuba_web/live/profile_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr "Keine auszuwählen heißt: alles, was sie schreiben."
 
-#: lib/abuuba_web/live/profile_live.ex:241
+#: lib/abuuba_web/live/profile_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr "Nur diese Sprachen"
 
-#: lib/abuuba_web/live/profile_live.ex:220
+#: lib/abuuba_web/live/profile_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr "Ihre Weitergaben anderer Leute"
 
-#: lib/abuuba_web/live/profile_live.ex:205
+#: lib/abuuba_web/live/profile_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr "Was du von ihnen siehst"
 
-#: lib/abuuba_web/components/status_component.ex:487
+#: lib/abuuba_web/components/status_component.ex:507
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr "Mehr"
 
-#: lib/abuuba_web/components/status_component.ex:499
+#: lib/abuuba_web/components/status_component.ex:520
 #, elixir-autogen, elixir-format
 msgid "Mute this conversation"
 msgstr "Diese Unterhaltung stummschalten"
 
-#: lib/abuuba_web/components/status_component.ex:506
+#: lib/abuuba_web/components/status_component.ex:527
 #, elixir-autogen, elixir-format
 msgid "Stops its notifications and takes it out of your timeline. Nobody is told."
 msgstr "Beendet die Benachrichtigungen und nimmt sie aus deiner Timeline. Niemand erfährt es."
 
-#: lib/abuuba_web/components/status_component.ex:498
+#: lib/abuuba_web/components/status_component.ex:519
 #, elixir-autogen, elixir-format
 msgid "Unmute this conversation"
 msgstr "Stummschaltung dieser Unterhaltung aufheben"
@@ -5590,7 +5610,7 @@ msgstr "Stummschaltung dieser Unterhaltung aufheben"
 msgid "Posts from people you watch"
 msgstr "Beiträge von Leuten, die du beobachtest"
 
-#: lib/abuuba_web/live/profile_live.ex:235
+#: lib/abuuba_web/live/profile_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr "Sag mir Bescheid, wenn sie etwas posten"
@@ -5655,7 +5675,7 @@ msgstr "ausgeschaltet"
 msgid "Mark unread"
 msgstr "Als ungelesen markieren"
 
-#: lib/abuuba_web/components/layouts.ex:243
+#: lib/abuuba_web/components/layouts.ex:267
 #: lib/abuuba_web/live/conversations_live.ex:46
 #: lib/abuuba_web/live/conversations_live.ex:62
 #, elixir-autogen, elixir-format
@@ -5749,22 +5769,22 @@ msgstr "Niemand: der Server sagt es nicht"
 msgid "Who may read the blocklist"
 msgstr "Wer die Sperrliste lesen darf"
 
-#: lib/abuuba_web/live/settings_live.ex:637
+#: lib/abuuba_web/live/settings_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr "Eine Domain pro Zeile. Wird hier ein Link auf eine dieser Seiten geteilt, weist die Vorschau dich als Urheberin oder Urheber aus. Eine Seite, die du nicht eingetragen hast, kann dich nicht für sich beanspruchen, egal was in ihrer Seitenquelle steht."
 
-#: lib/abuuba_web/live/settings_live.ex:629
+#: lib/abuuba_web/live/settings_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr "Seiten, die mich als Autorin oder Autor nennen dürfen"
 
-#: lib/abuuba_web/live/settings_live.ex:841
+#: lib/abuuba_web/live/settings_live.ex:851
 #, elixir-autogen, elixir-format
 msgid "Block a server"
 msgstr "Server blockieren"
 
-#: lib/abuuba_web/live/settings_live.ex:814
+#: lib/abuuba_web/live/settings_live.ex:824
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht deine Timelines, deine Suche, deine Threads oder deine Benachrichtigungen. Folge-Beziehungen in beide Richtungen werden aufgelöst, genau wie beim Blockieren einer einzelnen Person."
@@ -5775,7 +5795,7 @@ msgid "Too many sign-ups from here just now. Please try again later."
 msgstr "Zu viele Anmeldungen von hier im Moment. Bitte versuche es später noch einmal."
 
 #: lib/abuuba_web/live/explore_live.ex:149
-#: lib/abuuba_web/live/profile_live.ex:534
+#: lib/abuuba_web/live/profile_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr "Zu viele Follows für heute. Versuche es morgen noch einmal."
@@ -5840,8 +5860,8 @@ msgstr "Stattgeben und rückgängig machen"
 msgid "Warned"
 msgstr "Verwarnt"
 
-#: lib/abuuba_web/live/settings_live.ex:2312
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2254
+#: lib/abuuba_web/live/settings_live.ex:2257
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr "%{size} MB"
@@ -5856,18 +5876,18 @@ msgstr "Folgeanfrage zurückziehen"
 msgid "Requested"
 msgstr "Angefragt"
 
-#: lib/abuuba_web/live/profile_live.ex:544
+#: lib/abuuba_web/live/profile_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr "Dieses Konto bestätigt seine Follower selbst. Deine Anfrage wartet auf eine Antwort."
 
-#: lib/abuuba_web/components/status_component.ex:451
+#: lib/abuuba_web/components/status_component.ex:459
 #, elixir-autogen, elixir-format
 msgid "Delete this post? Other servers are told to forget it too."
 msgstr "Diesen Beitrag löschen? Andere Server werden aufgefordert, ihre Kopie ebenfalls zu löschen."
 
-#: lib/abuuba_web/components/layouts.ex:145
-#: lib/abuuba_web/live/settings_live.ex:953
+#: lib/abuuba_web/components/layouts.ex:155
+#: lib/abuuba_web/live/settings_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr "Abmelden"
@@ -5877,22 +5897,213 @@ msgstr "Abmelden"
 msgid "That post is gone."
 msgstr "Der Beitrag ist gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:876
+#: lib/abuuba_web/live/follow_requests_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Let them follow"
 msgstr "Folgen lassen"
 
-#: lib/abuuba_web/live/settings_live.ex:885
+#: lib/abuuba_web/live/follow_requests_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Turn them away"
 msgstr "Ablehnen"
 
-#: lib/abuuba_web/live/settings_live.ex:853
-#, elixir-autogen, elixir-format
-msgid "Waiting for your answer"
-msgstr "Wartet auf deine Antwort"
-
-#: lib/abuuba_web/live/settings_live.ex:855
+#: lib/abuuba_web/live/follow_requests_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Your account asks before letting somebody follow it. Turning one away tells them nothing, and they can ask again."
 msgstr "Dein Konto fragt nach, bevor dir jemand folgen darf. Wer abgelehnt wird, erfährt nichts davon und kann erneut anfragen."
+
+#: lib/abuuba_web/live/report_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Anything else a moderator should know?"
+msgstr "Sollte die Moderation noch etwas wissen?"
+
+#: lib/abuuba_web/live/report_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "Are there posts that show it?"
+msgstr "Gibt es Beiträge, die das zeigen?"
+
+#: lib/abuuba_web/live/report_live.ex:297
+#, elixir-autogen, elixir-format
+msgid "Blocked"
+msgstr "Blockiert"
+
+#: lib/abuuba_web/live/report_live.ex:303
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr "Fertig"
+
+#: lib/abuuba_web/live/report_live.ex:287
+#, elixir-autogen, elixir-format
+msgid "Everything mute does, and they cannot follow you or read your posts. They can tell."
+msgstr "Alles, was Stummschalten tut, und zusätzlich: Die Person kann dir nicht folgen und deine Beiträge nicht lesen. Sie merkt es."
+
+#: lib/abuuba_web/live/report_live.ex:374
+#, elixir-autogen, elixir-format
+msgid "I do not like it"
+msgstr "Ich mag es nicht"
+
+#: lib/abuuba_web/live/report_live.ex:217
+#, elixir-autogen, elixir-format
+msgid "In your own words. This is optional."
+msgstr "In deinen eigenen Worten. Freiwillig."
+
+#: lib/abuuba_web/live/report_live.ex:180
+#, elixir-autogen, elixir-format
+msgid "Include this post"
+msgstr "Diesen Beitrag mitschicken"
+
+#: lib/abuuba_web/live/report_live.ex:392
+#, elixir-autogen, elixir-format
+msgid "It breaks the rules of this server"
+msgstr "Es verstößt gegen die Regeln dieses Servers"
+
+#: lib/abuuba_web/live/report_live.ex:384
+#, elixir-autogen, elixir-format
+msgid "It does not fit any of the above."
+msgstr "Es passt in keine der Kategorien darüber."
+
+#: lib/abuuba_web/live/report_live.ex:378
+#, elixir-autogen, elixir-format
+msgid "It is illegal"
+msgstr "Es ist illegal"
+
+#: lib/abuuba_web/live/report_live.ex:375
+#, elixir-autogen, elixir-format
+msgid "It is not something you want to see. This tells nobody."
+msgstr "Es ist einfach nichts, was du sehen willst. Davon erfährt niemand."
+
+#: lib/abuuba_web/live/report_live.ex:376
+#, elixir-autogen, elixir-format
+msgid "It is spam"
+msgstr "Es ist Spam"
+
+#: lib/abuuba_web/live/settings_live.ex:217
+#, elixir-autogen, elixir-format
+msgid "Looking for what you saved?"
+msgstr "Suchst du, was du dir gemerkt hast?"
+
+#: lib/abuuba_web/live/report_live.ex:377
+#, elixir-autogen, elixir-format
+msgid "Malicious links, fake engagement, or the same thing over and over."
+msgstr "Schädliche Links, gekaufte Reichweite oder immer wieder dasselbe."
+
+#: lib/abuuba_web/live/report_live.ex:280
+#, elixir-autogen, elixir-format
+msgid "Muted"
+msgstr "Stummgeschaltet"
+
+#: lib/abuuba_web/live/report_live.ex:258
+#, elixir-autogen, elixir-format
+msgid "Neither of these tells a moderator anything."
+msgstr "Beides erfährt die Moderation nicht."
+
+#: lib/abuuba_web/live/report_live.ex:155
+#: lib/abuuba_web/live/report_live.ex:199
+#, elixir-autogen, elixir-format
+msgid "Next"
+msgstr "Weiter"
+
+#: lib/abuuba_web/live/follow_requests_live.ex:53
+#, elixir-autogen, elixir-format
+msgid "Nobody is waiting. Anybody who asks to follow you turns up here."
+msgstr "Niemand wartet. Wer dir folgen möchte, taucht hier auf."
+
+#: lib/abuuba_web/live/saved_live.ex:101
+#, elixir-autogen, elixir-format
+msgid "Nothing bookmarked yet. The bookmark under a post files it here, and tells nobody."
+msgstr "Noch keine Lesezeichen. Das Lesezeichen unter einem Beitrag legt ihn hier ab, und niemand erfährt davon."
+
+#: lib/abuuba_web/live/saved_live.ex:105
+#, elixir-autogen, elixir-format
+msgid "Nothing favourited yet. The star under a post lands here, and its author is told."
+msgstr "Noch keine Favoriten. Der Stern unter einem Beitrag landet hier, und die verfassende Person erfährt davon."
+
+#: lib/abuuba_web/live/report_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "Nothing of theirs is here to point at."
+msgstr "Es gibt hier nichts von dieser Person zu zeigen."
+
+#: lib/abuuba_web/live/report_live.ex:94
+#, elixir-autogen, elixir-format
+msgid "Report %{name}"
+msgstr "%{name} melden"
+
+#: lib/abuuba_web/components/status_component.ex:538
+#, elixir-autogen, elixir-format
+msgid "Report this post"
+msgstr "Diesen Beitrag melden"
+
+#: lib/abuuba_web/live/report_live.ex:237
+#, elixir-autogen, elixir-format
+msgid "Send the report"
+msgstr "Meldung abschicken"
+
+#: lib/abuuba_web/live/report_live.ex:383
+#, elixir-autogen, elixir-format
+msgid "Something else"
+msgstr "Etwas anderes"
+
+#: lib/abuuba_web/live/report_live.ex:251
+#, elixir-autogen, elixir-format
+msgid "Thank you. A moderator will read this."
+msgstr "Danke. Die Moderation liest das."
+
+#: lib/abuuba_web/live/report_live.ex:265
+#, elixir-autogen, elixir-format
+msgid "Their posts leave your home timeline. They keep following you."
+msgstr "Ihre Beiträge verschwinden aus deiner Startseite. Sie folgt dir weiterhin."
+
+#: lib/abuuba_web/live/report_live.ex:252
+#, elixir-autogen, elixir-format
+msgid "Then here is what you can do yourself."
+msgstr "Dann kannst du selbst etwas tun."
+
+#: lib/abuuba_web/live/report_live.ex:230
+#, elixir-autogen, elixir-format
+msgid "This account is on %{domain}. Send a copy of this report there as well, without your name."
+msgstr "Dieses Konto liegt auf %{domain}. Eine Kopie der Meldung ohne deinen Namen auch dorthin schicken."
+
+#: lib/abuuba_web/live/report_live.ex:169
+#, elixir-autogen, elixir-format
+msgid "Tick every one a moderator should read. You can tick none."
+msgstr "Kreuz alles an, was die Moderation lesen sollte. Nichts anzukreuzen ist auch in Ordnung."
+
+#: lib/abuuba_web/live/report_live.ex:139
+#, elixir-autogen, elixir-format
+msgid "Tick every one that applies."
+msgstr "Kreuz alles an, was zutrifft."
+
+#: lib/abuuba_web/live/report_live.ex:113
+#, elixir-autogen, elixir-format
+msgid "What is going on?"
+msgstr "Worum geht es?"
+
+#: lib/abuuba_web/live/report_live.ex:138
+#, elixir-autogen, elixir-format
+msgid "Which rules?"
+msgstr "Gegen welche Regeln?"
+
+#: lib/abuuba_web/live/report_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "While you wait, you do not have to keep seeing them."
+msgstr "Bis dahin musst du die Person nicht weiter sehen."
+
+#: lib/abuuba_web/live/report_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "You believe it breaks the law here or where you are."
+msgstr "Du glaubst, es verstößt gegen das Recht hier oder bei dir."
+
+#: lib/abuuba_web/live/report_live.ex:393
+#, elixir-autogen, elixir-format
+msgid "You know which rule it breaks."
+msgstr "Du weißt, gegen welche Regel es verstößt."
+
+#: lib/abuuba_web/live/report_live.ex:275
+#, elixir-autogen, elixir-format
+msgid "You stop seeing them everywhere. They can still follow you and are not told."
+msgstr "Du siehst die Person nirgends mehr. Sie kann dir weiter folgen und erfährt nichts davon."
+
+#: lib/abuuba_web/live/settings_live.ex:219
+#, elixir-autogen, elixir-format
+msgid "and"
+msgstr "und"

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -287,7 +287,7 @@ msgid "You are signed out."
 msgstr "Du bist abgemeldet."
 
 #: lib/abuuba_web/user_auth.ex:88
-#: lib/abuuba_web/user_auth.ex:205
+#: lib/abuuba_web/user_auth.ex:206
 #, elixir-autogen, elixir-format
 msgid "You have to be signed in to see that page."
 msgstr "Du musst angemeldet sein, um diese Seite zu sehen."
@@ -420,7 +420,7 @@ msgstr "Einschalten"
 msgid "Turn off two-factor authentication?"
 msgstr "Zwei-Faktor-Authentifizierung ausschalten?"
 
-#: lib/abuuba_web/live/settings_live.ex:902
+#: lib/abuuba_web/live/settings_live.ex:944
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -656,7 +656,7 @@ msgstr "Diese Anfrage muss signiert sein."
 
 #: lib/abuuba_web/components/layouts.ex:247
 #: lib/abuuba_web/components/layouts.ex:256
-#: lib/abuuba_web/live/explore_live.ex:49
+#: lib/abuuba_web/live/explore_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr "Entdecken"
@@ -664,7 +664,7 @@ msgstr "Entdecken"
 #: lib/abuuba_web/components/layouts.ex:234
 #: lib/abuuba_web/components/layouts.ex:255
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2318
+#: lib/abuuba_web/live/settings_live.ex:2388
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
@@ -691,14 +691,14 @@ msgstr "Hauptnavigation"
 #: lib/abuuba_web/components/layouts.ex:237
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2319
+#: lib/abuuba_web/live/settings_live.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr "Mitteilungen"
 
 #: lib/abuuba_web/components/layouts.ex:249
 #: lib/abuuba_web/live/settings_live.ex:121
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2197
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -849,19 +849,19 @@ msgid "Allow more than one choice"
 msgstr "Mehrfachauswahl erlauben"
 
 #: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2313
+#: lib/abuuba_web/live/settings_live.ex:2383
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr "Alle"
 
 #: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2308
+#: lib/abuuba_web/live/settings_live.ex:2378
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr "Alle, und überall gelistet"
 
 #: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2309
+#: lib/abuuba_web/live/settings_live.ex:2379
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr "Alle, aber nicht in öffentlichen Timelines"
@@ -916,13 +916,13 @@ msgstr "Erwähnte Personen"
 
 #: lib/abuuba_web/live/admin_live.ex:3427
 #: lib/abuuba_web/live/compose_component.ex:1677
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr "Niemand"
 
 #: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/settings_live.ex:2310
+#: lib/abuuba_web/live/settings_live.ex:2380
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr "Nur die Leute, die dir folgen"
@@ -933,7 +933,7 @@ msgid "Only the people you name"
 msgstr "Nur die Leute, die du nennst"
 
 #: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2384
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr "Leute, die dir folgen"
@@ -1216,9 +1216,9 @@ msgstr "Eine Notiz, die nur du liest"
 msgid "Block"
 msgstr "Blockieren"
 
-#: lib/abuuba_web/live/explore_live.ex:113
+#: lib/abuuba_web/live/explore_live.ex:114
 #: lib/abuuba_web/live/profile_live.ex:144
-#: lib/abuuba_web/live/tag_live.ex:62
+#: lib/abuuba_web/live/tag_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1254,7 +1254,7 @@ msgstr "Hier ist noch nichts."
 msgid "Pinned"
 msgstr "Angeheftet"
 
-#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/explore_live.ex:256
 #: lib/abuuba_web/live/profile_live.ex:789
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
@@ -1291,7 +1291,7 @@ msgid "Unblock"
 msgstr "Blockierung aufheben"
 
 #: lib/abuuba_web/live/profile_live.ex:162
-#: lib/abuuba_web/live/tag_live.ex:62
+#: lib/abuuba_web/live/tag_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Entfolgen"
@@ -1505,8 +1505,8 @@ msgstr "Folgeanfragen"
 
 #: lib/abuuba_web/live/notifications_live.ex:469
 #: lib/abuuba_web/live/profile_live.ex:793
-#: lib/abuuba_web/live/settings_live.ex:2111
-#: lib/abuuba_web/live/settings_live.ex:2249
+#: lib/abuuba_web/live/settings_live.ex:2181
+#: lib/abuuba_web/live/settings_live.ex:2319
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folge ich"
@@ -1581,7 +1581,7 @@ msgstr "Private Erwähnungen aus dem Nichts"
 #: lib/abuuba_web/live/settings_live.ex:598
 #: lib/abuuba_web/live/settings_live.ex:643
 #: lib/abuuba_web/live/settings_live.ex:676
-#: lib/abuuba_web/live/settings_live.ex:1004
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Speichern"
@@ -1647,7 +1647,7 @@ msgstr "Ein Name, ein #Tag oder ein paar Wörter"
 msgid "Everything"
 msgstr "Alles"
 
-#: lib/abuuba_web/live/explore_live.ex:250
+#: lib/abuuba_web/live/explore_live.ex:257
 #: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:207
@@ -1675,12 +1675,12 @@ msgstr "Eine Suche eingrenzen"
 msgid "Nobody has posted publicly here yet."
 msgstr "Hier hat noch niemand öffentlich etwas veröffentlicht."
 
-#: lib/abuuba_web/live/tag_live.ex:77
+#: lib/abuuba_web/live/tag_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted under this tag yet."
 msgstr "Unter diesem Tag hat noch niemand etwas veröffentlicht."
 
-#: lib/abuuba_web/live/explore_live.ex:123
+#: lib/abuuba_web/live/explore_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht haben."
@@ -1690,7 +1690,7 @@ msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht habe
 msgid "Nothing matched that."
 msgstr "Dazu gab es keine Treffer."
 
-#: lib/abuuba_web/live/explore_live.ex:251
+#: lib/abuuba_web/live/explore_live.ex:258
 #: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:206
@@ -1732,7 +1732,7 @@ msgstr "Suche"
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr "Dies ist ein Server im Fediverse: ein Netzwerk unabhängiger Server, deren Leute einander folgen und miteinander reden können, egal auf welchem sie sind. Ein Konto hier kann allen überall darin folgen."
 
-#: lib/abuuba_web/live/explore_live.ex:65
+#: lib/abuuba_web/live/explore_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "What to explore"
 msgstr "Was erkundet wird"
@@ -1757,7 +1757,7 @@ msgstr "Beiträge nach einem Datum"
 msgid "posts older than a date"
 msgstr "Beiträge vor einem Datum"
 
-#: lib/abuuba_web/live/settings_live.ex:893
+#: lib/abuuba_web/live/settings_live.ex:935
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr "Ein neues Passwort"
@@ -1768,7 +1768,7 @@ msgid "About you"
 msgstr "Über dich"
 
 #: lib/abuuba_web/live/admin_live.ex:3378
-#: lib/abuuba_web/live/settings_live.ex:2114
+#: lib/abuuba_web/live/settings_live.ex:2184
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Konto"
@@ -1783,37 +1783,37 @@ msgstr "Feld hinzufügen"
 msgid "Add a filter"
 msgstr "Filter hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:2107
+#: lib/abuuba_web/live/settings_live.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/abuuba_web/live/settings_live.ex:2285
+#: lib/abuuba_web/live/settings_live.ex:2355
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr "Gilt nur für deine öffentlichen Beiträge."
 
-#: lib/abuuba_web/live/settings_live.ex:2113
+#: lib/abuuba_web/live/settings_live.ex:2183
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/abuuba_web/live/settings_live.ex:2138
+#: lib/abuuba_web/live/settings_live.ex:2208
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr "Apps, die in dein Konto gelassen wurden."
 
-#: lib/abuuba_web/live/settings_live.ex:955
+#: lib/abuuba_web/live/settings_live.ex:997
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr "Apps, bei denen du angemeldet bist. Eine wieder hinauszunehmen meldet sie sofort ab."
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2350
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr "Vor jedem Follow fragen"
 
-#: lib/abuuba_web/live/settings_live.ex:897
+#: lib/abuuba_web/live/settings_live.ex:939
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr "Passwort ändern"
@@ -1830,22 +1830,22 @@ msgstr "Löschen"
 msgid "Display name"
 msgstr "Anzeigename"
 
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2366
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr "Medien nicht von selbst abspielen"
 
-#: lib/abuuba_web/live/settings_live.ex:1608
+#: lib/abuuba_web/live/settings_live.ex:1658
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr "Jede Zeile muss eine Webadresse sein, eine pro Zeile."
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr "Jeder Follow wird zu einer Anfrage, die du beantwortest."
 
-#: lib/abuuba_web/live/settings_live.ex:2136
+#: lib/abuuba_web/live/settings_live.ex:2206
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr "Allen, denen du folgst, und ein Weg, damit aufzuhören."
@@ -1860,33 +1860,33 @@ msgstr "Alles zu deinem Konto ist hier. Wähl einen Bereich."
 msgid "Fields"
 msgstr "Felder"
 
-#: lib/abuuba_web/live/settings_live.ex:2110
-#: lib/abuuba_web/live/settings_live.ex:2255
+#: lib/abuuba_web/live/settings_live.ex:2180
+#: lib/abuuba_web/live/settings_live.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/abuuba_web/live/settings_live.ex:2337
+#: lib/abuuba_web/live/settings_live.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr "Hinter einer Warnung zusammenklappen"
 
-#: lib/abuuba_web/live/settings_live.ex:2338
+#: lib/abuuba_web/live/settings_live.ex:2408
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr "Ganz ausblenden"
 
-#: lib/abuuba_web/live/settings_live.ex:2286
+#: lib/abuuba_web/live/settings_live.ex:2356
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr "Verbergen, wem ich folge und wer mir folgt"
 
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2364
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr "Mehr Kontrast"
 
-#: lib/abuuba_web/live/settings_live.ex:2132
+#: lib/abuuba_web/live/settings_live.ex:2202
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr "Wie sich die Oberfläche verhält und liest."
@@ -1896,17 +1896,17 @@ msgstr "Wie sich die Oberfläche verhält und liest."
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2284
+#: lib/abuuba_web/live/settings_live.ex:2354
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr "Suchmaschinen meine Beiträge indexieren lassen"
 
-#: lib/abuuba_web/live/settings_live.ex:2282
+#: lib/abuuba_web/live/settings_live.ex:2352
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr "Mich im Verzeichnis listen"
 
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/settings_live.ex:2359
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr "Markiert das Konto als Bot, worauf manche Leute filtern."
@@ -1916,12 +1916,12 @@ msgstr "Markiert das Konto als Bot, worauf manche Leute filtern."
 msgid "Move up"
 msgstr "Nach oben"
 
-#: lib/abuuba_web/live/settings_live.ex:984
+#: lib/abuuba_web/live/settings_live.ex:1026
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr "Es wurde keine App hereingelassen."
 
-#: lib/abuuba_web/live/settings_live.ex:998
+#: lib/abuuba_web/live/settings_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr "Eine Webadresse pro Zeile. Ein Konto hier zu nennen erlaubt dir später den Umzug dorthin, und es muss dieses hier zurücknennen."
@@ -1931,47 +1931,47 @@ msgstr "Eine Webadresse pro Zeile. Ein Konto hier zu nennen erlaubt dir später 
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr "Nur die genannten Leute fehlt mit Absicht: als Voreinstellung wird jeder Beitrag, den du zu ändern vergisst, zu einer Nachricht an niemanden."
 
-#: lib/abuuba_web/live/settings_live.ex:2139
+#: lib/abuuba_web/live/settings_live.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr "Deine anderen Konten und der Umzug zwischen ihnen."
 
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/settings_live.ex:2371
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr "Überschreibt deine Systemeinstellung, wenn sie für dich falsch ist."
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2175
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Überblick"
 
-#: lib/abuuba_web/live/settings_live.ex:2108
+#: lib/abuuba_web/live/settings_live.ex:2178
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2179
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2176
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/abuuba_web/live/settings_live.ex:2322
+#: lib/abuuba_web/live/settings_live.ex:2392
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
-#: lib/abuuba_web/live/settings_live.ex:2320
+#: lib/abuuba_web/live/settings_live.ex:2390
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr "Öffentliche Timelines"
 
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/settings_live.ex:2363
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr "Bewegung reduzieren"
@@ -1988,38 +1988,38 @@ msgstr "Bewegung reduzieren"
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2112
+#: lib/abuuba_web/live/settings_live.ex:2182
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr "Sicherheit"
 
-#: lib/abuuba_web/live/settings_live.ex:915
+#: lib/abuuba_web/live/settings_live.ex:957
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr "Überall abmelden"
 
-#: lib/abuuba_web/live/settings_live.ex:906
+#: lib/abuuba_web/live/settings_live.ex:948
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr "Überall abmelden beendet jede Sitzung, auch diese."
 
-#: lib/abuuba_web/live/settings_live.ex:2304
+#: lib/abuuba_web/live/settings_live.ex:2374
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr "Hält das erste Absenden an, wenn ein Bild keine Beschreibung hat."
 
-#: lib/abuuba_web/live/settings_live.ex:978
+#: lib/abuuba_web/live/settings_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr "Wieder hinausnehmen"
 
 #: lib/abuuba_web/live/admin_live.ex:3746
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2171
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr "Das konnte nicht gespeichert werden. Prüf, was du eingegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1583
+#: lib/abuuba_web/live/settings_live.ex:1633
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr "Das aktuelle Passwort stimmt nicht."
@@ -2029,27 +2029,27 @@ msgstr "Das aktuelle Passwort stimmt nicht."
 msgid "The language you usually write in"
 msgstr "Die Sprache, in der du meistens schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2357
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr "Die Listen sind nicht mehr öffentlich; die Follows selbst funktionieren weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/settings_live.ex:2358
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr "Dieses Konto veröffentlicht automatisch"
 
-#: lib/abuuba_web/live/settings_live.ex:2321
+#: lib/abuuba_web/live/settings_live.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr "Threads"
 
-#: lib/abuuba_web/live/settings_live.ex:851
+#: lib/abuuba_web/live/settings_live.ex:893
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr "Hak alle an, denen du nicht mehr folgen willst, und drück dann einmal den Knopf."
 
-#: lib/abuuba_web/live/settings_live.ex:876
+#: lib/abuuba_web/live/settings_live.ex:918
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr "Den angehakten entfolgen"
@@ -2059,7 +2059,7 @@ msgstr "Den angehakten entfolgen"
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr "Bis zu vier Zeilen auf deinem Profil. Die Reihenfolge hier ist die Reihenfolge dort."
 
-#: lib/abuuba_web/live/settings_live.ex:2295
+#: lib/abuuba_web/live/settings_live.ex:2365
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr "Die Schrift meines Systems verwenden"
@@ -2069,7 +2069,7 @@ msgstr "Die Schrift meines Systems verwenden"
 msgid "Value"
 msgstr "Wert"
 
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr "Mich auf fehlende Beschreibungen hinweisen"
@@ -2079,7 +2079,7 @@ msgstr "Mich auf fehlende Beschreibungen hinweisen"
 msgid "What it does"
 msgstr "Was er tut"
 
-#: lib/abuuba_web/live/settings_live.ex:2133
+#: lib/abuuba_web/live/settings_live.ex:2203
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr "Womit das Schreibfeld beginnt."
@@ -2095,7 +2095,7 @@ msgstr "Wie er heißen soll"
 msgid "Where it applies"
 msgstr "Wo er gilt"
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2204
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr "Wer dich finden kann und wer fragen muss, um zu folgen."
@@ -2110,37 +2110,37 @@ msgstr "Wer neue Beiträge zitieren darf"
 msgid "Who new posts go to"
 msgstr "An wen neue Beiträge gehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2135
+#: lib/abuuba_web/live/settings_live.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr "Wörter und Wendungen, die du lieber nicht siehst."
 
-#: lib/abuuba_web/live/settings_live.ex:872
+#: lib/abuuba_web/live/settings_live.ex:914
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr "Du folgst noch niemandem."
 
-#: lib/abuuba_web/live/settings_live.ex:2283
+#: lib/abuuba_web/live/settings_live.ex:2353
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr "Dein Konto erscheint auf der öffentlichen Verzeichnisseite dieses Servers."
 
-#: lib/abuuba_web/live/settings_live.ex:888
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr "Dein aktuelles Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2201
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr "Dein Name, was du über dich sagst, deine Felder."
 
-#: lib/abuuba_web/live/settings_live.ex:995
+#: lib/abuuba_web/live/settings_live.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr "Deine anderen Konten"
 
-#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr "Dein Passwort, Zwei-Faktor und das Abmelden."
@@ -2296,110 +2296,110 @@ msgstr "Beiträge"
 msgid "servers known"
 msgstr "bekannte Server"
 
-#: lib/abuuba_web/live/settings_live.ex:1866
+#: lib/abuuba_web/live/settings_live.ex:1936
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr "Eine Verwarnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2212
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr "Alles, was eine Moderatorin oder ein Moderator hier über dein Konto entschieden hat."
 
-#: lib/abuuba_web/live/settings_live.ex:1204
+#: lib/abuuba_web/live/settings_live.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr "Einspruch einlegen"
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2185
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr "Moderation"
 
-#: lib/abuuba_web/live/settings_live.ex:1234
+#: lib/abuuba_web/live/settings_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr "Hier ist nichts. Niemand aus der Moderation hat etwas gegen dein Konto unternommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1850
+#: lib/abuuba_web/live/settings_live.ex:1920
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr "Schreib bitte etwas dazu, warum du das für falsch hältst."
 
-#: lib/abuuba_web/live/settings_live.ex:1201
+#: lib/abuuba_web/live/settings_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr "Warum hältst du das für falsch?"
 
-#: lib/abuuba_web/live/settings_live.ex:1869
+#: lib/abuuba_web/live/settings_live.ex:1939
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr "Einige deiner Beiträge wurden gelöscht"
 
-#: lib/abuuba_web/live/settings_live.ex:1208
-#: lib/abuuba_web/live/settings_live.ex:1846
+#: lib/abuuba_web/live/settings_live.ex:1250
+#: lib/abuuba_web/live/settings_live.ex:1916
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr "Die Frist für einen Einspruch ist abgelaufen."
 
-#: lib/abuuba_web/live/settings_live.ex:1179
+#: lib/abuuba_web/live/settings_live.ex:1221
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr "Was die Moderation hier über dein Konto entschieden hat und was dir dazu gesagt wurde."
 
-#: lib/abuuba_web/live/settings_live.ex:1861
+#: lib/abuuba_web/live/settings_live.ex:1931
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr "Du hast Einspruch eingelegt, er wurde abgelehnt."
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1930
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr "Du hast Einspruch eingelegt, ihm wurde stattgegeben."
 
-#: lib/abuuba_web/live/settings_live.ex:1862
+#: lib/abuuba_web/live/settings_live.ex:1932
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr "Du hast Einspruch eingelegt. Entschieden ist noch nichts."
 
-#: lib/abuuba_web/live/settings_live.ex:1867
+#: lib/abuuba_web/live/settings_live.ex:1937
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr "Dein Konto wurde deaktiviert"
 
-#: lib/abuuba_web/live/settings_live.ex:1870
+#: lib/abuuba_web/live/settings_live.ex:1940
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr "Dein Konto wurde eingeschränkt"
 
-#: lib/abuuba_web/live/settings_live.ex:1871
+#: lib/abuuba_web/live/settings_live.ex:1941
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr "Dein Konto wurde gesperrt"
 
-#: lib/abuuba_web/live/settings_live.ex:1868
+#: lib/abuuba_web/live/settings_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr "Deine Beiträge wurden als sensibel markiert"
 
-#: lib/abuuba_web/live/settings_live.ex:1187
+#: lib/abuuba_web/live/settings_live.ex:1229
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr "inzwischen aufgehoben"
 
-#: lib/abuuba_web/live/settings_live.ex:1225
+#: lib/abuuba_web/live/settings_live.ex:1267
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] "%{count} Verbindung verloren"
 msgstr[1] "%{count} Verbindungen verloren"
 
-#: lib/abuuba_web/live/settings_live.ex:1214
+#: lib/abuuba_web/live/settings_live.ex:1256
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr "Verbindungen, die dich die Entscheidungen dieses Servers gekostet haben"
 
-#: lib/abuuba_web/live/settings_live.ex:1216
+#: lib/abuuba_web/live/settings_live.ex:1258
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr "Wenn dieser Server die Verbindung zu einem anderen abbricht, gehen die Folgebeziehungen zwischen dir und den Leuten dort verloren. Von hier aus lassen sie sich nicht wiederherstellen, weil die andere Seite nicht mehr erreichbar ist."
@@ -2695,7 +2695,7 @@ msgstr "Das ist keine Adresse."
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3339
-#: lib/abuuba_web/live/settings_live.ex:1636
+#: lib/abuuba_web/live/settings_live.ex:1686
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr "Das kann dein Konto nicht."
@@ -2829,17 +2829,17 @@ msgstr "Trends"
 msgid "What is trending now"
 msgstr "Was gerade im Trend liegt"
 
-#: lib/abuuba_web/live/explore_live.ex:77
+#: lib/abuuba_web/live/explore_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr "Worüber gerade mehr Leute als sonst schreiben, danach alles Übrige, das Neueste zuerst."
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2169
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr "%{uses} von %{max} genutzt"
 
-#: lib/abuuba_web/live/settings_live.ex:1250
+#: lib/abuuba_web/live/settings_live.ex:1292
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr "Ein Code, mit dem sich jemand anmelden kann, auch wenn Anmeldungen geschlossen sind. Lass die Anzahl leer für beliebig viele."
@@ -2854,7 +2854,7 @@ msgstr "Eine Ankündigung braucht einen Text."
 msgid "Announcements"
 msgstr "Ankündigungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2144
+#: lib/abuuba_web/live/settings_live.ex:2214
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr "Codes, mit denen sich Bekannte von dir anmelden können."
@@ -2879,7 +2879,7 @@ msgstr "Darüber wurden bereits alle informiert."
 msgid "Goes up"
 msgstr "Erscheint"
 
-#: lib/abuuba_web/live/settings_live.ex:1261
+#: lib/abuuba_web/live/settings_live.ex:1303
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr "Wie viele Personen"
@@ -2894,12 +2894,12 @@ msgstr "Gültig ab"
 msgid "In effect from %{date}"
 msgstr "Gültig ab %{date}"
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2186
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr "Einladungen"
 
-#: lib/abuuba_web/live/settings_live.ex:1245
+#: lib/abuuba_web/live/settings_live.ex:1287
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
@@ -2909,7 +2909,7 @@ msgstr "Einladungen kann dieses Konto nicht erstellen. Frag die Serverleitung."
 msgid "Leave this empty to publish it now."
 msgstr "Leer lassen, um sofort zu veröffentlichen."
 
-#: lib/abuuba_web/live/settings_live.ex:1268
+#: lib/abuuba_web/live/settings_live.ex:1310
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr "Erstellen"
@@ -2939,7 +2939,7 @@ msgstr "Veröffentlicht"
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr "Etwas, das hier alle lesen sollten. Mit einer Uhrzeit veröffentlicht es sich selbst, sodass ein Hinweis auf Sonntag schon am Donnerstag geschrieben werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1282
+#: lib/abuuba_web/live/settings_live.ex:1324
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr "Zurücknehmen"
@@ -2954,12 +2954,12 @@ msgstr "Alle informieren"
 msgid "Terms need some text and a day they take effect."
 msgstr "Nutzungsbedingungen brauchen einen Text und einen Tag, ab dem sie gelten."
 
-#: lib/abuuba_web/live/settings_live.ex:1266
+#: lib/abuuba_web/live/settings_live.ex:1308
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr "Sie folgen dir"
 
-#: lib/abuuba_web/live/settings_live.ex:1257
+#: lib/abuuba_web/live/settings_live.ex:1299
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr "Wofür sie ist"
@@ -2980,7 +2980,7 @@ msgstr "Wann es veröffentlicht wird"
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr "Du meldest dich auf eine Einladung hin an, eine Freigabe brauchst du deshalb nicht."
 
-#: lib/abuuba_web/live/settings_live.ex:1288
+#: lib/abuuba_web/live/settings_live.ex:1330
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr "Du hast noch keine erstellt."
@@ -2990,7 +2990,7 @@ msgstr "Du hast noch keine erstellt."
 msgid "everybody was told"
 msgstr "alle wurden informiert"
 
-#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2166
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3126,245 +3126,245 @@ msgstr "Übersetzt von %{provider}. Lade die Seite neu für das Original."
 msgid "This account has been disabled. Contact the moderators."
 msgstr "Dieses Konto wurde deaktiviert. Wende dich an die Moderation."
 
-#: lib/abuuba_web/live/settings_live.ex:1995
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr "%{count} konnten nicht übernommen werden"
 
-#: lib/abuuba_web/live/settings_live.ex:1986
+#: lib/abuuba_web/live/settings_live.ex:2056
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr "%{done} von %{total} gelesen, %{imported} übernommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1902
+#: lib/abuuba_web/live/settings_live.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr "Boosts und Umfragen. Ein Boost verweist auf den Beitrag einer anderen Person, den das Archiv nicht enthält, und die Stimmen einer Umfrage wären hier nicht mehr richtig."
 
-#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr "Wähle zuerst ein Archiv aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1883
+#: lib/abuuba_web/live/settings_live.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr "Jeder Fediverse-Server gibt dir ein ZIP mit allem, was du geschrieben hast. Lade es hier hoch, und deine Beiträge kommen zurück, mit ihren Bildern und ihrem ursprünglichen Datum."
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2152
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr "Fertig."
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2187
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
 
-#: lib/abuuba_web/live/settings_live.ex:1908
+#: lib/abuuba_web/live/settings_live.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr "Importierte Beiträge tauchen in keiner Timeline auf und gehen nicht ins Netzwerk. Sie stehen in deinem Profil, in der Reihenfolge, in der du sie geschrieben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2144
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr "Ein Archiv auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:2147
+#: lib/abuuba_web/live/settings_live.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr "Ein Archiv deiner Beiträge von einem anderen Server wieder einlesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr "Dein Archiv wird gelesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2153
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr "Das Archiv konnte nicht gelesen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2055
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr "Das konnte nicht gelesen werden. Lade das Archiv hoch, das dir dein alter Server gegeben hat."
 
-#: lib/abuuba_web/live/settings_live.ex:2070
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2140
+#: lib/abuuba_web/live/settings_live.ex:2145
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr "Das konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2072
+#: lib/abuuba_web/live/settings_live.ex:2142
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr "Das ist keine Archivdatei."
 
-#: lib/abuuba_web/live/settings_live.ex:1892
+#: lib/abuuba_web/live/settings_live.ex:1962
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr "Die alten Adressen. Deine Beiträge lagen auf einer anderen Domain und können dort nicht wieder liegen, also bleibt jeder Link darauf tot."
 
-#: lib/abuuba_web/live/settings_live.ex:2080
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr "Wartet auf den Start."
 
-#: lib/abuuba_web/live/settings_live.ex:1889
+#: lib/abuuba_web/live/settings_live.ex:1959
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr "Was nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:1897
+#: lib/abuuba_web/live/settings_live.ex:1967
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr "Deine Follower. Ein Follow ist eine Abmachung zwischen zwei Servern, und einer davon ist weg; sie müssen diesem Konto neu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:2086
+#: lib/abuuba_web/live/settings_live.ex:2156
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr "ein Boost, der nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2088
+#: lib/abuuba_web/live/settings_live.ex:2158
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr "eine Umfrage, die nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2089
+#: lib/abuuba_web/live/settings_live.ex:2159
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr "kein Datum, also kein Platz dafür"
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2162
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr "die Datei ist kein Archiv"
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2160
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr "der Beitrag wurde nicht gefunden"
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2161
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr "dieser Server hat ihn nicht angenommen"
 
-#: lib/abuuba_web/live/settings_live.ex:1053
+#: lib/abuuba_web/live/settings_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr "Alle annehmen"
 
-#: lib/abuuba_web/live/settings_live.ex:1941
+#: lib/abuuba_web/live/settings_live.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr "Dazu hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:1048
+#: lib/abuuba_web/live/settings_live.ex:1090
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr "Nach einem Umzug kommen alle, die dir gefolgt sind, auf einmal an. Das nimmt sie alle an, was dieselbe Antwort ist, die du ihnen schon gegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1959
+#: lib/abuuba_web/live/settings_live.ex:2029
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr "Ein Archiv deiner Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:1058
+#: lib/abuuba_web/live/settings_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr "Für den Export deiner Daten und das Löschen des Kontos steht die Arbeit noch aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1046
+#: lib/abuuba_web/live/settings_live.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr "Wartende Folgeanfragen"
 
-#: lib/abuuba_web/live/settings_live.ex:1015
+#: lib/abuuba_web/live/settings_live.ex:1057
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr "Ich bin zurück"
 
-#: lib/abuuba_web/live/settings_live.ex:1972
+#: lib/abuuba_web/live/settings_live.ex:2042
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr "Archiv importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1949
+#: lib/abuuba_web/live/settings_live.ex:2019
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr "Liste importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1072
-#: lib/abuuba_web/live/settings_live.ex:1921
-#: lib/abuuba_web/live/settings_live.ex:2252
+#: lib/abuuba_web/live/settings_live.ex:1114
+#: lib/abuuba_web/live/settings_live.ex:1991
+#: lib/abuuba_web/live/settings_live.ex:2322
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr "Listen"
 
-#: lib/abuuba_web/live/settings_live.ex:1042
+#: lib/abuuba_web/live/settings_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr "Umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:1026
+#: lib/abuuba_web/live/settings_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr "Zu einem anderen Konto umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2045
+#: lib/abuuba_web/live/settings_live.ex:2115
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr "Unter dieser Adresse war niemand zu finden."
 
-#: lib/abuuba_web/live/settings_live.ex:1010
+#: lib/abuuba_web/live/settings_live.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr "Anderen Servern wird gesagt, dass sie stattdessen dem neuen Konto folgen sollen. Wer dir von diesem Server aus folgt, ist bereits umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1945
+#: lib/abuuba_web/live/settings_live.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr "Durch die Datei ersetzen"
 
-#: lib/abuuba_web/live/settings_live.ex:2035
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr "Dieses Konto nennt dieses hier nicht als eines von deinen. Trage die Adresse dieses Kontos zuerst dort bei den Aliassen ein."
 
-#: lib/abuuba_web/live/settings_live.ex:2046
+#: lib/abuuba_web/live/settings_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr "Das ist dieses Konto."
 
-#: lib/abuuba_web/live/settings_live.ex:1923
+#: lib/abuuba_web/live/settings_live.ex:1993
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr "Die CSV-Dateien, die dir dein alter Server gibt: Follows, Blocks, Stummschaltungen, Domain-Blocks, Listen, Lesezeichen, Filter. Lade sie einzeln hoch, unter dem Namen, unter dem sie kamen."
 
-#: lib/abuuba_web/live/settings_live.ex:1036
+#: lib/abuuba_web/live/settings_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr "Das andere Konto muss dieses hier zuerst in seinen eigenen Aliassen nennen. Deine Follower hier ziehen mit um, und alle anderen Server werden benachrichtigt; ein Konto kann nur alle %{days} Tage umziehen."
 
-#: lib/abuuba_web/live/settings_live.ex:1008
+#: lib/abuuba_web/live/settings_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1938
+#: lib/abuuba_web/live/settings_live.ex:2008
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr "Was mit dem passieren soll, was schon da ist"
 
-#: lib/abuuba_web/live/settings_live.ex:2041
+#: lib/abuuba_web/live/settings_live.ex:2111
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr "Du bist vor Kurzem umgezogen. Ein Konto kann nur alle %{days} Tage umziehen."
@@ -3394,7 +3394,7 @@ msgstr "Nur ganze Wörter, damit „Katze“ nicht auf „Katzenklo“ passt"
 msgid "Words to look for"
 msgstr "Wonach gesucht wird"
 
-#: lib/abuuba_web/live/settings_live.ex:1522
+#: lib/abuuba_web/live/settings_live.ex:1572
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr "Ein Filter braucht mindestens ein Wort, nach dem er suchen soll."
@@ -3431,7 +3431,7 @@ msgstr "Hervorgehobene Hashtags"
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr "Stehen auf deinem Profil als Abkürzung zu dem, worüber du schreibst."
 
-#: lib/abuuba_web/live/settings_live.ex:1505
+#: lib/abuuba_web/live/settings_live.ex:1555
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr "Das ist kein Hashtag, den man benutzen kann."
@@ -3441,7 +3441,7 @@ msgstr "Das ist kein Hashtag, den man benutzen kann."
 msgid "You often write about:"
 msgstr "Du schreibst oft über:"
 
-#: lib/abuuba_web/live/settings_live.ex:1499
+#: lib/abuuba_web/live/settings_live.ex:1549
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr "Ein Profil kann %{count} Hashtags tragen. Nimm zuerst einen weg."
@@ -3825,75 +3825,75 @@ msgstr "jemand hat für dein Konto auf %{site} ein neues Passwort angefordert. W
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr "das Passwort deines Kontos auf %{site} wurde gerade geändert, und überall, wo du angemeldet warst, wurdest du abgemeldet."
 
-#: lib/abuuba_web/live/settings_live.ex:1085
+#: lib/abuuba_web/live/settings_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr "Eine Kopie von allem"
 
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/settings_live.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr "Wird gebaut"
 
 #: lib/abuuba_web/live/settings_live.ex:812
-#: lib/abuuba_web/live/settings_live.ex:2253
+#: lib/abuuba_web/live/settings_live.ex:2323
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr "Blockierte Server"
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2250
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr "Blockierte"
 
-#: lib/abuuba_web/live/settings_live.ex:2254
+#: lib/abuuba_web/live/settings_live.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
 
-#: lib/abuuba_web/live/settings_live.ex:1127
+#: lib/abuuba_web/live/settings_live.ex:1169
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr "Bau mir eine Kopie"
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr "Hat nicht geklappt"
 
-#: lib/abuuba_web/live/settings_live.ex:1110
+#: lib/abuuba_web/live/settings_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr "Herunterladen"
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2188
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr "Exportieren"
 
-#: lib/abuuba_web/live/settings_live.ex:2251
+#: lib/abuuba_web/live/settings_live.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr "Stummgeschaltete"
 
-#: lib/abuuba_web/live/settings_live.ex:1074
+#: lib/abuuba_web/live/settings_live.ex:1116
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr "Je eine Datei, im Format, das der Import dieses Servers liest. Ein Export von hier ist ein Import anderswo."
 
-#: lib/abuuba_web/live/settings_live.ex:1395
+#: lib/abuuba_web/live/settings_live.ex:1445
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr "Eine wird gerade schon gebaut."
 
-#: lib/abuuba_web/live/settings_live.ex:1092
+#: lib/abuuba_web/live/settings_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr "Bilder und Videos sind nicht in der Datei. Sie enthält ihre Adressen, die funktionieren, solange dieser Server läuft."
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr "Fertig"
@@ -3913,13 +3913,13 @@ msgstr "Die Datei wird nach %{days} Tagen gelöscht, weil sie dein ganzes Konto 
 msgid "There is nothing of that kind to export."
 msgstr "So etwas gibt es hier nicht zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:2258
+#: lib/abuuba_web/live/settings_live.ex:2328
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr "Wartet auf den Start"
 
-#: lib/abuuba_web/live/settings_live.ex:1116
-#: lib/abuuba_web/live/settings_live.ex:1401
+#: lib/abuuba_web/live/settings_live.ex:1158
+#: lib/abuuba_web/live/settings_live.ex:1451
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr "Ab %{date} kannst du eine neue anfordern."
@@ -3929,7 +3929,7 @@ msgstr "Ab %{date} kannst du eine neue anfordern."
 msgid "Your archive is ready"
 msgstr "Deine Kopie ist fertig"
 
-#: lib/abuuba_web/live/settings_live.ex:1087
+#: lib/abuuba_web/live/settings_live.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wird im Hintergrund gebaut; wir schicken dir eine E-Mail, wenn sie fertig ist."
@@ -3939,67 +3939,67 @@ msgstr "Dein Profil und jeder Beitrag als JSON, zusammen mit den Listen oben. Wi
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr "die Kopie deines Kontos auf %{site}, die du angefordert hast, ist fertig. Hier herunterladen:"
 
-#: lib/abuuba_web/live/settings_live.ex:1166
+#: lib/abuuba_web/live/settings_live.ex:1208
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr "Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1164
+#: lib/abuuba_web/live/settings_live.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr "Das Konto endgültig schließen? Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1130
+#: lib/abuuba_web/live/settings_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr "Dieses Konto schließen"
 
-#: lib/abuuba_web/live/settings_live.ex:1069
+#: lib/abuuba_web/live/settings_live.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr "Alles hier gehört dir, und das Konto zu schließen ist deine Entscheidung."
 
-#: lib/abuuba_web/live/settings_live.ex:2150
+#: lib/abuuba_web/live/settings_live.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr "Eine Kopie von allem mitnehmen, oder das Konto endgültig schließen."
 
-#: lib/abuuba_web/live/settings_live.ex:1147
+#: lib/abuuba_web/live/settings_live.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr "Hol dir vorher deine Kopie. Danach gibt es nichts mehr zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:1428
+#: lib/abuuba_web/live/settings_live.ex:1478
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr "Das hat nicht geklappt. Es wurde nichts gelöscht."
 
-#: lib/abuuba_web/live/settings_live.ex:1425
+#: lib/abuuba_web/live/settings_live.ex:1475
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr "Das ist nicht dein Passwort."
 
-#: lib/abuuba_web/live/settings_live.ex:1137
+#: lib/abuuba_web/live/settings_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr "Das Konto verschwindet sofort. Die Datensätze werden kurz danach gelöscht, damit die Nachricht an die anderen Server noch signiert und verschickt werden kann."
 
-#: lib/abuuba_web/live/settings_live.ex:1421
+#: lib/abuuba_web/live/settings_live.ex:1471
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr "Das Konto ist geschlossen. Danke, dass du hier warst."
 
-#: lib/abuuba_web/live/settings_live.ex:1152
+#: lib/abuuba_web/live/settings_live.ex:1194
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr "Dein Passwort, damit sicher ist, dass du es bist"
 
-#: lib/abuuba_web/live/settings_live.ex:1132
+#: lib/abuuba_web/live/settings_live.ex:1174
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr "Deine Beiträge, Folge-Beziehungen, Listen, Filter, Lesezeichen und Einstellungen werden gelöscht, und andere Server werden aufgefordert, ihre Kopien zu löschen. Das lässt sich nicht rückgängig machen."
 
-#: lib/abuuba_web/live/settings_live.ex:1142
+#: lib/abuuba_web/live/settings_live.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr "Dein Benutzername bleibt und niemand kann ihn je bekommen, damit alte Links und Erwähnungen von dir nie auf jemand anderen zeigen."
@@ -4045,12 +4045,12 @@ msgstr "Diese Einladung kennen wir nicht."
 msgid "You can still sign up without one."
 msgstr "Du kannst dich trotzdem ohne eine anmelden."
 
-#: lib/abuuba_web/live/settings_live.ex:1457
+#: lib/abuuba_web/live/settings_live.ex:1507
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr "Ein Alter muss mindestens 7 Tage betragen, und die Anzahlen dürfen nicht negativ sein."
 
-#: lib/abuuba_web/live/settings_live.ex:922
+#: lib/abuuba_web/live/settings_live.ex:964
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr "Gescheiterte Versuche stehen hier ebenfalls. Dass jemand anderes dein Passwort probiert, sollte man früh mitbekommen, und nichts sonst würde es dir sagen."
@@ -4085,7 +4085,7 @@ msgstr "Beiträge behalten, die mindestens so oft favorisiert wurden"
 msgid "Keep posts with pictures or video"
 msgstr "Beiträge mit Bildern oder Video behalten"
 
-#: lib/abuuba_web/live/settings_live.ex:945
+#: lib/abuuba_web/live/settings_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr "Wird %{days} Tage aufgehoben und dann gelöscht."
@@ -4095,7 +4095,7 @@ msgstr "Wird %{days} Tage aufgehoben und dann gelöscht."
 msgid "Nothing pinned."
 msgstr "Nichts angeheftet."
 
-#: lib/abuuba_web/live/settings_live.ex:941
+#: lib/abuuba_web/live/settings_live.ex:983
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr "Noch nichts aufgezeichnet."
@@ -4117,17 +4117,17 @@ msgstr[1] "%{count} Beiträge passen gerade auf diese Einstellungen."
 msgid "Pinned posts"
 msgstr "Angeheftete Beiträge"
 
-#: lib/abuuba_web/live/settings_live.ex:920
+#: lib/abuuba_web/live/settings_live.ex:962
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr "Letzte Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:930
+#: lib/abuuba_web/live/settings_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr "Abgelehnt"
 
-#: lib/abuuba_web/live/settings_live.ex:930
+#: lib/abuuba_web/live/settings_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr "Angemeldet"
@@ -4949,12 +4949,12 @@ msgid_plural "%{count} signed up"
 msgstr[0] "eine Anmeldung"
 msgstr[1] "%{count} Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2228
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr "Profilbild"
 
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr "Titelbild"
@@ -4970,7 +4970,7 @@ msgstr "JPEG, PNG, GIF oder WebP, bis %{size}. Größere werden schon vor dem Ho
 msgid "None yet."
 msgstr "Noch keins."
 
-#: lib/abuuba_web/live/settings_live.ex:2069
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr "Ein Bild auf einmal."
@@ -4985,19 +4985,19 @@ msgstr "Bilder"
 msgid "Take it off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2067
-#: lib/abuuba_web/live/settings_live.ex:2222
+#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2292
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr "Damit kann dieser Server nichts anfangen. Versuch es mit JPEG, PNG, GIF oder WebP."
 
-#: lib/abuuba_web/live/settings_live.ex:2217
-#: lib/abuuba_web/live/settings_live.ex:2224
+#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr "Dieses Bild konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2064
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr "Dieses Bild ist zu groß. Die Grenze steht eine Zeile weiter oben."
@@ -5056,7 +5056,7 @@ msgstr[0] "Am %{date} an eine Adresse geschickt."
 msgstr[1] "Am %{date} an %{count} Adressen geschickt."
 
 #: lib/abuuba_web/live/settings_live.ex:693
-#: lib/abuuba_web/live/settings_live.ex:1796
+#: lib/abuuba_web/live/settings_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Betreff"
@@ -5066,7 +5066,7 @@ msgstr "Betreff"
 msgid "That does not look like a valid email address."
 msgstr "Das sieht nicht nach einer gültigen E-Mail-Adresse aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1376
+#: lib/abuuba_web/live/settings_live.ex:1426
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr "Diese Liste ist nicht offen."
@@ -5096,7 +5096,7 @@ msgstr "An sie schreiben"
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr "Du bekommst das, weil du auf %{site} um Neuigkeiten von %{name} gebeten hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1381
+#: lib/abuuba_web/live/settings_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr "Du hast heute schon so viele Nachrichten geschickt, wie du kannst."
@@ -5106,7 +5106,7 @@ msgstr "Du hast heute schon so viele Nachrichten geschickt, wie du kannst."
 msgid "you@example.com"
 msgstr "du@example.com"
 
-#: lib/abuuba_web/live/settings_live.ex:1797
+#: lib/abuuba_web/live/settings_live.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
@@ -5397,7 +5397,7 @@ msgstr "Deine Unterhaltungen als gelesen markieren"
 msgid "Mute and unmute people for you"
 msgstr "Leute für dich stummschalten und wieder lautstellen"
 
-#: lib/abuuba_web/live/settings_live.ex:968
+#: lib/abuuba_web/live/settings_live.ex:1010
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr "Nichts. Sie sieht nur, dass du angemeldet bist, sonst nichts."
@@ -5774,7 +5774,7 @@ msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht d
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr "Zu viele Anmeldungen von hier im Moment. Bitte versuche es später noch einmal."
 
-#: lib/abuuba_web/live/explore_live.ex:148
+#: lib/abuuba_web/live/explore_live.ex:149
 #: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
@@ -5840,8 +5840,8 @@ msgstr "Stattgeben und rückgängig machen"
 msgid "Warned"
 msgstr "Verwarnt"
 
-#: lib/abuuba_web/live/settings_live.ex:2242
-#: lib/abuuba_web/live/settings_live.ex:2245
+#: lib/abuuba_web/live/settings_live.ex:2312
+#: lib/abuuba_web/live/settings_live.ex:2315
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr "%{size} MB"
@@ -5851,7 +5851,7 @@ msgstr "%{size} MB"
 msgid "Cancel follow request"
 msgstr "Folgeanfrage zurückziehen"
 
-#: lib/abuuba_web/live/explore_live.ex:117
+#: lib/abuuba_web/live/explore_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr "Angefragt"
@@ -5867,7 +5867,7 @@ msgid "Delete this post? Other servers are told to forget it too."
 msgstr "Diesen Beitrag löschen? Andere Server werden aufgefordert, ihre Kopie ebenfalls zu löschen."
 
 #: lib/abuuba_web/components/layouts.ex:145
-#: lib/abuuba_web/live/settings_live.ex:911
+#: lib/abuuba_web/live/settings_live.ex:953
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr "Abmelden"
@@ -5876,3 +5876,23 @@ msgstr "Abmelden"
 #, elixir-autogen, elixir-format
 msgid "That post is gone."
 msgstr "Der Beitrag ist gelöscht."
+
+#: lib/abuuba_web/live/settings_live.ex:876
+#, elixir-autogen, elixir-format
+msgid "Let them follow"
+msgstr "Folgen lassen"
+
+#: lib/abuuba_web/live/settings_live.ex:885
+#, elixir-autogen, elixir-format
+msgid "Turn them away"
+msgstr "Ablehnen"
+
+#: lib/abuuba_web/live/settings_live.ex:853
+#, elixir-autogen, elixir-format
+msgid "Waiting for your answer"
+msgstr "Wartet auf deine Antwort"
+
+#: lib/abuuba_web/live/settings_live.ex:855
+#, elixir-autogen, elixir-format
+msgid "Your account asks before letting somebody follow it. Turning one away tells them nothing, and they can ask again."
+msgstr "Dein Konto fragt nach, bevor dir jemand folgen darf. Wer abgelehnt wird, erfährt nichts davon und kann erneut anfragen."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -37,8 +37,8 @@ msgstr[1] ""
 msgid "Actions"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:289
-#: lib/abuuba_web/components/layouts.ex:304
+#: lib/abuuba_web/components/layouts.ex:326
+#: lib/abuuba_web/components/layouts.ex:341
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:296
+#: lib/abuuba_web/components/layouts.ex:333
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
@@ -64,7 +64,7 @@ msgstr ""
 msgid "That language is not available."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:281
+#: lib/abuuba_web/components/layouts.ex:318
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:944
+#: lib/abuuba_web/live/settings_live.ex:912
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -652,51 +652,51 @@ msgstr ""
 msgid "That request has to be signed."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:247
-#: lib/abuuba_web/components/layouts.ex:256
+#: lib/abuuba_web/components/layouts.ex:271
+#: lib/abuuba_web/components/layouts.ex:280
 #: lib/abuuba_web/live/explore_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:234
-#: lib/abuuba_web/components/layouts.ex:255
+#: lib/abuuba_web/components/layouts.ex:258
+#: lib/abuuba_web/components/layouts.ex:279
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2388
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:143
+#: lib/abuuba_web/components/layouts.ex:153
 #: lib/abuuba_web/controllers/shortcuts_controller.ex:15
 #: lib/abuuba_web/controllers/shortcuts_html/show.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:258
+#: lib/abuuba_web/components/layouts.ex:282
 #: lib/abuuba_web/live/landing_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:133
-#: lib/abuuba_web/components/layouts.ex:158
+#: lib/abuuba_web/components/layouts.ex:168
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:237
+#: lib/abuuba_web/components/layouts.ex:261
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2389
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:249
+#: lib/abuuba_web/components/layouts.ex:273
 #: lib/abuuba_web/live/settings_live.ex:121
-#: lib/abuuba_web/live/settings_live.ex:2197
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -735,12 +735,12 @@ msgstr ""
 msgid "Attachment"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:430
+#: lib/abuuba_web/components/status_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:407
+#: lib/abuuba_web/components/status_component.ex:415
 #, elixir-autogen, elixir-format
 msgid "Boost"
 msgstr ""
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Closed"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:419
+#: lib/abuuba_web/components/status_component.ex:427
 #, elixir-autogen, elixir-format
 msgid "Favourite"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:395
+#: lib/abuuba_web/components/status_component.ex:403
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
@@ -847,19 +847,19 @@ msgid "Allow more than one choice"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2383
+#: lib/abuuba_web/live/settings_live.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2378
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2379
+#: lib/abuuba_web/live/settings_live.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
@@ -885,7 +885,7 @@ msgstr ""
 msgid "Do not reply to this person"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:441
+#: lib/abuuba_web/components/status_component.ex:449
 #: lib/abuuba_web/live/admin_live.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -902,7 +902,7 @@ msgid "Ends after"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/profile_live.ex:792
+#: lib/abuuba_web/live/profile_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
@@ -914,13 +914,13 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3427
 #: lib/abuuba_web/live/compose_component.ex:1677
-#: lib/abuuba_web/live/settings_live.ex:2385
+#: lib/abuuba_web/live/settings_live.ex:2327
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/settings_live.ex:2380
+#: lib/abuuba_web/live/settings_live.ex:2322
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
@@ -931,7 +931,7 @@ msgid "Only the people you name"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2384
+#: lib/abuuba_web/live/settings_live.ex:2326
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
@@ -1204,12 +1204,14 @@ msgstr ""
 msgid "%{name} on %{server}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:299
+#: lib/abuuba_web/live/profile_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:196
+#: lib/abuuba_web/live/report_live.ex:285
+#: lib/abuuba_web/live/report_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
@@ -1231,29 +1233,31 @@ msgstr ""
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:791
+#: lib/abuuba_web/live/profile_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:188
+#: lib/abuuba_web/live/report_live.ex:273
+#: lib/abuuba_web/live/report_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:370
+#: lib/abuuba_web/live/profile_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:345
-#: lib/abuuba_web/live/profile_live.ex:346
+#: lib/abuuba_web/live/profile_live.ex:351
+#: lib/abuuba_web/live/profile_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
 #: lib/abuuba_web/live/explore_live.ex:256
-#: lib/abuuba_web/live/profile_live.ex:789
+#: lib/abuuba_web/live/profile_live.ex:795
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:208
@@ -1261,13 +1265,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:790
+#: lib/abuuba_web/live/profile_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:944
-#: lib/abuuba_web/live/profile_live.ex:303
+#: lib/abuuba_web/live/profile_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr ""
@@ -1283,12 +1287,14 @@ msgid "This account has moved to %{handle}."
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:196
-#: lib/abuuba_web/live/settings_live.ex:828
+#: lib/abuuba_web/live/settings_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:162
+#: lib/abuuba_web/live/report_live.ex:263
+#: lib/abuuba_web/live/report_live.ex:268
 #: lib/abuuba_web/live/tag_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -1304,7 +1310,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:307
+#: lib/abuuba_web/live/profile_live.ex:313
 #: lib/abuuba_web/live/search_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "What to show"
@@ -1486,7 +1492,11 @@ msgstr ""
 msgid "Edits"
 msgstr ""
 
+#: lib/abuuba_web/components/layouts.ex:151
 #: lib/abuuba_web/live/notifications_live.ex:471
+#: lib/abuuba_web/live/saved_live.ex:88
+#: lib/abuuba_web/live/saved_live.ex:95
+#: lib/abuuba_web/live/settings_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Favourites"
 msgstr ""
@@ -1496,15 +1506,18 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
+#: lib/abuuba_web/components/layouts.ex:292
+#: lib/abuuba_web/live/follow_requests_live.ex:37
+#: lib/abuuba_web/live/follow_requests_live.ex:44
 #: lib/abuuba_web/live/notifications_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr ""
 
 #: lib/abuuba_web/live/notifications_live.ex:469
-#: lib/abuuba_web/live/profile_live.ex:793
-#: lib/abuuba_web/live/settings_live.ex:2181
-#: lib/abuuba_web/live/settings_live.ex:2319
+#: lib/abuuba_web/live/profile_live.ex:799
+#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -1571,15 +1584,15 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1587
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:262
-#: lib/abuuba_web/live/settings_live.ex:296
-#: lib/abuuba_web/live/settings_live.ex:390
-#: lib/abuuba_web/live/settings_live.ex:427
-#: lib/abuuba_web/live/settings_live.ex:491
-#: lib/abuuba_web/live/settings_live.ex:598
-#: lib/abuuba_web/live/settings_live.ex:643
-#: lib/abuuba_web/live/settings_live.ex:676
-#: lib/abuuba_web/live/settings_live.ex:1046
+#: lib/abuuba_web/live/profile_live.ex:268
+#: lib/abuuba_web/live/settings_live.ex:306
+#: lib/abuuba_web/live/settings_live.ex:400
+#: lib/abuuba_web/live/settings_live.ex:437
+#: lib/abuuba_web/live/settings_live.ex:501
+#: lib/abuuba_web/live/settings_live.ex:608
+#: lib/abuuba_web/live/settings_live.ex:653
+#: lib/abuuba_web/live/settings_live.ex:686
+#: lib/abuuba_web/live/settings_live.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
@@ -1627,7 +1640,7 @@ msgstr ""
 msgid "Your settings filed these instead of showing them."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:190
+#: lib/abuuba_web/components/layouts.ex:200
 #: lib/abuuba_web/live/conversations_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "unread"
@@ -1716,8 +1729,8 @@ msgstr ""
 msgid "Registration needs approval: you sign up and an admin reads your request."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:248
-#: lib/abuuba_web/components/layouts.ex:257
+#: lib/abuuba_web/components/layouts.ex:272
+#: lib/abuuba_web/components/layouts.ex:281
 #: lib/abuuba_web/live/search_live.ex:38
 #: lib/abuuba_web/live/search_live.ex:61
 #: lib/abuuba_web/live/search_live.ex:70
@@ -1755,95 +1768,95 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:935
+#: lib/abuuba_web/live/settings_live.ex:903
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:236
+#: lib/abuuba_web/live/settings_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3378
-#: lib/abuuba_web/live/settings_live.ex:2184
+#: lib/abuuba_web/live/settings_live.ex:2126
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:292
+#: lib/abuuba_web/live/settings_live.ex:302
 #, elixir-autogen, elixir-format
 msgid "Add a field"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:809
+#: lib/abuuba_web/live/settings_live.ex:819
 #, elixir-autogen, elixir-format
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2177
+#: lib/abuuba_web/live/settings_live.ex:2119
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2355
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2183
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2208
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:997
+#: lib/abuuba_web/live/settings_live.ex:965
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2350
+#: lib/abuuba_web/live/settings_live.ex:2292
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:939
+#: lib/abuuba_web/live/settings_live.ex:907
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:455
+#: lib/abuuba_web/components/status_component.ex:463
 #: lib/abuuba_web/live/admin_live.ex:998
-#: lib/abuuba_web/live/settings_live.ex:756
+#: lib/abuuba_web/live/settings_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:225
+#: lib/abuuba_web/live/settings_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2366
+#: lib/abuuba_web/live/settings_live.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1658
+#: lib/abuuba_web/live/settings_live.ex:1618
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2351
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2206
+#: lib/abuuba_web/live/settings_live.ex:2148
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
@@ -1853,123 +1866,123 @@ msgstr ""
 msgid "Everything about your account is here. Pick a section."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:241
+#: lib/abuuba_web/live/settings_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2180
-#: lib/abuuba_web/live/settings_live.ex:2325
+#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2407
+#: lib/abuuba_web/live/settings_live.ex:2349
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2408
+#: lib/abuuba_web/live/settings_live.ex:2350
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2356
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2364
+#: lib/abuuba_web/live/settings_live.ex:2306
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2202
+#: lib/abuuba_web/live/settings_live.ex:2144
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:256
+#: lib/abuuba_web/live/settings_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2354
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2352
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2359
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:274
+#: lib/abuuba_web/live/settings_live.ex:284
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1026
+#: lib/abuuba_web/live/settings_live.ex:994
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1040
+#: lib/abuuba_web/live/settings_live.ex:1008
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:451
+#: lib/abuuba_web/live/settings_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2209
+#: lib/abuuba_web/live/settings_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2371
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2175
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2178
+#: lib/abuuba_web/live/settings_live.ex:2120
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2179
+#: lib/abuuba_web/live/settings_live.ex:2121
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2176
+#: lib/abuuba_web/live/settings_live.ex:2118
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2392
+#: lib/abuuba_web/live/settings_live.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2390
+#: lib/abuuba_web/live/settings_live.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2363
+#: lib/abuuba_web/live/settings_live.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1980,165 +1993,165 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1878
 #: lib/abuuba_web/live/admin_live.ex:2202
 #: lib/abuuba_web/live/conversations_live.ex:113
-#: lib/abuuba_web/live/settings_live.ex:282
-#: lib/abuuba_web/live/settings_live.ex:317
+#: lib/abuuba_web/live/settings_live.ex:292
+#: lib/abuuba_web/live/settings_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2182
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:957
+#: lib/abuuba_web/live/settings_live.ex:925
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:948
+#: lib/abuuba_web/live/settings_live.ex:916
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2374
+#: lib/abuuba_web/live/settings_live.ex:2316
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1020
+#: lib/abuuba_web/live/settings_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3746
-#: lib/abuuba_web/live/settings_live.ex:2171
+#: lib/abuuba_web/live/settings_live.ex:2113
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1633
+#: lib/abuuba_web/live/settings_live.ex:1593
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:470
+#: lib/abuuba_web/live/settings_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2357
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2358
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2391
+#: lib/abuuba_web/live/settings_live.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:893
+#: lib/abuuba_web/live/settings_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:918
+#: lib/abuuba_web/live/settings_live.ex:886
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:243
+#: lib/abuuba_web/live/settings_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2365
+#: lib/abuuba_web/live/settings_live.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:263
+#: lib/abuuba_web/live/settings_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2367
+#: lib/abuuba_web/live/settings_live.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:801
+#: lib/abuuba_web/live/settings_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2203
+#: lib/abuuba_web/live/settings_live.ex:2145
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2178
-#: lib/abuuba_web/live/settings_live.ex:763
+#: lib/abuuba_web/live/settings_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:768
+#: lib/abuuba_web/live/settings_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2204
+#: lib/abuuba_web/live/settings_live.ex:2146
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:457
+#: lib/abuuba_web/live/settings_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:438
+#: lib/abuuba_web/live/settings_live.ex:448
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2205
+#: lib/abuuba_web/live/settings_live.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:914
+#: lib/abuuba_web/live/settings_live.ex:882
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2353
+#: lib/abuuba_web/live/settings_live.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:930
+#: lib/abuuba_web/live/settings_live.ex:898
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2201
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1037
+#: lib/abuuba_web/live/settings_live.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2207
+#: lib/abuuba_web/live/settings_live.ex:2149
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2294,110 +2307,110 @@ msgstr ""
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1936
+#: lib/abuuba_web/live/settings_live.ex:1878
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2212
+#: lib/abuuba_web/live/settings_live.ex:2154
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1246
+#: lib/abuuba_web/live/settings_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2185
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1276
+#: lib/abuuba_web/live/settings_live.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1920
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1243
+#: lib/abuuba_web/live/settings_live.ex:1211
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1939
+#: lib/abuuba_web/live/settings_live.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1250
-#: lib/abuuba_web/live/settings_live.ex:1916
+#: lib/abuuba_web/live/settings_live.ex:1218
+#: lib/abuuba_web/live/settings_live.ex:1858
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1221
+#: lib/abuuba_web/live/settings_live.ex:1189
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1931
+#: lib/abuuba_web/live/settings_live.ex:1873
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1930
+#: lib/abuuba_web/live/settings_live.ex:1872
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1932
+#: lib/abuuba_web/live/settings_live.ex:1874
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1937
+#: lib/abuuba_web/live/settings_live.ex:1879
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1940
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1941
+#: lib/abuuba_web/live/settings_live.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1938
+#: lib/abuuba_web/live/settings_live.ex:1880
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1229
+#: lib/abuuba_web/live/settings_live.ex:1197
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1267
+#: lib/abuuba_web/live/settings_live.ex:1235
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1256
+#: lib/abuuba_web/live/settings_live.ex:1224
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1258
+#: lib/abuuba_web/live/settings_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
@@ -2693,7 +2706,7 @@ msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3339
-#: lib/abuuba_web/live/settings_live.ex:1686
+#: lib/abuuba_web/live/settings_live.ex:1646
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
@@ -2832,12 +2845,12 @@ msgstr ""
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2169
+#: lib/abuuba_web/live/settings_live.ex:2111
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1292
+#: lib/abuuba_web/live/settings_live.ex:1260
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
@@ -2852,7 +2865,7 @@ msgstr ""
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2214
+#: lib/abuuba_web/live/settings_live.ex:2156
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2877,7 +2890,7 @@ msgstr ""
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1303
+#: lib/abuuba_web/live/settings_live.ex:1271
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
@@ -2892,12 +2905,12 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2186
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1287
+#: lib/abuuba_web/live/settings_live.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
@@ -2907,7 +2920,7 @@ msgstr ""
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1310
+#: lib/abuuba_web/live/settings_live.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
@@ -2937,7 +2950,7 @@ msgstr ""
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1324
+#: lib/abuuba_web/live/settings_live.ex:1292
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr ""
@@ -2952,12 +2965,12 @@ msgstr ""
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1308
+#: lib/abuuba_web/live/settings_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1299
+#: lib/abuuba_web/live/settings_live.ex:1267
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr ""
@@ -2978,7 +2991,7 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1330
+#: lib/abuuba_web/live/settings_live.ex:1298
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
@@ -2988,7 +3001,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2166
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3109,7 +3122,7 @@ msgstr ""
 msgid "That could not be translated just now."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:469
+#: lib/abuuba_web/components/status_component.ex:477
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
@@ -3124,245 +3137,245 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2007
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:1998
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1972
+#: lib/abuuba_web/live/settings_live.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1953
+#: lib/abuuba_web/live/settings_live.ex:1895
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2152
+#: lib/abuuba_web/live/settings_live.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2187
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1978
+#: lib/abuuba_web/live/settings_live.ex:1920
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2144
+#: lib/abuuba_web/live/settings_live.ex:2086
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2217
+#: lib/abuuba_web/live/settings_live.ex:2159
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2151
+#: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2153
+#: lib/abuuba_web/live/settings_live.ex:2095
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2140
-#: lib/abuuba_web/live/settings_live.ex:2145
+#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2087
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2143
+#: lib/abuuba_web/live/settings_live.ex:2085
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1962
+#: lib/abuuba_web/live/settings_live.ex:1904
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2150
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1959
+#: lib/abuuba_web/live/settings_live.ex:1901
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1967
+#: lib/abuuba_web/live/settings_live.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2156
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2158
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2159
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2162
+#: lib/abuuba_web/live/settings_live.ex:2104
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2160
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2161
+#: lib/abuuba_web/live/settings_live.ex:2103
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1095
+#: lib/abuuba_web/live/settings_live.ex:1063
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2011
+#: lib/abuuba_web/live/settings_live.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1090
+#: lib/abuuba_web/live/settings_live.ex:1058
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2029
+#: lib/abuuba_web/live/settings_live.ex:1971
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1100
+#: lib/abuuba_web/live/settings_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1088
+#: lib/abuuba_web/live/settings_live.ex:1056
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1057
+#: lib/abuuba_web/live/settings_live.ex:1025
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2042
+#: lib/abuuba_web/live/settings_live.ex:1984
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2019
+#: lib/abuuba_web/live/settings_live.ex:1961
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1114
-#: lib/abuuba_web/live/settings_live.ex:1991
-#: lib/abuuba_web/live/settings_live.ex:2322
+#: lib/abuuba_web/live/settings_live.ex:1082
+#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:2264
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1084
+#: lib/abuuba_web/live/settings_live.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1068
+#: lib/abuuba_web/live/settings_live.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1052
+#: lib/abuuba_web/live/settings_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2015
+#: lib/abuuba_web/live/settings_live.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2047
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2058
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1993
+#: lib/abuuba_web/live/settings_live.ex:1935
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1078
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1050
+#: lib/abuuba_web/live/settings_live.ex:1018
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2008
+#: lib/abuuba_web/live/settings_live.ex:1950
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2053
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
@@ -3372,27 +3385,27 @@ msgstr ""
 msgid "No such post here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:246
+#: lib/abuuba_web/live/settings_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:784
+#: lib/abuuba_web/live/settings_live.ex:794
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:797
+#: lib/abuuba_web/live/settings_live.ex:807
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:781
+#: lib/abuuba_web/live/settings_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1572
+#: lib/abuuba_web/live/settings_live.ex:1532
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
@@ -3402,54 +3415,54 @@ msgstr ""
 msgid "Why they want to join:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:309
+#: lib/abuuba_web/live/settings_live.ex:319
 #, elixir-autogen, elixir-format
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:326
+#: lib/abuuba_web/live/settings_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:329
+#: lib/abuuba_web/live/settings_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Feature it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:300
+#: lib/abuuba_web/live/settings_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:302
+#: lib/abuuba_web/live/settings_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1555
+#: lib/abuuba_web/live/settings_live.ex:1515
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:333
+#: lib/abuuba_web/live/settings_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1549
+#: lib/abuuba_web/live/settings_live.ex:1509
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:484
+#: lib/abuuba_web/live/settings_live.ex:494
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:486
+#: lib/abuuba_web/live/settings_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
@@ -3597,7 +3610,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr ""
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:647
+#: lib/abuuba_web/live/settings_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Email updates"
 msgstr ""
@@ -3612,7 +3625,7 @@ msgstr ""
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:665
+#: lib/abuuba_web/live/settings_live.ex:675
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr ""
@@ -3622,7 +3635,7 @@ msgstr ""
 msgid "No, remove my address"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:667
+#: lib/abuuba_web/live/settings_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3675,7 +3688,7 @@ msgstr ""
 msgid "Let people collect email addresses for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:649
+#: lib/abuuba_web/live/settings_live.ex:659
 #, elixir-autogen, elixir-format
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr ""
@@ -3823,75 +3836,79 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1127
+#: lib/abuuba_web/live/settings_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2329
+#: lib/abuuba_web/live/settings_live.ex:2271
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:812
-#: lib/abuuba_web/live/settings_live.ex:2323
+#: lib/abuuba_web/live/settings_live.ex:822
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2320
+#: lib/abuuba_web/live/settings_live.ex:2262
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2324
+#: lib/abuuba_web/components/layouts.ex:148
+#: lib/abuuba_web/live/saved_live.ex:88
+#: lib/abuuba_web/live/saved_live.ex:94
+#: lib/abuuba_web/live/settings_live.ex:218
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1169
+#: lib/abuuba_web/live/settings_live.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2331
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1152
+#: lib/abuuba_web/live/settings_live.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2188
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2321
+#: lib/abuuba_web/live/settings_live.ex:2263
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1116
+#: lib/abuuba_web/live/settings_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1445
+#: lib/abuuba_web/live/settings_live.ex:1405
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1134
+#: lib/abuuba_web/live/settings_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3911,13 +3928,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2328
+#: lib/abuuba_web/live/settings_live.ex:2270
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1158
-#: lib/abuuba_web/live/settings_live.ex:1451
+#: lib/abuuba_web/live/settings_live.ex:1126
+#: lib/abuuba_web/live/settings_live.ex:1411
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3927,7 +3944,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1129
+#: lib/abuuba_web/live/settings_live.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3937,67 +3954,67 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1208
+#: lib/abuuba_web/live/settings_live.ex:1176
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1206
+#: lib/abuuba_web/live/settings_live.ex:1174
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1172
+#: lib/abuuba_web/live/settings_live.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1111
+#: lib/abuuba_web/live/settings_live.ex:1079
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2220
+#: lib/abuuba_web/live/settings_live.ex:2162
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1189
+#: lib/abuuba_web/live/settings_live.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1478
+#: lib/abuuba_web/live/settings_live.ex:1438
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1475
+#: lib/abuuba_web/live/settings_live.ex:1435
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1179
+#: lib/abuuba_web/live/settings_live.ex:1147
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1471
+#: lib/abuuba_web/live/settings_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1194
+#: lib/abuuba_web/live/settings_live.ex:1162
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1174
+#: lib/abuuba_web/live/settings_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1184
+#: lib/abuuba_web/live/settings_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
@@ -4007,7 +4024,7 @@ msgstr ""
 msgid "A post"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:397
+#: lib/abuuba_web/live/profile_live.ex:403
 #, elixir-autogen, elixir-format
 msgid "Nobody yet."
 msgstr ""
@@ -4017,7 +4034,7 @@ msgstr ""
 msgid "Public posts tagged #%{tag}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:374
+#: lib/abuuba_web/live/profile_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr ""
@@ -4043,99 +4060,99 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1507
+#: lib/abuuba_web/live/settings_live.ex:1467
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:964
+#: lib/abuuba_web/live/settings_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:525
+#: lib/abuuba_web/live/settings_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:534
+#: lib/abuuba_web/live/settings_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:553
+#: lib/abuuba_web/live/settings_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:580
+#: lib/abuuba_web/live/settings_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:569
+#: lib/abuuba_web/live/settings_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:565
+#: lib/abuuba_web/live/settings_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:987
+#: lib/abuuba_web/live/settings_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:522
+#: lib/abuuba_web/live/settings_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:983
+#: lib/abuuba_web/live/settings_live.ex:951
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:527
+#: lib/abuuba_web/live/settings_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:591
+#: lib/abuuba_web/live/settings_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:502
+#: lib/abuuba_web/live/settings_live.ex:512
 #, elixir-autogen, elixir-format
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:962
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:972
+#: lib/abuuba_web/live/settings_live.ex:940
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:972
+#: lib/abuuba_web/live/settings_live.ex:940
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:516
+#: lib/abuuba_web/live/settings_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:504
+#: lib/abuuba_web/live/settings_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr ""
@@ -4844,6 +4861,7 @@ msgid "There is no list of that kind."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1329
+#: lib/abuuba_web/live/saved_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Which list"
 msgstr ""
@@ -4947,55 +4965,55 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:348
+#: lib/abuuba_web/live/settings_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:565
-#: lib/abuuba_web/live/settings_live.ex:366
+#: lib/abuuba_web/live/settings_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2139
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:346
+#: lib/abuuba_web/live/settings_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:398
+#: lib/abuuba_web/live/settings_live.ex:408
 #, elixir-autogen, elixir-format
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2137
-#: lib/abuuba_web/live/settings_live.ex:2292
+#: lib/abuuba_web/live/settings_live.ex:2079
+#: lib/abuuba_web/live/settings_live.ex:2234
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2287
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2236
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2076
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
@@ -5005,8 +5023,8 @@ msgstr ""
 msgid "Feature on my profile"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:320
-#: lib/abuuba_web/live/profile_live.ex:324
+#: lib/abuuba_web/live/profile_live.ex:326
+#: lib/abuuba_web/live/profile_live.ex:330
 #, elixir-autogen, elixir-format
 msgid "Featured accounts"
 msgstr ""
@@ -5016,55 +5034,55 @@ msgstr ""
 msgid "Stop featuring"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:493
+#: lib/abuuba_web/live/profile_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:274
+#: lib/abuuba_web/live/profile_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:682
+#: lib/abuuba_web/live/settings_live.ex:692
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:277
+#: lib/abuuba_web/live/profile_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:707
+#: lib/abuuba_web/live/settings_live.ex:717
 #, elixir-autogen, elixir-format
 msgid "Send it"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:293
+#: lib/abuuba_web/live/profile_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:716
+#: lib/abuuba_web/live/settings_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:693
-#: lib/abuuba_web/live/settings_live.ex:1866
+#: lib/abuuba_web/live/settings_live.ex:703
+#: lib/abuuba_web/live/settings_live.ex:1808
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:496
+#: lib/abuuba_web/live/profile_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1426
+#: lib/abuuba_web/live/settings_live.ex:1386
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5074,17 +5092,17 @@ msgstr ""
 msgid "To stop them, open this link:"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:483
+#: lib/abuuba_web/live/profile_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:700
+#: lib/abuuba_web/live/settings_live.ex:710
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:680
+#: lib/abuuba_web/live/settings_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr ""
@@ -5094,22 +5112,22 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1431
+#: lib/abuuba_web/live/settings_live.ex:1391
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:286
+#: lib/abuuba_web/live/profile_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1867
+#: lib/abuuba_web/live/settings_live.ex:1809
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:723
+#: lib/abuuba_web/live/settings_live.ex:733
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr ""
@@ -5198,6 +5216,8 @@ msgid "Ready-made texts a moderator picks instead of retyping. Kept for the serv
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/profile_live.ex:202
+#: lib/abuuba_web/live/report_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Report"
 msgstr ""
@@ -5395,7 +5415,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1010
+#: lib/abuuba_web/live/settings_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5543,42 +5563,42 @@ msgstr ""
 msgid "not offered"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:243
+#: lib/abuuba_web/live/profile_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:241
+#: lib/abuuba_web/live/profile_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:220
+#: lib/abuuba_web/live/profile_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:205
+#: lib/abuuba_web/live/profile_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:487
+#: lib/abuuba_web/components/status_component.ex:507
 #, elixir-autogen, elixir-format
 msgid "More"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:499
+#: lib/abuuba_web/components/status_component.ex:520
 #, elixir-autogen, elixir-format
 msgid "Mute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:506
+#: lib/abuuba_web/components/status_component.ex:527
 #, elixir-autogen, elixir-format
 msgid "Stops its notifications and takes it out of your timeline. Nobody is told."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:498
+#: lib/abuuba_web/components/status_component.ex:519
 #, elixir-autogen, elixir-format
 msgid "Unmute this conversation"
 msgstr ""
@@ -5588,7 +5608,7 @@ msgstr ""
 msgid "Posts from people you watch"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:235
+#: lib/abuuba_web/live/profile_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr ""
@@ -5653,7 +5673,7 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:243
+#: lib/abuuba_web/components/layouts.ex:267
 #: lib/abuuba_web/live/conversations_live.ex:46
 #: lib/abuuba_web/live/conversations_live.ex:62
 #, elixir-autogen, elixir-format
@@ -5747,22 +5767,22 @@ msgstr ""
 msgid "Who may read the blocklist"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:637
+#: lib/abuuba_web/live/settings_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:629
+#: lib/abuuba_web/live/settings_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:841
+#: lib/abuuba_web/live/settings_live.ex:851
 #, elixir-autogen, elixir-format
 msgid "Block a server"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:814
+#: lib/abuuba_web/live/settings_live.ex:824
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr ""
@@ -5773,7 +5793,7 @@ msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
 #: lib/abuuba_web/live/explore_live.ex:149
-#: lib/abuuba_web/live/profile_live.ex:534
+#: lib/abuuba_web/live/profile_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
@@ -5838,8 +5858,8 @@ msgstr ""
 msgid "Warned"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2312
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2254
+#: lib/abuuba_web/live/settings_live.ex:2257
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr ""
@@ -5854,18 +5874,18 @@ msgstr ""
 msgid "Requested"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:544
+#: lib/abuuba_web/live/profile_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:451
+#: lib/abuuba_web/components/status_component.ex:459
 #, elixir-autogen, elixir-format
 msgid "Delete this post? Other servers are told to forget it too."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:145
-#: lib/abuuba_web/live/settings_live.ex:953
+#: lib/abuuba_web/components/layouts.ex:155
+#: lib/abuuba_web/live/settings_live.ex:921
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr ""
@@ -5875,22 +5895,213 @@ msgstr ""
 msgid "That post is gone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:876
+#: lib/abuuba_web/live/follow_requests_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Let them follow"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:885
+#: lib/abuuba_web/live/follow_requests_live.ex:76
 #, elixir-autogen, elixir-format
 msgid "Turn them away"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:853
-#, elixir-autogen, elixir-format
-msgid "Waiting for your answer"
-msgstr ""
-
-#: lib/abuuba_web/live/settings_live.ex:855
+#: lib/abuuba_web/live/follow_requests_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Your account asks before letting somebody follow it. Turning one away tells them nothing, and they can ask again."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Anything else a moderator should know?"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "Are there posts that show it?"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:297
+#, elixir-autogen, elixir-format
+msgid "Blocked"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:303
+#, elixir-autogen, elixir-format
+msgid "Done"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:287
+#, elixir-autogen, elixir-format
+msgid "Everything mute does, and they cannot follow you or read your posts. They can tell."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:374
+#, elixir-autogen, elixir-format
+msgid "I do not like it"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:217
+#, elixir-autogen, elixir-format
+msgid "In your own words. This is optional."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:180
+#, elixir-autogen, elixir-format
+msgid "Include this post"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:392
+#, elixir-autogen, elixir-format
+msgid "It breaks the rules of this server"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:384
+#, elixir-autogen, elixir-format
+msgid "It does not fit any of the above."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:378
+#, elixir-autogen, elixir-format
+msgid "It is illegal"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:375
+#, elixir-autogen, elixir-format
+msgid "It is not something you want to see. This tells nobody."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:376
+#, elixir-autogen, elixir-format
+msgid "It is spam"
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:217
+#, elixir-autogen, elixir-format
+msgid "Looking for what you saved?"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:377
+#, elixir-autogen, elixir-format
+msgid "Malicious links, fake engagement, or the same thing over and over."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:280
+#, elixir-autogen, elixir-format
+msgid "Muted"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:258
+#, elixir-autogen, elixir-format
+msgid "Neither of these tells a moderator anything."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:155
+#: lib/abuuba_web/live/report_live.ex:199
+#, elixir-autogen, elixir-format
+msgid "Next"
+msgstr ""
+
+#: lib/abuuba_web/live/follow_requests_live.ex:53
+#, elixir-autogen, elixir-format
+msgid "Nobody is waiting. Anybody who asks to follow you turns up here."
+msgstr ""
+
+#: lib/abuuba_web/live/saved_live.ex:101
+#, elixir-autogen, elixir-format
+msgid "Nothing bookmarked yet. The bookmark under a post files it here, and tells nobody."
+msgstr ""
+
+#: lib/abuuba_web/live/saved_live.ex:105
+#, elixir-autogen, elixir-format
+msgid "Nothing favourited yet. The star under a post lands here, and its author is told."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "Nothing of theirs is here to point at."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:94
+#, elixir-autogen, elixir-format
+msgid "Report %{name}"
+msgstr ""
+
+#: lib/abuuba_web/components/status_component.ex:538
+#, elixir-autogen, elixir-format
+msgid "Report this post"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:237
+#, elixir-autogen, elixir-format
+msgid "Send the report"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:383
+#, elixir-autogen, elixir-format
+msgid "Something else"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:251
+#, elixir-autogen, elixir-format
+msgid "Thank you. A moderator will read this."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:265
+#, elixir-autogen, elixir-format
+msgid "Their posts leave your home timeline. They keep following you."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:252
+#, elixir-autogen, elixir-format
+msgid "Then here is what you can do yourself."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:230
+#, elixir-autogen, elixir-format
+msgid "This account is on %{domain}. Send a copy of this report there as well, without your name."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:169
+#, elixir-autogen, elixir-format
+msgid "Tick every one a moderator should read. You can tick none."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:139
+#, elixir-autogen, elixir-format
+msgid "Tick every one that applies."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:113
+#, elixir-autogen, elixir-format
+msgid "What is going on?"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:138
+#, elixir-autogen, elixir-format
+msgid "Which rules?"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "While you wait, you do not have to keep seeing them."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "You believe it breaks the law here or where you are."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:393
+#, elixir-autogen, elixir-format
+msgid "You know which rule it breaks."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:275
+#, elixir-autogen, elixir-format
+msgid "You stop seeing them everywhere. They can still follow you and are not told."
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:219
+#, elixir-autogen, elixir-format
+msgid "and"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -285,7 +285,7 @@ msgid "You are signed out."
 msgstr ""
 
 #: lib/abuuba_web/user_auth.ex:88
-#: lib/abuuba_web/user_auth.ex:205
+#: lib/abuuba_web/user_auth.ex:206
 #, elixir-autogen, elixir-format
 msgid "You have to be signed in to see that page."
 msgstr ""
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:902
+#: lib/abuuba_web/live/settings_live.ex:944
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -654,7 +654,7 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:247
 #: lib/abuuba_web/components/layouts.ex:256
-#: lib/abuuba_web/live/explore_live.ex:49
+#: lib/abuuba_web/live/explore_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr ""
@@ -662,7 +662,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:234
 #: lib/abuuba_web/components/layouts.ex:255
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2318
+#: lib/abuuba_web/live/settings_live.ex:2388
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -689,14 +689,14 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:237
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2319
+#: lib/abuuba_web/live/settings_live.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:249
 #: lib/abuuba_web/live/settings_live.ex:121
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2197
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -847,19 +847,19 @@ msgid "Allow more than one choice"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2313
+#: lib/abuuba_web/live/settings_live.ex:2383
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2308
+#: lib/abuuba_web/live/settings_live.ex:2378
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2309
+#: lib/abuuba_web/live/settings_live.ex:2379
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
@@ -914,13 +914,13 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3427
 #: lib/abuuba_web/live/compose_component.ex:1677
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/settings_live.ex:2310
+#: lib/abuuba_web/live/settings_live.ex:2380
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
@@ -931,7 +931,7 @@ msgid "Only the people you name"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2384
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
@@ -1214,9 +1214,9 @@ msgstr ""
 msgid "Block"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:113
+#: lib/abuuba_web/live/explore_live.ex:114
 #: lib/abuuba_web/live/profile_live.ex:144
-#: lib/abuuba_web/live/tag_live.ex:62
+#: lib/abuuba_web/live/tag_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/explore_live.ex:256
 #: lib/abuuba_web/live/profile_live.ex:789
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
@@ -1289,7 +1289,7 @@ msgid "Unblock"
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:162
-#: lib/abuuba_web/live/tag_live.ex:62
+#: lib/abuuba_web/live/tag_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
@@ -1503,8 +1503,8 @@ msgstr ""
 
 #: lib/abuuba_web/live/notifications_live.ex:469
 #: lib/abuuba_web/live/profile_live.ex:793
-#: lib/abuuba_web/live/settings_live.ex:2111
-#: lib/abuuba_web/live/settings_live.ex:2249
+#: lib/abuuba_web/live/settings_live.ex:2181
+#: lib/abuuba_web/live/settings_live.ex:2319
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -1579,7 +1579,7 @@ msgstr ""
 #: lib/abuuba_web/live/settings_live.ex:598
 #: lib/abuuba_web/live/settings_live.ex:643
 #: lib/abuuba_web/live/settings_live.ex:676
-#: lib/abuuba_web/live/settings_live.ex:1004
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:250
+#: lib/abuuba_web/live/explore_live.ex:257
 #: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:207
@@ -1673,12 +1673,12 @@ msgstr ""
 msgid "Nobody has posted publicly here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/tag_live.ex:77
+#: lib/abuuba_web/live/tag_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:123
+#: lib/abuuba_web/live/explore_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:251
+#: lib/abuuba_web/live/explore_live.ex:258
 #: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:206
@@ -1730,7 +1730,7 @@ msgstr ""
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:65
+#: lib/abuuba_web/live/explore_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "What to explore"
 msgstr ""
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:893
+#: lib/abuuba_web/live/settings_live.ex:935
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
@@ -1766,7 +1766,7 @@ msgid "About you"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3378
-#: lib/abuuba_web/live/settings_live.ex:2114
+#: lib/abuuba_web/live/settings_live.ex:2184
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
@@ -1781,37 +1781,37 @@ msgstr ""
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2107
+#: lib/abuuba_web/live/settings_live.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2285
+#: lib/abuuba_web/live/settings_live.ex:2355
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2113
+#: lib/abuuba_web/live/settings_live.ex:2183
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2138
+#: lib/abuuba_web/live/settings_live.ex:2208
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:955
+#: lib/abuuba_web/live/settings_live.ex:997
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2350
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:897
+#: lib/abuuba_web/live/settings_live.ex:939
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
@@ -1828,22 +1828,22 @@ msgstr ""
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2366
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1608
+#: lib/abuuba_web/live/settings_live.ex:1658
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2136
+#: lib/abuuba_web/live/settings_live.ex:2206
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
@@ -1858,33 +1858,33 @@ msgstr ""
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2110
-#: lib/abuuba_web/live/settings_live.ex:2255
+#: lib/abuuba_web/live/settings_live.ex:2180
+#: lib/abuuba_web/live/settings_live.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2337
+#: lib/abuuba_web/live/settings_live.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2338
+#: lib/abuuba_web/live/settings_live.ex:2408
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2286
+#: lib/abuuba_web/live/settings_live.ex:2356
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2364
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2132
+#: lib/abuuba_web/live/settings_live.ex:2202
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
@@ -1894,17 +1894,17 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2284
+#: lib/abuuba_web/live/settings_live.ex:2354
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2282
+#: lib/abuuba_web/live/settings_live.ex:2352
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/settings_live.ex:2359
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
@@ -1914,12 +1914,12 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:984
+#: lib/abuuba_web/live/settings_live.ex:1026
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:998
+#: lib/abuuba_web/live/settings_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
@@ -1929,47 +1929,47 @@ msgstr ""
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2139
+#: lib/abuuba_web/live/settings_live.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/settings_live.ex:2371
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2175
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2108
+#: lib/abuuba_web/live/settings_live.ex:2178
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2179
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2176
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2322
+#: lib/abuuba_web/live/settings_live.ex:2392
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2320
+#: lib/abuuba_web/live/settings_live.ex:2390
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/settings_live.ex:2363
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1986,38 +1986,38 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2112
+#: lib/abuuba_web/live/settings_live.ex:2182
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:915
+#: lib/abuuba_web/live/settings_live.ex:957
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:906
+#: lib/abuuba_web/live/settings_live.ex:948
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2304
+#: lib/abuuba_web/live/settings_live.ex:2374
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:978
+#: lib/abuuba_web/live/settings_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3746
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2171
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1583
+#: lib/abuuba_web/live/settings_live.ex:1633
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
@@ -2027,27 +2027,27 @@ msgstr ""
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2357
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/settings_live.ex:2358
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2321
+#: lib/abuuba_web/live/settings_live.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:851
+#: lib/abuuba_web/live/settings_live.ex:893
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:876
+#: lib/abuuba_web/live/settings_live.ex:918
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2295
+#: lib/abuuba_web/live/settings_live.ex:2365
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
@@ -2077,7 +2077,7 @@ msgstr ""
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2133
+#: lib/abuuba_web/live/settings_live.ex:2203
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
@@ -2093,7 +2093,7 @@ msgstr ""
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2204
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
@@ -2108,37 +2108,37 @@ msgstr ""
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2135
+#: lib/abuuba_web/live/settings_live.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:872
+#: lib/abuuba_web/live/settings_live.ex:914
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2283
+#: lib/abuuba_web/live/settings_live.ex:2353
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:888
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2201
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:995
+#: lib/abuuba_web/live/settings_live.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2294,110 +2294,110 @@ msgstr ""
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1866
+#: lib/abuuba_web/live/settings_live.ex:1936
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2212
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1204
+#: lib/abuuba_web/live/settings_live.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2185
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1234
+#: lib/abuuba_web/live/settings_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1850
+#: lib/abuuba_web/live/settings_live.ex:1920
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1201
+#: lib/abuuba_web/live/settings_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1869
+#: lib/abuuba_web/live/settings_live.ex:1939
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1208
-#: lib/abuuba_web/live/settings_live.ex:1846
+#: lib/abuuba_web/live/settings_live.ex:1250
+#: lib/abuuba_web/live/settings_live.ex:1916
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1179
+#: lib/abuuba_web/live/settings_live.ex:1221
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1861
+#: lib/abuuba_web/live/settings_live.ex:1931
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1930
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1862
+#: lib/abuuba_web/live/settings_live.ex:1932
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1867
+#: lib/abuuba_web/live/settings_live.ex:1937
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1870
+#: lib/abuuba_web/live/settings_live.ex:1940
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1871
+#: lib/abuuba_web/live/settings_live.ex:1941
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1868
+#: lib/abuuba_web/live/settings_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1187
+#: lib/abuuba_web/live/settings_live.ex:1229
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1225
+#: lib/abuuba_web/live/settings_live.ex:1267
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1214
+#: lib/abuuba_web/live/settings_live.ex:1256
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1216
+#: lib/abuuba_web/live/settings_live.ex:1258
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
@@ -2693,7 +2693,7 @@ msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3339
-#: lib/abuuba_web/live/settings_live.ex:1636
+#: lib/abuuba_web/live/settings_live.ex:1686
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
@@ -2827,17 +2827,17 @@ msgstr ""
 msgid "What is trending now"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:77
+#: lib/abuuba_web/live/explore_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2169
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1250
+#: lib/abuuba_web/live/settings_live.ex:1292
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
@@ -2852,7 +2852,7 @@ msgstr ""
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2144
+#: lib/abuuba_web/live/settings_live.ex:2214
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2877,7 +2877,7 @@ msgstr ""
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1261
+#: lib/abuuba_web/live/settings_live.ex:1303
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
@@ -2892,12 +2892,12 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2186
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1245
+#: lib/abuuba_web/live/settings_live.ex:1287
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
@@ -2907,7 +2907,7 @@ msgstr ""
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1268
+#: lib/abuuba_web/live/settings_live.ex:1310
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
@@ -2937,7 +2937,7 @@ msgstr ""
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1282
+#: lib/abuuba_web/live/settings_live.ex:1324
 #, elixir-autogen, elixir-format
 msgid "Take it back"
 msgstr ""
@@ -2952,12 +2952,12 @@ msgstr ""
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1266
+#: lib/abuuba_web/live/settings_live.ex:1308
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1257
+#: lib/abuuba_web/live/settings_live.ex:1299
 #, elixir-autogen, elixir-format
 msgid "What it is for"
 msgstr ""
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1288
+#: lib/abuuba_web/live/settings_live.ex:1330
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
@@ -2988,7 +2988,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2166
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3124,245 +3124,245 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1995
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1986
+#: lib/abuuba_web/live/settings_live.ex:2056
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1902
+#: lib/abuuba_web/live/settings_live.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1883
+#: lib/abuuba_web/live/settings_live.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2152
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2187
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1908
+#: lib/abuuba_web/live/settings_live.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2144
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2147
+#: lib/abuuba_web/live/settings_live.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2153
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2055
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2070
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2140
+#: lib/abuuba_web/live/settings_live.ex:2145
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2072
+#: lib/abuuba_web/live/settings_live.ex:2142
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1892
+#: lib/abuuba_web/live/settings_live.ex:1962
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2080
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1889
+#: lib/abuuba_web/live/settings_live.ex:1959
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1897
+#: lib/abuuba_web/live/settings_live.ex:1967
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2086
+#: lib/abuuba_web/live/settings_live.ex:2156
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2088
+#: lib/abuuba_web/live/settings_live.ex:2158
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2089
+#: lib/abuuba_web/live/settings_live.ex:2159
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2162
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2160
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2161
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1053
+#: lib/abuuba_web/live/settings_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1941
+#: lib/abuuba_web/live/settings_live.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1048
+#: lib/abuuba_web/live/settings_live.ex:1090
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1959
+#: lib/abuuba_web/live/settings_live.ex:2029
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1058
+#: lib/abuuba_web/live/settings_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1046
+#: lib/abuuba_web/live/settings_live.ex:1088
 #, elixir-autogen, elixir-format
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1015
+#: lib/abuuba_web/live/settings_live.ex:1057
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1972
+#: lib/abuuba_web/live/settings_live.ex:2042
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1949
+#: lib/abuuba_web/live/settings_live.ex:2019
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1072
-#: lib/abuuba_web/live/settings_live.ex:1921
-#: lib/abuuba_web/live/settings_live.ex:2252
+#: lib/abuuba_web/live/settings_live.ex:1114
+#: lib/abuuba_web/live/settings_live.ex:1991
+#: lib/abuuba_web/live/settings_live.ex:2322
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1042
+#: lib/abuuba_web/live/settings_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1026
+#: lib/abuuba_web/live/settings_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2045
+#: lib/abuuba_web/live/settings_live.ex:2115
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1010
+#: lib/abuuba_web/live/settings_live.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1945
+#: lib/abuuba_web/live/settings_live.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2035
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2046
+#: lib/abuuba_web/live/settings_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1923
+#: lib/abuuba_web/live/settings_live.ex:1993
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1036
+#: lib/abuuba_web/live/settings_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1008
+#: lib/abuuba_web/live/settings_live.ex:1050
 #, elixir-autogen, elixir-format
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1938
+#: lib/abuuba_web/live/settings_live.ex:2008
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2041
+#: lib/abuuba_web/live/settings_live.ex:2111
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
@@ -3392,7 +3392,7 @@ msgstr ""
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1522
+#: lib/abuuba_web/live/settings_live.ex:1572
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
@@ -3429,7 +3429,7 @@ msgstr ""
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1505
+#: lib/abuuba_web/live/settings_live.ex:1555
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
@@ -3439,7 +3439,7 @@ msgstr ""
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1499
+#: lib/abuuba_web/live/settings_live.ex:1549
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
@@ -3823,75 +3823,75 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1085
+#: lib/abuuba_web/live/settings_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/settings_live.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:812
-#: lib/abuuba_web/live/settings_live.ex:2253
+#: lib/abuuba_web/live/settings_live.ex:2323
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2250
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2254
+#: lib/abuuba_web/live/settings_live.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1127
+#: lib/abuuba_web/live/settings_live.ex:1169
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1110
+#: lib/abuuba_web/live/settings_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2188
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2251
+#: lib/abuuba_web/live/settings_live.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1074
+#: lib/abuuba_web/live/settings_live.ex:1116
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1395
+#: lib/abuuba_web/live/settings_live.ex:1445
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1092
+#: lib/abuuba_web/live/settings_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3911,13 +3911,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2258
+#: lib/abuuba_web/live/settings_live.ex:2328
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1116
-#: lib/abuuba_web/live/settings_live.ex:1401
+#: lib/abuuba_web/live/settings_live.ex:1158
+#: lib/abuuba_web/live/settings_live.ex:1451
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3927,7 +3927,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1087
+#: lib/abuuba_web/live/settings_live.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3937,67 +3937,67 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1166
+#: lib/abuuba_web/live/settings_live.ex:1208
 #, elixir-autogen, elixir-format
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1164
+#: lib/abuuba_web/live/settings_live.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1130
+#: lib/abuuba_web/live/settings_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1069
+#: lib/abuuba_web/live/settings_live.ex:1111
 #, elixir-autogen, elixir-format
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2150
+#: lib/abuuba_web/live/settings_live.ex:2220
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1147
+#: lib/abuuba_web/live/settings_live.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1428
+#: lib/abuuba_web/live/settings_live.ex:1478
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1425
+#: lib/abuuba_web/live/settings_live.ex:1475
 #, elixir-autogen, elixir-format
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1137
+#: lib/abuuba_web/live/settings_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1421
+#: lib/abuuba_web/live/settings_live.ex:1471
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1152
+#: lib/abuuba_web/live/settings_live.ex:1194
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1132
+#: lib/abuuba_web/live/settings_live.ex:1174
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1142
+#: lib/abuuba_web/live/settings_live.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
@@ -4043,12 +4043,12 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1457
+#: lib/abuuba_web/live/settings_live.ex:1507
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:922
+#: lib/abuuba_web/live/settings_live.ex:964
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
@@ -4083,7 +4083,7 @@ msgstr ""
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:945
+#: lib/abuuba_web/live/settings_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
@@ -4093,7 +4093,7 @@ msgstr ""
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:941
+#: lib/abuuba_web/live/settings_live.ex:983
 #, elixir-autogen, elixir-format
 msgid "Nothing recorded yet."
 msgstr ""
@@ -4115,17 +4115,17 @@ msgstr[1] ""
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:920
+#: lib/abuuba_web/live/settings_live.ex:962
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:930
+#: lib/abuuba_web/live/settings_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:930
+#: lib/abuuba_web/live/settings_live.ex:972
 #, elixir-autogen, elixir-format
 msgid "Signed in"
 msgstr ""
@@ -4947,12 +4947,12 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2228
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
@@ -4968,7 +4968,7 @@ msgstr ""
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2069
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr ""
@@ -4983,19 +4983,19 @@ msgstr ""
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2067
-#: lib/abuuba_web/live/settings_live.ex:2222
+#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2292
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2217
-#: lib/abuuba_web/live/settings_live.ex:2224
+#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2064
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
@@ -5054,7 +5054,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/abuuba_web/live/settings_live.ex:693
-#: lib/abuuba_web/live/settings_live.ex:1796
+#: lib/abuuba_web/live/settings_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
@@ -5064,7 +5064,7 @@ msgstr ""
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1376
+#: lib/abuuba_web/live/settings_live.ex:1426
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5094,7 +5094,7 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1381
+#: lib/abuuba_web/live/settings_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
@@ -5104,7 +5104,7 @@ msgstr ""
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1797
+#: lib/abuuba_web/live/settings_live.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -5395,7 +5395,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:968
+#: lib/abuuba_web/live/settings_live.ex:1010
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5772,7 +5772,7 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:148
+#: lib/abuuba_web/live/explore_live.ex:149
 #: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
@@ -5838,8 +5838,8 @@ msgstr ""
 msgid "Warned"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2242
-#: lib/abuuba_web/live/settings_live.ex:2245
+#: lib/abuuba_web/live/settings_live.ex:2312
+#: lib/abuuba_web/live/settings_live.ex:2315
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr ""
@@ -5849,7 +5849,7 @@ msgstr ""
 msgid "Cancel follow request"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:117
+#: lib/abuuba_web/live/explore_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
@@ -5865,7 +5865,7 @@ msgid "Delete this post? Other servers are told to forget it too."
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:145
-#: lib/abuuba_web/live/settings_live.ex:911
+#: lib/abuuba_web/live/settings_live.ex:953
 #, elixir-autogen, elixir-format
 msgid "Sign out"
 msgstr ""
@@ -5873,4 +5873,24 @@ msgstr ""
 #: lib/abuuba_web/live/post_actions.ex:428
 #, elixir-autogen, elixir-format
 msgid "That post is gone."
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:876
+#, elixir-autogen, elixir-format
+msgid "Let them follow"
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:885
+#, elixir-autogen, elixir-format
+msgid "Turn them away"
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:853
+#, elixir-autogen, elixir-format
+msgid "Waiting for your answer"
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:855
+#, elixir-autogen, elixir-format
+msgid "Your account asks before letting somebody follow it. Turning one away tells them nothing, and they can ask again."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -285,7 +285,7 @@ msgid "You are signed out."
 msgstr ""
 
 #: lib/abuuba_web/user_auth.ex:88
-#: lib/abuuba_web/user_auth.ex:205
+#: lib/abuuba_web/user_auth.ex:206
 #, elixir-autogen, elixir-format
 msgid "You have to be signed in to see that page."
 msgstr ""
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:902
+#: lib/abuuba_web/live/settings_live.ex:944
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -654,7 +654,7 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:247
 #: lib/abuuba_web/components/layouts.ex:256
-#: lib/abuuba_web/live/explore_live.ex:49
+#: lib/abuuba_web/live/explore_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr ""
@@ -662,7 +662,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:234
 #: lib/abuuba_web/components/layouts.ex:255
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2318
+#: lib/abuuba_web/live/settings_live.ex:2388
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -689,14 +689,14 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:237
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2319
+#: lib/abuuba_web/live/settings_live.ex:2389
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:249
 #: lib/abuuba_web/live/settings_live.ex:121
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2197
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -847,19 +847,19 @@ msgid "Allow more than one choice"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2313
+#: lib/abuuba_web/live/settings_live.ex:2383
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2308
+#: lib/abuuba_web/live/settings_live.ex:2378
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2309
+#: lib/abuuba_web/live/settings_live.ex:2379
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
@@ -914,13 +914,13 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3427
 #: lib/abuuba_web/live/compose_component.ex:1677
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2385
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/settings_live.ex:2310
+#: lib/abuuba_web/live/settings_live.ex:2380
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
@@ -931,7 +931,7 @@ msgid "Only the people you name"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2384
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
@@ -1214,9 +1214,9 @@ msgstr ""
 msgid "Block"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:113
+#: lib/abuuba_web/live/explore_live.ex:114
 #: lib/abuuba_web/live/profile_live.ex:144
-#: lib/abuuba_web/live/tag_live.ex:62
+#: lib/abuuba_web/live/tag_live.ex:63
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow"
 msgstr ""
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:249
+#: lib/abuuba_web/live/explore_live.ex:256
 #: lib/abuuba_web/live/profile_live.ex:789
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
@@ -1289,7 +1289,7 @@ msgid "Unblock"
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:162
-#: lib/abuuba_web/live/tag_live.ex:62
+#: lib/abuuba_web/live/tag_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
@@ -1503,8 +1503,8 @@ msgstr ""
 
 #: lib/abuuba_web/live/notifications_live.ex:469
 #: lib/abuuba_web/live/profile_live.ex:793
-#: lib/abuuba_web/live/settings_live.ex:2111
-#: lib/abuuba_web/live/settings_live.ex:2249
+#: lib/abuuba_web/live/settings_live.ex:2181
+#: lib/abuuba_web/live/settings_live.ex:2319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows"
 msgstr ""
@@ -1579,7 +1579,7 @@ msgstr ""
 #: lib/abuuba_web/live/settings_live.ex:598
 #: lib/abuuba_web/live/settings_live.ex:643
 #: lib/abuuba_web/live/settings_live.ex:676
-#: lib/abuuba_web/live/settings_live.ex:1004
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:250
+#: lib/abuuba_web/live/explore_live.ex:257
 #: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:207
@@ -1673,12 +1673,12 @@ msgstr ""
 msgid "Nobody has posted publicly here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/tag_live.ex:77
+#: lib/abuuba_web/live/tag_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:123
+#: lib/abuuba_web/live/explore_live.ex:124
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1688,7 +1688,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:251
+#: lib/abuuba_web/live/explore_live.ex:258
 #: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:206
@@ -1730,7 +1730,7 @@ msgstr ""
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:65
+#: lib/abuuba_web/live/explore_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "What to explore"
 msgstr ""
@@ -1755,7 +1755,7 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:893
+#: lib/abuuba_web/live/settings_live.ex:935
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
@@ -1766,7 +1766,7 @@ msgid "About you"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3378
-#: lib/abuuba_web/live/settings_live.ex:2114
+#: lib/abuuba_web/live/settings_live.ex:2184
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
@@ -1781,37 +1781,37 @@ msgstr ""
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2107
+#: lib/abuuba_web/live/settings_live.ex:2177
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2285
+#: lib/abuuba_web/live/settings_live.ex:2355
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2113
+#: lib/abuuba_web/live/settings_live.ex:2183
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2138
+#: lib/abuuba_web/live/settings_live.ex:2208
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:955
+#: lib/abuuba_web/live/settings_live.ex:997
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2280
+#: lib/abuuba_web/live/settings_live.ex:2350
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:897
+#: lib/abuuba_web/live/settings_live.ex:939
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
@@ -1828,22 +1828,22 @@ msgstr ""
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2366
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1608
+#: lib/abuuba_web/live/settings_live.ex:1658
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2281
+#: lib/abuuba_web/live/settings_live.ex:2351
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2136
+#: lib/abuuba_web/live/settings_live.ex:2206
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
@@ -1858,33 +1858,33 @@ msgstr ""
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2110
-#: lib/abuuba_web/live/settings_live.ex:2255
+#: lib/abuuba_web/live/settings_live.ex:2180
+#: lib/abuuba_web/live/settings_live.ex:2325
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2337
+#: lib/abuuba_web/live/settings_live.ex:2407
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2338
+#: lib/abuuba_web/live/settings_live.ex:2408
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2286
+#: lib/abuuba_web/live/settings_live.ex:2356
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2364
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2132
+#: lib/abuuba_web/live/settings_live.ex:2202
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
@@ -1894,17 +1894,17 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2284
+#: lib/abuuba_web/live/settings_live.ex:2354
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2282
+#: lib/abuuba_web/live/settings_live.ex:2352
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2289
+#: lib/abuuba_web/live/settings_live.ex:2359
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
@@ -1914,12 +1914,12 @@ msgstr ""
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:984
+#: lib/abuuba_web/live/settings_live.ex:1026
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:998
+#: lib/abuuba_web/live/settings_live.ex:1040
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
@@ -1929,47 +1929,47 @@ msgstr ""
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2139
+#: lib/abuuba_web/live/settings_live.ex:2209
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2301
+#: lib/abuuba_web/live/settings_live.ex:2371
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2175
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2108
+#: lib/abuuba_web/live/settings_live.ex:2178
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2179
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2176
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2322
+#: lib/abuuba_web/live/settings_live.ex:2392
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2320
+#: lib/abuuba_web/live/settings_live.ex:2390
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/settings_live.ex:2363
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1986,38 +1986,38 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2112
+#: lib/abuuba_web/live/settings_live.ex:2182
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:915
+#: lib/abuuba_web/live/settings_live.ex:957
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:906
+#: lib/abuuba_web/live/settings_live.ex:948
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2304
+#: lib/abuuba_web/live/settings_live.ex:2374
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:978
+#: lib/abuuba_web/live/settings_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3746
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2171
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1583
+#: lib/abuuba_web/live/settings_live.ex:1633
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
@@ -2027,27 +2027,27 @@ msgstr ""
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2357
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2288
+#: lib/abuuba_web/live/settings_live.ex:2358
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2321
+#: lib/abuuba_web/live/settings_live.ex:2391
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:851
+#: lib/abuuba_web/live/settings_live.ex:893
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:876
+#: lib/abuuba_web/live/settings_live.ex:918
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2295
+#: lib/abuuba_web/live/settings_live.ex:2365
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2367
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
@@ -2077,7 +2077,7 @@ msgstr ""
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2133
+#: lib/abuuba_web/live/settings_live.ex:2203
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
@@ -2093,7 +2093,7 @@ msgstr ""
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2204
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
@@ -2108,37 +2108,37 @@ msgstr ""
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2135
+#: lib/abuuba_web/live/settings_live.ex:2205
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:872
+#: lib/abuuba_web/live/settings_live.ex:914
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2283
+#: lib/abuuba_web/live/settings_live.ex:2353
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:888
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2131
+#: lib/abuuba_web/live/settings_live.ex:2201
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:995
+#: lib/abuuba_web/live/settings_live.ex:1037
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2207
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2294,110 +2294,110 @@ msgstr ""
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1866
+#: lib/abuuba_web/live/settings_live.ex:1936
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2212
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1204
+#: lib/abuuba_web/live/settings_live.ex:1246
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2185
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1234
+#: lib/abuuba_web/live/settings_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1850
+#: lib/abuuba_web/live/settings_live.ex:1920
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1201
+#: lib/abuuba_web/live/settings_live.ex:1243
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1869
+#: lib/abuuba_web/live/settings_live.ex:1939
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1208
-#: lib/abuuba_web/live/settings_live.ex:1846
+#: lib/abuuba_web/live/settings_live.ex:1250
+#: lib/abuuba_web/live/settings_live.ex:1916
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1179
+#: lib/abuuba_web/live/settings_live.ex:1221
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1861
+#: lib/abuuba_web/live/settings_live.ex:1931
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1930
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1862
+#: lib/abuuba_web/live/settings_live.ex:1932
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1867
+#: lib/abuuba_web/live/settings_live.ex:1937
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1870
+#: lib/abuuba_web/live/settings_live.ex:1940
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1871
+#: lib/abuuba_web/live/settings_live.ex:1941
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1868
+#: lib/abuuba_web/live/settings_live.ex:1938
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1187
+#: lib/abuuba_web/live/settings_live.ex:1229
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1225
+#: lib/abuuba_web/live/settings_live.ex:1267
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1214
+#: lib/abuuba_web/live/settings_live.ex:1256
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1216
+#: lib/abuuba_web/live/settings_live.ex:1258
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
@@ -2693,7 +2693,7 @@ msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3339
-#: lib/abuuba_web/live/settings_live.ex:1636
+#: lib/abuuba_web/live/settings_live.ex:1686
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
@@ -2827,17 +2827,17 @@ msgstr ""
 msgid "What is trending now"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:77
+#: lib/abuuba_web/live/explore_live.ex:78
 #, elixir-autogen, elixir-format
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2169
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1250
+#: lib/abuuba_web/live/settings_live.ex:1292
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
@@ -2852,7 +2852,7 @@ msgstr ""
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2144
+#: lib/abuuba_web/live/settings_live.ex:2214
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2877,7 +2877,7 @@ msgstr ""
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1261
+#: lib/abuuba_web/live/settings_live.ex:1303
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
@@ -2892,12 +2892,12 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2186
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1245
+#: lib/abuuba_web/live/settings_live.ex:1287
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
@@ -2907,7 +2907,7 @@ msgstr ""
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1268
+#: lib/abuuba_web/live/settings_live.ex:1310
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
@@ -2937,7 +2937,7 @@ msgstr ""
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1282
+#: lib/abuuba_web/live/settings_live.ex:1324
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take it back"
 msgstr ""
@@ -2952,12 +2952,12 @@ msgstr ""
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1266
+#: lib/abuuba_web/live/settings_live.ex:1308
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1257
+#: lib/abuuba_web/live/settings_live.ex:1299
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What it is for"
 msgstr ""
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1288
+#: lib/abuuba_web/live/settings_live.ex:1330
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
@@ -2988,7 +2988,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2166
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3124,245 +3124,245 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr "This account has been disabled. Contact the moderators."
 
-#: lib/abuuba_web/live/settings_live.ex:1995
+#: lib/abuuba_web/live/settings_live.ex:2065
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1986
+#: lib/abuuba_web/live/settings_live.ex:2056
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1902
+#: lib/abuuba_web/live/settings_live.ex:1972
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2059
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1883
+#: lib/abuuba_web/live/settings_live.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2152
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2187
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1908
+#: lib/abuuba_web/live/settings_live.ex:1978
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2144
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2147
+#: lib/abuuba_web/live/settings_live.ex:2217
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2081
+#: lib/abuuba_web/live/settings_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2153
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2055
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2070
-#: lib/abuuba_web/live/settings_live.ex:2075
+#: lib/abuuba_web/live/settings_live.ex:2140
+#: lib/abuuba_web/live/settings_live.ex:2145
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2072
+#: lib/abuuba_web/live/settings_live.ex:2142
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2073
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1892
+#: lib/abuuba_web/live/settings_live.ex:1962
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2080
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1889
+#: lib/abuuba_web/live/settings_live.ex:1959
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1897
+#: lib/abuuba_web/live/settings_live.ex:1967
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2086
+#: lib/abuuba_web/live/settings_live.ex:2156
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2088
+#: lib/abuuba_web/live/settings_live.ex:2158
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2089
+#: lib/abuuba_web/live/settings_live.ex:2159
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2162
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2160
 #, elixir-autogen, elixir-format, fuzzy
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2161
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1053
+#: lib/abuuba_web/live/settings_live.ex:1095
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1941
+#: lib/abuuba_web/live/settings_live.ex:2011
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1048
+#: lib/abuuba_web/live/settings_live.ex:1090
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1959
+#: lib/abuuba_web/live/settings_live.ex:2029
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1058
+#: lib/abuuba_web/live/settings_live.ex:1100
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1046
+#: lib/abuuba_web/live/settings_live.ex:1088
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1015
+#: lib/abuuba_web/live/settings_live.ex:1057
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1972
+#: lib/abuuba_web/live/settings_live.ex:2042
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1949
+#: lib/abuuba_web/live/settings_live.ex:2019
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1072
-#: lib/abuuba_web/live/settings_live.ex:1921
-#: lib/abuuba_web/live/settings_live.ex:2252
+#: lib/abuuba_web/live/settings_live.ex:1114
+#: lib/abuuba_web/live/settings_live.ex:1991
+#: lib/abuuba_web/live/settings_live.ex:2322
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1042
+#: lib/abuuba_web/live/settings_live.ex:1084
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1026
+#: lib/abuuba_web/live/settings_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2045
+#: lib/abuuba_web/live/settings_live.ex:2115
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1010
+#: lib/abuuba_web/live/settings_live.ex:1052
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1945
+#: lib/abuuba_web/live/settings_live.ex:2015
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2035
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2046
+#: lib/abuuba_web/live/settings_live.ex:2116
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1923
+#: lib/abuuba_web/live/settings_live.ex:1993
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1036
+#: lib/abuuba_web/live/settings_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1008
+#: lib/abuuba_web/live/settings_live.ex:1050
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1938
+#: lib/abuuba_web/live/settings_live.ex:2008
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2041
+#: lib/abuuba_web/live/settings_live.ex:2111
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
@@ -3392,7 +3392,7 @@ msgstr ""
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1522
+#: lib/abuuba_web/live/settings_live.ex:1572
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
@@ -3429,7 +3429,7 @@ msgstr ""
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1505
+#: lib/abuuba_web/live/settings_live.ex:1555
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
@@ -3439,7 +3439,7 @@ msgstr ""
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1499
+#: lib/abuuba_web/live/settings_live.ex:1549
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
@@ -3823,75 +3823,75 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1085
+#: lib/abuuba_web/live/settings_live.ex:1127
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/settings_live.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:812
-#: lib/abuuba_web/live/settings_live.ex:2253
+#: lib/abuuba_web/live/settings_live.ex:2323
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2250
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2254
+#: lib/abuuba_web/live/settings_live.ex:2324
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1127
+#: lib/abuuba_web/live/settings_live.ex:1169
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1110
+#: lib/abuuba_web/live/settings_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2188
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2251
+#: lib/abuuba_web/live/settings_live.ex:2321
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1074
+#: lib/abuuba_web/live/settings_live.ex:1116
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1395
+#: lib/abuuba_web/live/settings_live.ex:1445
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1092
+#: lib/abuuba_web/live/settings_live.ex:1134
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3911,13 +3911,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2258
+#: lib/abuuba_web/live/settings_live.ex:2328
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1116
-#: lib/abuuba_web/live/settings_live.ex:1401
+#: lib/abuuba_web/live/settings_live.ex:1158
+#: lib/abuuba_web/live/settings_live.ex:1451
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3927,7 +3927,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1087
+#: lib/abuuba_web/live/settings_live.ex:1129
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3937,67 +3937,67 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1166
+#: lib/abuuba_web/live/settings_live.ex:1208
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1164
+#: lib/abuuba_web/live/settings_live.ex:1206
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1130
+#: lib/abuuba_web/live/settings_live.ex:1172
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1069
+#: lib/abuuba_web/live/settings_live.ex:1111
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2150
+#: lib/abuuba_web/live/settings_live.ex:2220
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1147
+#: lib/abuuba_web/live/settings_live.ex:1189
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1428
+#: lib/abuuba_web/live/settings_live.ex:1478
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1425
+#: lib/abuuba_web/live/settings_live.ex:1475
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1137
+#: lib/abuuba_web/live/settings_live.ex:1179
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1421
+#: lib/abuuba_web/live/settings_live.ex:1471
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1152
+#: lib/abuuba_web/live/settings_live.ex:1194
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1132
+#: lib/abuuba_web/live/settings_live.ex:1174
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1142
+#: lib/abuuba_web/live/settings_live.ex:1184
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
@@ -4043,12 +4043,12 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1457
+#: lib/abuuba_web/live/settings_live.ex:1507
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:922
+#: lib/abuuba_web/live/settings_live.ex:964
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
@@ -4083,7 +4083,7 @@ msgstr ""
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:945
+#: lib/abuuba_web/live/settings_live.ex:987
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
@@ -4093,7 +4093,7 @@ msgstr ""
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:941
+#: lib/abuuba_web/live/settings_live.ex:983
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing recorded yet."
 msgstr ""
@@ -4115,17 +4115,17 @@ msgstr[1] ""
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:920
+#: lib/abuuba_web/live/settings_live.ex:962
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:930
+#: lib/abuuba_web/live/settings_live.ex:972
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:930
+#: lib/abuuba_web/live/settings_live.ex:972
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signed in"
 msgstr ""
@@ -4947,12 +4947,12 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2228
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
@@ -4968,7 +4968,7 @@ msgstr ""
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2069
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One picture at a time."
 msgstr ""
@@ -4983,19 +4983,19 @@ msgstr ""
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2067
-#: lib/abuuba_web/live/settings_live.ex:2222
+#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2292
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2217
-#: lib/abuuba_web/live/settings_live.ex:2224
+#: lib/abuuba_web/live/settings_live.ex:2287
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2064
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
@@ -5054,7 +5054,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/abuuba_web/live/settings_live.ex:693
-#: lib/abuuba_web/live/settings_live.ex:1796
+#: lib/abuuba_web/live/settings_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
@@ -5064,7 +5064,7 @@ msgstr ""
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1376
+#: lib/abuuba_web/live/settings_live.ex:1426
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5094,7 +5094,7 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1381
+#: lib/abuuba_web/live/settings_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
@@ -5104,7 +5104,7 @@ msgstr ""
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1797
+#: lib/abuuba_web/live/settings_live.ex:1867
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -5395,7 +5395,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:968
+#: lib/abuuba_web/live/settings_live.ex:1010
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5772,7 +5772,7 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:148
+#: lib/abuuba_web/live/explore_live.ex:149
 #: lib/abuuba_web/live/profile_live.ex:534
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
@@ -5838,8 +5838,8 @@ msgstr ""
 msgid "Warned"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2242
-#: lib/abuuba_web/live/settings_live.ex:2245
+#: lib/abuuba_web/live/settings_live.ex:2312
+#: lib/abuuba_web/live/settings_live.ex:2315
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr ""
@@ -5849,7 +5849,7 @@ msgstr ""
 msgid "Cancel follow request"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:117
+#: lib/abuuba_web/live/explore_live.ex:118
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
@@ -5865,7 +5865,7 @@ msgid "Delete this post? Other servers are told to forget it too."
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:145
-#: lib/abuuba_web/live/settings_live.ex:911
+#: lib/abuuba_web/live/settings_live.ex:953
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sign out"
 msgstr ""
@@ -5873,4 +5873,24 @@ msgstr ""
 #: lib/abuuba_web/live/post_actions.ex:428
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is gone."
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:876
+#, elixir-autogen, elixir-format
+msgid "Let them follow"
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:885
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Turn them away"
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:853
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Waiting for your answer"
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:855
+#, elixir-autogen, elixir-format
+msgid "Your account asks before letting somebody follow it. Turning one away tells them nothing, and they can ask again."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -37,8 +37,8 @@ msgstr[1] ""
 msgid "Actions"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:289
-#: lib/abuuba_web/components/layouts.ex:304
+#: lib/abuuba_web/components/layouts.ex:326
+#: lib/abuuba_web/components/layouts.ex:341
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
@@ -54,7 +54,7 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:296
+#: lib/abuuba_web/components/layouts.ex:333
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
@@ -64,7 +64,7 @@ msgstr ""
 msgid "That language is not available."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:281
+#: lib/abuuba_web/components/layouts.ex:318
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Turn off two-factor authentication?"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:944
+#: lib/abuuba_web/live/settings_live.ex:912
 #: lib/abuuba_web/live/two_factor_live.ex:16
 #: lib/abuuba_web/live/two_factor_settings_live.ex:20
 #: lib/abuuba_web/live/two_factor_settings_live.ex:79
@@ -652,51 +652,51 @@ msgstr ""
 msgid "That request has to be signed."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:247
-#: lib/abuuba_web/components/layouts.ex:256
+#: lib/abuuba_web/components/layouts.ex:271
+#: lib/abuuba_web/components/layouts.ex:280
 #: lib/abuuba_web/live/explore_live.ex:50
 #, elixir-autogen, elixir-format
 msgid "Explore"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:234
-#: lib/abuuba_web/components/layouts.ex:255
+#: lib/abuuba_web/components/layouts.ex:258
+#: lib/abuuba_web/components/layouts.ex:279
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2388
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:143
+#: lib/abuuba_web/components/layouts.ex:153
 #: lib/abuuba_web/controllers/shortcuts_controller.ex:15
 #: lib/abuuba_web/controllers/shortcuts_html/show.html.heex:3
 #, elixir-autogen, elixir-format
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:258
+#: lib/abuuba_web/components/layouts.ex:282
 #: lib/abuuba_web/live/landing_live.ex:83
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:133
-#: lib/abuuba_web/components/layouts.ex:158
+#: lib/abuuba_web/components/layouts.ex:168
 #, elixir-autogen, elixir-format
 msgid "Main"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:237
+#: lib/abuuba_web/components/layouts.ex:261
 #: lib/abuuba_web/live/notification_settings_live.ex:31
 #: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2389
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:249
+#: lib/abuuba_web/components/layouts.ex:273
 #: lib/abuuba_web/live/settings_live.ex:121
-#: lib/abuuba_web/live/settings_live.ex:2197
+#: lib/abuuba_web/live/settings_live.ex:2139
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -735,12 +735,12 @@ msgstr ""
 msgid "Attachment"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:430
+#: lib/abuuba_web/components/status_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "Bookmark"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:407
+#: lib/abuuba_web/components/status_component.ex:415
 #, elixir-autogen, elixir-format
 msgid "Boost"
 msgstr ""
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Closed"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:419
+#: lib/abuuba_web/components/status_component.ex:427
 #, elixir-autogen, elixir-format
 msgid "Favourite"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Poll"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:395
+#: lib/abuuba_web/components/status_component.ex:403
 #, elixir-autogen, elixir-format
 msgid "Reply"
 msgstr ""
@@ -847,19 +847,19 @@ msgid "Allow more than one choice"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2383
+#: lib/abuuba_web/live/settings_live.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2378
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2379
+#: lib/abuuba_web/live/settings_live.ex:2321
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
@@ -885,7 +885,7 @@ msgstr ""
 msgid "Do not reply to this person"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:441
+#: lib/abuuba_web/components/status_component.ex:449
 #: lib/abuuba_web/live/admin_live.ex:1775
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -902,7 +902,7 @@ msgid "Ends after"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/profile_live.ex:792
+#: lib/abuuba_web/live/profile_live.ex:798
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
@@ -914,13 +914,13 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3427
 #: lib/abuuba_web/live/compose_component.ex:1677
-#: lib/abuuba_web/live/settings_live.ex:2385
+#: lib/abuuba_web/live/settings_live.ex:2327
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/settings_live.ex:2380
+#: lib/abuuba_web/live/settings_live.ex:2322
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
@@ -931,7 +931,7 @@ msgid "Only the people you name"
 msgstr ""
 
 #: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2384
+#: lib/abuuba_web/live/settings_live.ex:2326
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
@@ -1204,12 +1204,14 @@ msgstr ""
 msgid "%{name} on %{server}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:299
+#: lib/abuuba_web/live/profile_live.ex:305
 #, elixir-autogen, elixir-format
 msgid "A note only you can read"
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:196
+#: lib/abuuba_web/live/report_live.ex:285
+#: lib/abuuba_web/live/report_live.ex:297
 #, elixir-autogen, elixir-format
 msgid "Block"
 msgstr ""
@@ -1231,29 +1233,31 @@ msgstr ""
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:791
+#: lib/abuuba_web/live/profile_live.ex:797
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:188
+#: lib/abuuba_web/live/report_live.ex:273
+#: lib/abuuba_web/live/report_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Mute"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:370
+#: lib/abuuba_web/live/profile_live.ex:376
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:345
-#: lib/abuuba_web/live/profile_live.ex:346
+#: lib/abuuba_web/live/profile_live.ex:351
+#: lib/abuuba_web/live/profile_live.ex:352
 #, elixir-autogen, elixir-format
 msgid "Pinned"
 msgstr ""
 
 #: lib/abuuba_web/live/explore_live.ex:256
-#: lib/abuuba_web/live/profile_live.ex:789
+#: lib/abuuba_web/live/profile_live.ex:795
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:208
@@ -1261,13 +1265,13 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:790
+#: lib/abuuba_web/live/profile_live.ex:796
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:944
-#: lib/abuuba_web/live/profile_live.ex:303
+#: lib/abuuba_web/live/profile_live.ex:309
 #, elixir-autogen, elixir-format
 msgid "Save the note"
 msgstr ""
@@ -1283,12 +1287,14 @@ msgid "This account has moved to %{handle}."
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:196
-#: lib/abuuba_web/live/settings_live.ex:828
+#: lib/abuuba_web/live/settings_live.ex:838
 #, elixir-autogen, elixir-format
 msgid "Unblock"
 msgstr ""
 
 #: lib/abuuba_web/live/profile_live.ex:162
+#: lib/abuuba_web/live/report_live.ex:263
+#: lib/abuuba_web/live/report_live.ex:268
 #: lib/abuuba_web/live/tag_live.ex:63
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
@@ -1304,7 +1310,7 @@ msgstr ""
 msgid "Verified"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:307
+#: lib/abuuba_web/live/profile_live.ex:313
 #: lib/abuuba_web/live/search_live.ex:89
 #, elixir-autogen, elixir-format
 msgid "What to show"
@@ -1486,7 +1492,11 @@ msgstr ""
 msgid "Edits"
 msgstr ""
 
+#: lib/abuuba_web/components/layouts.ex:151
 #: lib/abuuba_web/live/notifications_live.ex:471
+#: lib/abuuba_web/live/saved_live.ex:88
+#: lib/abuuba_web/live/saved_live.ex:95
+#: lib/abuuba_web/live/settings_live.ex:220
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Favourites"
 msgstr ""
@@ -1496,15 +1506,18 @@ msgstr ""
 msgid "Filter"
 msgstr ""
 
+#: lib/abuuba_web/components/layouts.ex:292
+#: lib/abuuba_web/live/follow_requests_live.ex:37
+#: lib/abuuba_web/live/follow_requests_live.ex:44
 #: lib/abuuba_web/live/notifications_live.ex:470
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests"
 msgstr ""
 
 #: lib/abuuba_web/live/notifications_live.ex:469
-#: lib/abuuba_web/live/profile_live.ex:793
-#: lib/abuuba_web/live/settings_live.ex:2181
-#: lib/abuuba_web/live/settings_live.ex:2319
+#: lib/abuuba_web/live/profile_live.ex:799
+#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows"
 msgstr ""
@@ -1571,15 +1584,15 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1587
 #: lib/abuuba_web/live/admin_live.ex:2164
 #: lib/abuuba_web/live/notification_settings_live.ex:76
-#: lib/abuuba_web/live/profile_live.ex:262
-#: lib/abuuba_web/live/settings_live.ex:296
-#: lib/abuuba_web/live/settings_live.ex:390
-#: lib/abuuba_web/live/settings_live.ex:427
-#: lib/abuuba_web/live/settings_live.ex:491
-#: lib/abuuba_web/live/settings_live.ex:598
-#: lib/abuuba_web/live/settings_live.ex:643
-#: lib/abuuba_web/live/settings_live.ex:676
-#: lib/abuuba_web/live/settings_live.ex:1046
+#: lib/abuuba_web/live/profile_live.ex:268
+#: lib/abuuba_web/live/settings_live.ex:306
+#: lib/abuuba_web/live/settings_live.ex:400
+#: lib/abuuba_web/live/settings_live.ex:437
+#: lib/abuuba_web/live/settings_live.ex:501
+#: lib/abuuba_web/live/settings_live.ex:608
+#: lib/abuuba_web/live/settings_live.ex:653
+#: lib/abuuba_web/live/settings_live.ex:686
+#: lib/abuuba_web/live/settings_live.ex:1014
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
@@ -1627,7 +1640,7 @@ msgstr ""
 msgid "Your settings filed these instead of showing them."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:190
+#: lib/abuuba_web/components/layouts.ex:200
 #: lib/abuuba_web/live/conversations_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "unread"
@@ -1716,8 +1729,8 @@ msgstr ""
 msgid "Registration needs approval: you sign up and an admin reads your request."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:248
-#: lib/abuuba_web/components/layouts.ex:257
+#: lib/abuuba_web/components/layouts.ex:272
+#: lib/abuuba_web/components/layouts.ex:281
 #: lib/abuuba_web/live/search_live.ex:38
 #: lib/abuuba_web/live/search_live.ex:61
 #: lib/abuuba_web/live/search_live.ex:70
@@ -1755,95 +1768,95 @@ msgstr ""
 msgid "posts older than a date"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:935
+#: lib/abuuba_web/live/settings_live.ex:903
 #, elixir-autogen, elixir-format
 msgid "A new password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:236
+#: lib/abuuba_web/live/settings_live.ex:246
 #, elixir-autogen, elixir-format
 msgid "About you"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3378
-#: lib/abuuba_web/live/settings_live.ex:2184
+#: lib/abuuba_web/live/settings_live.ex:2126
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:292
+#: lib/abuuba_web/live/settings_live.ex:302
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a field"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:809
+#: lib/abuuba_web/live/settings_live.ex:819
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2177
+#: lib/abuuba_web/live/settings_live.ex:2119
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2355
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2183
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2208
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:997
+#: lib/abuuba_web/live/settings_live.ex:965
 #, elixir-autogen, elixir-format
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2350
+#: lib/abuuba_web/live/settings_live.ex:2292
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:939
+#: lib/abuuba_web/live/settings_live.ex:907
 #, elixir-autogen, elixir-format
 msgid "Change the password"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:455
+#: lib/abuuba_web/components/status_component.ex:463
 #: lib/abuuba_web/live/admin_live.ex:998
-#: lib/abuuba_web/live/settings_live.ex:756
+#: lib/abuuba_web/live/settings_live.ex:766
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:225
+#: lib/abuuba_web/live/settings_live.ex:235
 #, elixir-autogen, elixir-format
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2366
+#: lib/abuuba_web/live/settings_live.ex:2308
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1658
+#: lib/abuuba_web/live/settings_live.ex:1618
 #, elixir-autogen, elixir-format
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2351
+#: lib/abuuba_web/live/settings_live.ex:2293
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2206
+#: lib/abuuba_web/live/settings_live.ex:2148
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
@@ -1853,123 +1866,123 @@ msgstr ""
 msgid "Everything about your account is here. Pick a section."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:241
+#: lib/abuuba_web/live/settings_live.ex:251
 #, elixir-autogen, elixir-format
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2180
-#: lib/abuuba_web/live/settings_live.ex:2325
+#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2407
+#: lib/abuuba_web/live/settings_live.ex:2349
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2408
+#: lib/abuuba_web/live/settings_live.ex:2350
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2356
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2364
+#: lib/abuuba_web/live/settings_live.ex:2306
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2202
+#: lib/abuuba_web/live/settings_live.ex:2144
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:256
+#: lib/abuuba_web/live/settings_live.ex:266
 #, elixir-autogen, elixir-format
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2354
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2352
+#: lib/abuuba_web/live/settings_live.ex:2294
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2359
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:274
+#: lib/abuuba_web/live/settings_live.ex:284
 #, elixir-autogen, elixir-format
 msgid "Move up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1026
+#: lib/abuuba_web/live/settings_live.ex:994
 #, elixir-autogen, elixir-format
 msgid "No app has been let in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1040
+#: lib/abuuba_web/live/settings_live.ex:1008
 #, elixir-autogen, elixir-format
 msgid "One web address per line. Naming an account here is what lets you move to it later, and it has to name this one back."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:451
+#: lib/abuuba_web/live/settings_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2209
+#: lib/abuuba_web/live/settings_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2371
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2175
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2178
+#: lib/abuuba_web/live/settings_live.ex:2120
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2179
+#: lib/abuuba_web/live/settings_live.ex:2121
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2176
+#: lib/abuuba_web/live/settings_live.ex:2118
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2392
+#: lib/abuuba_web/live/settings_live.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2390
+#: lib/abuuba_web/live/settings_live.ex:2332
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2363
+#: lib/abuuba_web/live/settings_live.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1980,165 +1993,165 @@ msgstr ""
 #: lib/abuuba_web/live/admin_live.ex:1878
 #: lib/abuuba_web/live/admin_live.ex:2202
 #: lib/abuuba_web/live/conversations_live.ex:113
-#: lib/abuuba_web/live/settings_live.ex:282
-#: lib/abuuba_web/live/settings_live.ex:317
+#: lib/abuuba_web/live/settings_live.ex:292
+#: lib/abuuba_web/live/settings_live.ex:327
 #, elixir-autogen, elixir-format
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2182
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:957
+#: lib/abuuba_web/live/settings_live.ex:925
 #, elixir-autogen, elixir-format
 msgid "Sign out everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:948
+#: lib/abuuba_web/live/settings_live.ex:916
 #, elixir-autogen, elixir-format
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2374
+#: lib/abuuba_web/live/settings_live.ex:2316
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1020
+#: lib/abuuba_web/live/settings_live.ex:988
 #, elixir-autogen, elixir-format
 msgid "Take it back out"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3746
-#: lib/abuuba_web/live/settings_live.ex:2171
+#: lib/abuuba_web/live/settings_live.ex:2113
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved. Check what you typed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1633
+#: lib/abuuba_web/live/settings_live.ex:1593
 #, elixir-autogen, elixir-format
 msgid "That current password is not right."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:470
+#: lib/abuuba_web/live/settings_live.ex:480
 #, elixir-autogen, elixir-format
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2357
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2358
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2391
+#: lib/abuuba_web/live/settings_live.ex:2333
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:893
+#: lib/abuuba_web/live/settings_live.ex:861
 #, elixir-autogen, elixir-format
 msgid "Tick anybody you want to stop following, then press the button once."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:918
+#: lib/abuuba_web/live/settings_live.ex:886
 #, elixir-autogen, elixir-format
 msgid "Unfollow the ticked ones"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:243
+#: lib/abuuba_web/live/settings_live.ex:253
 #, elixir-autogen, elixir-format
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2365
+#: lib/abuuba_web/live/settings_live.ex:2307
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:263
+#: lib/abuuba_web/live/settings_live.ex:273
 #, elixir-autogen, elixir-format
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2367
+#: lib/abuuba_web/live/settings_live.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:801
+#: lib/abuuba_web/live/settings_live.ex:811
 #, elixir-autogen, elixir-format
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2203
+#: lib/abuuba_web/live/settings_live.ex:2145
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:2178
-#: lib/abuuba_web/live/settings_live.ex:763
+#: lib/abuuba_web/live/settings_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "What to call it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:768
+#: lib/abuuba_web/live/settings_live.ex:778
 #, elixir-autogen, elixir-format
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2204
+#: lib/abuuba_web/live/settings_live.ex:2146
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:457
+#: lib/abuuba_web/live/settings_live.ex:467
 #, elixir-autogen, elixir-format
 msgid "Who may quote new posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:438
+#: lib/abuuba_web/live/settings_live.ex:448
 #, elixir-autogen, elixir-format
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2205
+#: lib/abuuba_web/live/settings_live.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:914
+#: lib/abuuba_web/live/settings_live.ex:882
 #, elixir-autogen, elixir-format
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2353
+#: lib/abuuba_web/live/settings_live.ex:2295
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:930
+#: lib/abuuba_web/live/settings_live.ex:898
 #, elixir-autogen, elixir-format
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2201
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1037
+#: lib/abuuba_web/live/settings_live.ex:1005
 #, elixir-autogen, elixir-format
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2207
+#: lib/abuuba_web/live/settings_live.ex:2149
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2294,110 +2307,110 @@ msgstr ""
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1936
+#: lib/abuuba_web/live/settings_live.ex:1878
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2212
+#: lib/abuuba_web/live/settings_live.ex:2154
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1246
+#: lib/abuuba_web/live/settings_live.ex:1214
 #, elixir-autogen, elixir-format
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2185
+#: lib/abuuba_web/live/settings_live.ex:2127
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1276
+#: lib/abuuba_web/live/settings_live.ex:1244
 #, elixir-autogen, elixir-format
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1920
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1243
+#: lib/abuuba_web/live/settings_live.ex:1211
 #, elixir-autogen, elixir-format
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1939
+#: lib/abuuba_web/live/settings_live.ex:1881
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1250
-#: lib/abuuba_web/live/settings_live.ex:1916
+#: lib/abuuba_web/live/settings_live.ex:1218
+#: lib/abuuba_web/live/settings_live.ex:1858
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1221
+#: lib/abuuba_web/live/settings_live.ex:1189
 #, elixir-autogen, elixir-format
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1931
+#: lib/abuuba_web/live/settings_live.ex:1873
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1930
+#: lib/abuuba_web/live/settings_live.ex:1872
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1932
+#: lib/abuuba_web/live/settings_live.ex:1874
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1937
+#: lib/abuuba_web/live/settings_live.ex:1879
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1940
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1941
+#: lib/abuuba_web/live/settings_live.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1938
+#: lib/abuuba_web/live/settings_live.ex:1880
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1229
+#: lib/abuuba_web/live/settings_live.ex:1197
 #, elixir-autogen, elixir-format
 msgid "since lifted"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1267
+#: lib/abuuba_web/live/settings_live.ex:1235
 #, elixir-autogen, elixir-format
 msgid "%{count} relationship lost"
 msgid_plural "%{count} relationships lost"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:1256
+#: lib/abuuba_web/live/settings_live.ex:1224
 #, elixir-autogen, elixir-format
 msgid "Relationships this server's decisions cost you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1258
+#: lib/abuuba_web/live/settings_live.ex:1226
 #, elixir-autogen, elixir-format
 msgid "When this server stops federating with another one, the follows between you and the people there are lost. They cannot be restored from here, because the other side is no longer reachable to ask."
 msgstr ""
@@ -2693,7 +2706,7 @@ msgstr ""
 
 #: lib/abuuba_web/controllers/domain_list_controller.ex:51
 #: lib/abuuba_web/live/admin_live.ex:3339
-#: lib/abuuba_web/live/settings_live.ex:1686
+#: lib/abuuba_web/live/settings_live.ex:1646
 #, elixir-autogen, elixir-format
 msgid "That is not something your account can do."
 msgstr ""
@@ -2832,12 +2845,12 @@ msgstr ""
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2169
+#: lib/abuuba_web/live/settings_live.ex:2111
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1292
+#: lib/abuuba_web/live/settings_live.ex:1260
 #, elixir-autogen, elixir-format
 msgid "A code somebody can sign up with, even when sign-ups are closed. Leave the number of uses empty for as many as you like."
 msgstr ""
@@ -2852,7 +2865,7 @@ msgstr ""
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2214
+#: lib/abuuba_web/live/settings_live.ex:2156
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2877,7 +2890,7 @@ msgstr ""
 msgid "Goes up"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1303
+#: lib/abuuba_web/live/settings_live.ex:1271
 #, elixir-autogen, elixir-format
 msgid "How many people"
 msgstr ""
@@ -2892,12 +2905,12 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2186
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1287
+#: lib/abuuba_web/live/settings_live.ex:1255
 #, elixir-autogen, elixir-format
 msgid "Inviting people is not something this account can do. Ask whoever runs the server."
 msgstr ""
@@ -2907,7 +2920,7 @@ msgstr ""
 msgid "Leave this empty to publish it now."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1310
+#: lib/abuuba_web/live/settings_live.ex:1278
 #, elixir-autogen, elixir-format
 msgid "Make one"
 msgstr ""
@@ -2937,7 +2950,7 @@ msgstr ""
 msgid "Something everybody here should read. Give it a time and it publishes itself, so a notice about Sunday can be written on Thursday."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1324
+#: lib/abuuba_web/live/settings_live.ex:1292
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take it back"
 msgstr ""
@@ -2952,12 +2965,12 @@ msgstr ""
 msgid "Terms need some text and a day they take effect."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1308
+#: lib/abuuba_web/live/settings_live.ex:1276
 #, elixir-autogen, elixir-format
 msgid "They follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1299
+#: lib/abuuba_web/live/settings_live.ex:1267
 #, elixir-autogen, elixir-format, fuzzy
 msgid "What it is for"
 msgstr ""
@@ -2978,7 +2991,7 @@ msgstr ""
 msgid "You are signing up on an invitation, so you do not need to be approved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1330
+#: lib/abuuba_web/live/settings_live.ex:1298
 #, elixir-autogen, elixir-format
 msgid "You have not made any."
 msgstr ""
@@ -2988,7 +3001,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2166
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3109,7 +3122,7 @@ msgstr ""
 msgid "That could not be translated just now."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:469
+#: lib/abuuba_web/components/status_component.ex:477
 #, elixir-autogen, elixir-format
 msgid "Translate"
 msgstr ""
@@ -3124,245 +3137,245 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr "This account has been disabled. Contact the moderators."
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2007
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:1998
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1972
+#: lib/abuuba_web/live/settings_live.ex:1914
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2129
+#: lib/abuuba_web/live/settings_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1953
+#: lib/abuuba_web/live/settings_live.ex:1895
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2152
+#: lib/abuuba_web/live/settings_live.ex:2094
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2187
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1978
+#: lib/abuuba_web/live/settings_live.ex:1920
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2144
+#: lib/abuuba_web/live/settings_live.ex:2086
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2217
+#: lib/abuuba_web/live/settings_live.ex:2159
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2151
+#: lib/abuuba_web/live/settings_live.ex:2093
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2153
+#: lib/abuuba_web/live/settings_live.ex:2095
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2067
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2140
-#: lib/abuuba_web/live/settings_live.ex:2145
+#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2087
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2084
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2143
+#: lib/abuuba_web/live/settings_live.ex:2085
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1962
+#: lib/abuuba_web/live/settings_live.ex:1904
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2150
+#: lib/abuuba_web/live/settings_live.ex:2092
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1959
+#: lib/abuuba_web/live/settings_live.ex:1901
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1967
+#: lib/abuuba_web/live/settings_live.ex:1909
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2156
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2158
+#: lib/abuuba_web/live/settings_live.ex:2100
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2159
+#: lib/abuuba_web/live/settings_live.ex:2101
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2162
+#: lib/abuuba_web/live/settings_live.ex:2104
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2160
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format, fuzzy
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2161
+#: lib/abuuba_web/live/settings_live.ex:2103
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1095
+#: lib/abuuba_web/live/settings_live.ex:1063
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2011
+#: lib/abuuba_web/live/settings_live.ex:1953
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1090
+#: lib/abuuba_web/live/settings_live.ex:1058
 #, elixir-autogen, elixir-format
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2029
+#: lib/abuuba_web/live/settings_live.ex:1971
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1100
+#: lib/abuuba_web/live/settings_live.ex:1068
 #, elixir-autogen, elixir-format
 msgid "Exporting what you have and deleting the account need work of their own."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1088
+#: lib/abuuba_web/live/settings_live.ex:1056
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests waiting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1057
+#: lib/abuuba_web/live/settings_live.ex:1025
 #, elixir-autogen, elixir-format
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2042
+#: lib/abuuba_web/live/settings_live.ex:1984
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2019
+#: lib/abuuba_web/live/settings_live.ex:1961
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import list"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1114
-#: lib/abuuba_web/live/settings_live.ex:1991
-#: lib/abuuba_web/live/settings_live.ex:2322
+#: lib/abuuba_web/live/settings_live.ex:1082
+#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:2264
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1084
+#: lib/abuuba_web/live/settings_live.ex:1052
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Move"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1068
+#: lib/abuuba_web/live/settings_live.ex:1036
 #, elixir-autogen, elixir-format
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1052
+#: lib/abuuba_web/live/settings_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2015
+#: lib/abuuba_web/live/settings_live.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2105
+#: lib/abuuba_web/live/settings_live.ex:2047
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2058
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1993
+#: lib/abuuba_web/live/settings_live.ex:1935
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1078
+#: lib/abuuba_web/live/settings_live.ex:1046
 #, elixir-autogen, elixir-format
 msgid "The other account has to name this one in its own aliases first. Your followers here are moved over and every other server is told; an account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1050
+#: lib/abuuba_web/live/settings_live.ex:1018
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2008
+#: lib/abuuba_web/live/settings_live.ex:1950
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2053
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
@@ -3372,27 +3385,27 @@ msgstr ""
 msgid "No such post here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:246
+#: lib/abuuba_web/live/settings_live.ex:256
 #, elixir-autogen, elixir-format
 msgid "A link gets a checkmark once the page it points at links back to your profile with rel=\"me\". We look again about once a week."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:784
+#: lib/abuuba_web/live/settings_live.ex:794
 #, elixir-autogen, elixir-format
 msgid "One per line. A post matches when it contains any of them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:797
+#: lib/abuuba_web/live/settings_live.ex:807
 #, elixir-autogen, elixir-format
 msgid "Whole words only, so \"cat\" does not match \"concatenate\""
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:781
+#: lib/abuuba_web/live/settings_live.ex:791
 #, elixir-autogen, elixir-format
 msgid "Words to look for"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1572
+#: lib/abuuba_web/live/settings_live.ex:1532
 #, elixir-autogen, elixir-format
 msgid "A filter needs at least one word to look for."
 msgstr ""
@@ -3402,54 +3415,54 @@ msgstr ""
 msgid "Why they want to join:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:309
+#: lib/abuuba_web/live/settings_live.ex:319
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} post"
 msgid_plural "%{count} posts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:326
+#: lib/abuuba_web/live/settings_live.ex:336
 #, elixir-autogen, elixir-format
 msgid "A hashtag, without the #"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:329
+#: lib/abuuba_web/live/settings_live.ex:339
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Feature it"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:300
+#: lib/abuuba_web/live/settings_live.ex:310
 #, elixir-autogen, elixir-format
 msgid "Featured hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:302
+#: lib/abuuba_web/live/settings_live.ex:312
 #, elixir-autogen, elixir-format
 msgid "Shown on your profile as a shortcut to what you write about."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1555
+#: lib/abuuba_web/live/settings_live.ex:1515
 #, elixir-autogen, elixir-format
 msgid "That is not a hashtag anybody can use."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:333
+#: lib/abuuba_web/live/settings_live.ex:343
 #, elixir-autogen, elixir-format
 msgid "You often write about:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1549
+#: lib/abuuba_web/live/settings_live.ex:1509
 #, elixir-autogen, elixir-format
 msgid "A profile can carry %{count} hashtags. Take one off first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:484
+#: lib/abuuba_web/live/settings_live.ex:494
 #, elixir-autogen, elixir-format
 msgid "Say which app you posted from"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:486
+#: lib/abuuba_web/live/settings_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Shown under your posts to everybody else. You always see it on your own."
 msgstr ""
@@ -3597,7 +3610,7 @@ msgid "Each person still has to turn it on for themselves, and every address has
 msgstr ""
 
 #: lib/abuuba_web/controllers/email_subscription_controller.ex:28
-#: lib/abuuba_web/live/settings_live.ex:647
+#: lib/abuuba_web/live/settings_live.ex:657
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Email updates"
 msgstr ""
@@ -3612,7 +3625,7 @@ msgstr ""
 msgid "If it was not you, you can ignore this message. Nothing else will be sent to this address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:665
+#: lib/abuuba_web/live/settings_live.ex:675
 #, elixir-autogen, elixir-format
 msgid "Let people subscribe by email"
 msgstr ""
@@ -3622,7 +3635,7 @@ msgstr ""
 msgid "No, remove my address"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:667
+#: lib/abuuba_web/live/settings_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "One address has confirmed."
 msgid_plural "%{count} addresses have confirmed."
@@ -3675,7 +3688,7 @@ msgstr ""
 msgid "Let people collect email addresses for updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:649
+#: lib/abuuba_web/live/settings_live.ex:659
 #, elixir-autogen, elixir-format, fuzzy
 msgid "People who do not want an account here can give an address instead. They confirm it themselves and can stop the updates from any message. Nothing is sent to them yet; this collects the list."
 msgstr ""
@@ -3823,75 +3836,79 @@ msgstr ""
 msgid "the password on your %{site} account was just changed, and everywhere you were signed in has been signed out."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1127
+#: lib/abuuba_web/live/settings_live.ex:1095
 #, elixir-autogen, elixir-format
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2329
+#: lib/abuuba_web/live/settings_live.ex:2271
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:812
-#: lib/abuuba_web/live/settings_live.ex:2323
+#: lib/abuuba_web/live/settings_live.ex:822
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2320
+#: lib/abuuba_web/live/settings_live.ex:2262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Blocks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2324
+#: lib/abuuba_web/components/layouts.ex:148
+#: lib/abuuba_web/live/saved_live.ex:88
+#: lib/abuuba_web/live/saved_live.ex:94
+#: lib/abuuba_web/live/settings_live.ex:218
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Bookmarks"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1169
+#: lib/abuuba_web/live/settings_live.ex:1137
 #, elixir-autogen, elixir-format
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2331
+#: lib/abuuba_web/live/settings_live.ex:2273
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1152
+#: lib/abuuba_web/live/settings_live.ex:1120
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2188
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2321
+#: lib/abuuba_web/live/settings_live.ex:2263
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mutes"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1116
+#: lib/abuuba_web/live/settings_live.ex:1084
 #, elixir-autogen, elixir-format
 msgid "One file each, in the format this server's import reads. An export from here is an import somewhere else."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1445
+#: lib/abuuba_web/live/settings_live.ex:1405
 #, elixir-autogen, elixir-format
 msgid "One is already being built."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1134
+#: lib/abuuba_web/live/settings_live.ex:1102
 #, elixir-autogen, elixir-format
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2272
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3911,13 +3928,13 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2328
+#: lib/abuuba_web/live/settings_live.ex:2270
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waiting to start"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1158
-#: lib/abuuba_web/live/settings_live.ex:1451
+#: lib/abuuba_web/live/settings_live.ex:1126
+#: lib/abuuba_web/live/settings_live.ex:1411
 #, elixir-autogen, elixir-format
 msgid "You can ask for another one from %{date}."
 msgstr ""
@@ -3927,7 +3944,7 @@ msgstr ""
 msgid "Your archive is ready"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1129
+#: lib/abuuba_web/live/settings_live.ex:1097
 #, elixir-autogen, elixir-format
 msgid "Your profile and every post, as JSON, with the lists above alongside. Built in the background; we email you when it is ready."
 msgstr ""
@@ -3937,67 +3954,67 @@ msgstr ""
 msgid "the copy of your %{site} account you asked for is built. Download it here:"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1208
+#: lib/abuuba_web/live/settings_live.ex:1176
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Close the account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1206
+#: lib/abuuba_web/live/settings_live.ex:1174
 #, elixir-autogen, elixir-format
 msgid "Close the account for good? This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1172
+#: lib/abuuba_web/live/settings_live.ex:1140
 #, elixir-autogen, elixir-format
 msgid "Close this account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1111
+#: lib/abuuba_web/live/settings_live.ex:1079
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2220
+#: lib/abuuba_web/live/settings_live.ex:2162
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1189
+#: lib/abuuba_web/live/settings_live.ex:1157
 #, elixir-autogen, elixir-format
 msgid "Take your copy first. There is nothing to export afterwards."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1478
+#: lib/abuuba_web/live/settings_live.ex:1438
 #, elixir-autogen, elixir-format
 msgid "That did not work. Nothing has been deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1475
+#: lib/abuuba_web/live/settings_live.ex:1435
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not your password."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1179
+#: lib/abuuba_web/live/settings_live.ex:1147
 #, elixir-autogen, elixir-format
 msgid "The account disappears at once. The rows are deleted a little later, so that the message telling other servers can still be signed and sent."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1471
+#: lib/abuuba_web/live/settings_live.ex:1431
 #, elixir-autogen, elixir-format
 msgid "The account is closed. Thank you for having been here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1194
+#: lib/abuuba_web/live/settings_live.ex:1162
 #, elixir-autogen, elixir-format
 msgid "Your password, to be sure it is you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1174
+#: lib/abuuba_web/live/settings_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Your posts, follows, lists, filters, bookmarks and settings are deleted, and other servers are told to delete their copies. This cannot be undone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1184
+#: lib/abuuba_web/live/settings_live.ex:1152
 #, elixir-autogen, elixir-format
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
@@ -4007,7 +4024,7 @@ msgstr ""
 msgid "A post"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:397
+#: lib/abuuba_web/live/profile_live.ex:403
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nobody yet."
 msgstr ""
@@ -4017,7 +4034,7 @@ msgstr ""
 msgid "Public posts tagged #%{tag}"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:374
+#: lib/abuuba_web/live/profile_live.ex:380
 #, elixir-autogen, elixir-format
 msgid "This account keeps its follows to itself."
 msgstr ""
@@ -4043,99 +4060,99 @@ msgstr ""
 msgid "You can still sign up without one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1507
+#: lib/abuuba_web/live/settings_live.ex:1467
 #, elixir-autogen, elixir-format
 msgid "An age has to be at least 7 days, and the counts cannot be negative."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:964
+#: lib/abuuba_web/live/settings_live.ex:932
 #, elixir-autogen, elixir-format
 msgid "Attempts that failed are here too. Somebody else trying your password is the thing worth spotting early, and nothing else would tell you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:525
+#: lib/abuuba_web/live/settings_live.ex:535
 #, elixir-autogen, elixir-format
 msgid "Delete my old posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:534
+#: lib/abuuba_web/live/settings_live.ex:544
 #, elixir-autogen, elixir-format
 msgid "Delete posts older than, in days"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:553
+#: lib/abuuba_web/live/settings_live.ex:563
 #, elixir-autogen, elixir-format
 msgid "Keep pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:580
+#: lib/abuuba_web/live/settings_live.ex:590
 #, elixir-autogen, elixir-format
 msgid "Keep posts boosted at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:569
+#: lib/abuuba_web/live/settings_live.ex:579
 #, elixir-autogen, elixir-format
 msgid "Keep posts favourited at least this many times"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:565
+#: lib/abuuba_web/live/settings_live.ex:575
 #, elixir-autogen, elixir-format
 msgid "Keep posts with pictures or video"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:987
+#: lib/abuuba_web/live/settings_live.ex:955
 #, elixir-autogen, elixir-format
 msgid "Kept for %{days} days, then deleted."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:522
+#: lib/abuuba_web/live/settings_live.ex:532
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing pinned."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:983
+#: lib/abuuba_web/live/settings_live.ex:951
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing recorded yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:527
+#: lib/abuuba_web/live/settings_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "Off unless you turn it on. Leave the age empty to turn it off again; nothing is deleted until you set one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:591
+#: lib/abuuba_web/live/settings_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "One post matches these settings right now."
 msgid_plural "%{count} posts match these settings right now."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:502
+#: lib/abuuba_web/live/settings_live.ex:512
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Pinned posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:962
+#: lib/abuuba_web/live/settings_live.ex:930
 #, elixir-autogen, elixir-format
 msgid "Recent sign-ins"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:972
+#: lib/abuuba_web/live/settings_live.ex:940
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Refused"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:972
+#: lib/abuuba_web/live/settings_live.ex:940
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Signed in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:516
+#: lib/abuuba_web/live/settings_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Unpin"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:504
+#: lib/abuuba_web/live/settings_live.ex:514
 #, elixir-autogen, elixir-format
 msgid "What sits at the top of your profile. Pin a post from the post itself."
 msgstr ""
@@ -4844,6 +4861,7 @@ msgid "There is no list of that kind."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1329
+#: lib/abuuba_web/live/saved_live.ex:57
 #, elixir-autogen, elixir-format
 msgid "Which list"
 msgstr ""
@@ -4947,55 +4965,55 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2241
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:348
+#: lib/abuuba_web/live/settings_live.ex:358
 #, elixir-autogen, elixir-format
 msgid "JPEG, PNG, GIF or WebP, up to %{size}. Bigger ones are refused before they are uploaded rather than after, and what you send is scaled down here so a reader is not fetching a photograph to see it at forty pixels."
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:565
-#: lib/abuuba_web/live/settings_live.ex:366
+#: lib/abuuba_web/live/settings_live.ex:376
 #, elixir-autogen, elixir-format, fuzzy
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2139
+#: lib/abuuba_web/live/settings_live.ex:2081
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One picture at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:346
+#: lib/abuuba_web/live/settings_live.ex:356
 #, elixir-autogen, elixir-format
 msgid "Pictures"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:398
+#: lib/abuuba_web/live/settings_live.ex:408
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2137
-#: lib/abuuba_web/live/settings_live.ex:2292
+#: lib/abuuba_web/live/settings_live.ex:2079
+#: lib/abuuba_web/live/settings_live.ex:2234
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2287
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2229
+#: lib/abuuba_web/live/settings_live.ex:2236
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2134
+#: lib/abuuba_web/live/settings_live.ex:2076
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
@@ -5005,8 +5023,8 @@ msgstr ""
 msgid "Feature on my profile"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:320
-#: lib/abuuba_web/live/profile_live.ex:324
+#: lib/abuuba_web/live/profile_live.ex:326
+#: lib/abuuba_web/live/profile_live.ex:330
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Featured accounts"
 msgstr ""
@@ -5016,55 +5034,55 @@ msgstr ""
 msgid "Stop featuring"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:493
+#: lib/abuuba_web/live/profile_live.ex:499
 #, elixir-autogen, elixir-format
 msgid "Check that address for a message asking you to confirm."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:274
+#: lib/abuuba_web/live/profile_live.ex:280
 #, elixir-autogen, elixir-format
 msgid "Get updates from %{name} by email"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:682
+#: lib/abuuba_web/live/settings_live.ex:692
 #, elixir-autogen, elixir-format
 msgid "Goes to every address that has confirmed, with a link that stops the updates. Up to %{count} messages a day."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:277
+#: lib/abuuba_web/live/profile_live.ex:283
 #, elixir-autogen, elixir-format
 msgid "No account needed. We write to the address once to check it is yours, and every message has a link that stops them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:707
+#: lib/abuuba_web/live/settings_live.ex:717
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Send it"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:293
+#: lib/abuuba_web/live/profile_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "Send me updates"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:716
+#: lib/abuuba_web/live/settings_live.ex:726
 #, elixir-autogen, elixir-format
 msgid "Sent to one address on %{date}."
 msgid_plural "Sent to %{count} addresses on %{date}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:693
-#: lib/abuuba_web/live/settings_live.ex:1866
+#: lib/abuuba_web/live/settings_live.ex:703
+#: lib/abuuba_web/live/settings_live.ex:1808
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:496
+#: lib/abuuba_web/live/profile_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "That does not look like a valid email address."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1426
+#: lib/abuuba_web/live/settings_live.ex:1386
 #, elixir-autogen, elixir-format
 msgid "This list is not open."
 msgstr ""
@@ -5074,17 +5092,17 @@ msgstr ""
 msgid "To stop them, open this link:"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:483
+#: lib/abuuba_web/live/profile_live.ex:489
 #, elixir-autogen, elixir-format
 msgid "Too many tries from here just now. Try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:700
+#: lib/abuuba_web/live/settings_live.ex:710
 #, elixir-autogen, elixir-format
 msgid "What you want to tell them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:680
+#: lib/abuuba_web/live/settings_live.ex:690
 #, elixir-autogen, elixir-format
 msgid "Write to them"
 msgstr ""
@@ -5094,22 +5112,22 @@ msgstr ""
 msgid "You are receiving this because you asked for updates from %{name} on %{site}."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1431
+#: lib/abuuba_web/live/settings_live.ex:1391
 #, elixir-autogen, elixir-format
 msgid "You have sent as many messages as you can today."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:286
+#: lib/abuuba_web/live/profile_live.ex:292
 #, elixir-autogen, elixir-format
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1867
+#: lib/abuuba_web/live/settings_live.ex:1809
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:723
+#: lib/abuuba_web/live/settings_live.ex:733
 #, elixir-autogen, elixir-format
 msgid "On its way."
 msgstr ""
@@ -5198,6 +5216,8 @@ msgid "Ready-made texts a moderator picks instead of retyping. Kept for the serv
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3381
+#: lib/abuuba_web/live/profile_live.ex:202
+#: lib/abuuba_web/live/report_live.ex:71
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report"
 msgstr ""
@@ -5395,7 +5415,7 @@ msgstr ""
 msgid "Mute and unmute people for you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1010
+#: lib/abuuba_web/live/settings_live.ex:978
 #, elixir-autogen, elixir-format
 msgid "Nothing. It can tell that you are signed in and no more."
 msgstr ""
@@ -5543,42 +5563,42 @@ msgstr ""
 msgid "not offered"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:243
+#: lib/abuuba_web/live/profile_live.ex:249
 #, elixir-autogen, elixir-format
 msgid "Choose none to read everything they write."
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:241
+#: lib/abuuba_web/live/profile_live.ex:247
 #, elixir-autogen, elixir-format
 msgid "Only these languages"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:220
+#: lib/abuuba_web/live/profile_live.ex:226
 #, elixir-autogen, elixir-format
 msgid "Their boosts of other people"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:205
+#: lib/abuuba_web/live/profile_live.ex:211
 #, elixir-autogen, elixir-format
 msgid "What you see from them"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:487
+#: lib/abuuba_web/components/status_component.ex:507
 #, elixir-autogen, elixir-format, fuzzy
 msgid "More"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:499
+#: lib/abuuba_web/components/status_component.ex:520
 #, elixir-autogen, elixir-format
 msgid "Mute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:506
+#: lib/abuuba_web/components/status_component.ex:527
 #, elixir-autogen, elixir-format
 msgid "Stops its notifications and takes it out of your timeline. Nobody is told."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:498
+#: lib/abuuba_web/components/status_component.ex:519
 #, elixir-autogen, elixir-format
 msgid "Unmute this conversation"
 msgstr ""
@@ -5588,7 +5608,7 @@ msgstr ""
 msgid "Posts from people you watch"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:235
+#: lib/abuuba_web/live/profile_live.ex:241
 #, elixir-autogen, elixir-format
 msgid "Tell me when they post"
 msgstr ""
@@ -5653,7 +5673,7 @@ msgstr ""
 msgid "Mark unread"
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:243
+#: lib/abuuba_web/components/layouts.ex:267
 #: lib/abuuba_web/live/conversations_live.ex:46
 #: lib/abuuba_web/live/conversations_live.ex:62
 #, elixir-autogen, elixir-format, fuzzy
@@ -5747,22 +5767,22 @@ msgstr ""
 msgid "Who may read the blocklist"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:637
+#: lib/abuuba_web/live/settings_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "One domain per line. When a link to one of these sites is shared here, the preview credits you as its author. A site you have not listed cannot claim you, however its page is written."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:629
+#: lib/abuuba_web/live/settings_live.ex:639
 #, elixir-autogen, elixir-format
 msgid "Sites that may name me as an author"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:841
+#: lib/abuuba_web/live/settings_live.ex:851
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Block a server"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:814
+#: lib/abuuba_web/live/settings_live.ex:824
 #, elixir-autogen, elixir-format
 msgid "Everybody on a blocked server at once: nothing of theirs reaches your timelines, your search, your threads or your notifications. Follows in either direction are undone, as they are when you block one person."
 msgstr ""
@@ -5773,7 +5793,7 @@ msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
 #: lib/abuuba_web/live/explore_live.ex:149
-#: lib/abuuba_web/live/profile_live.ex:534
+#: lib/abuuba_web/live/profile_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
 msgstr ""
@@ -5838,8 +5858,8 @@ msgstr ""
 msgid "Warned"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2312
-#: lib/abuuba_web/live/settings_live.ex:2315
+#: lib/abuuba_web/live/settings_live.ex:2254
+#: lib/abuuba_web/live/settings_live.ex:2257
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr ""
@@ -5854,18 +5874,18 @@ msgstr ""
 msgid "Requested"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:544
+#: lib/abuuba_web/live/profile_live.ex:550
 #, elixir-autogen, elixir-format
 msgid "This account approves its followers. Your request is waiting for an answer."
 msgstr ""
 
-#: lib/abuuba_web/components/status_component.ex:451
+#: lib/abuuba_web/components/status_component.ex:459
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Delete this post? Other servers are told to forget it too."
 msgstr ""
 
-#: lib/abuuba_web/components/layouts.ex:145
-#: lib/abuuba_web/live/settings_live.ex:953
+#: lib/abuuba_web/components/layouts.ex:155
+#: lib/abuuba_web/live/settings_live.ex:921
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Sign out"
 msgstr ""
@@ -5875,22 +5895,213 @@ msgstr ""
 msgid "That post is gone."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:876
+#: lib/abuuba_web/live/follow_requests_live.ex:72
 #, elixir-autogen, elixir-format
 msgid "Let them follow"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:885
+#: lib/abuuba_web/live/follow_requests_live.ex:76
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Turn them away"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:853
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Waiting for your answer"
-msgstr ""
-
-#: lib/abuuba_web/live/settings_live.ex:855
+#: lib/abuuba_web/live/follow_requests_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Your account asks before letting somebody follow it. Turning one away tells them nothing, and they can ask again."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:211
+#, elixir-autogen, elixir-format
+msgid "Anything else a moderator should know?"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:167
+#, elixir-autogen, elixir-format
+msgid "Are there posts that show it?"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:297
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Blocked"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:303
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Done"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:287
+#, elixir-autogen, elixir-format
+msgid "Everything mute does, and they cannot follow you or read your posts. They can tell."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:374
+#, elixir-autogen, elixir-format
+msgid "I do not like it"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:217
+#, elixir-autogen, elixir-format
+msgid "In your own words. This is optional."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:180
+#, elixir-autogen, elixir-format
+msgid "Include this post"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:392
+#, elixir-autogen, elixir-format
+msgid "It breaks the rules of this server"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:384
+#, elixir-autogen, elixir-format
+msgid "It does not fit any of the above."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:378
+#, elixir-autogen, elixir-format
+msgid "It is illegal"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:375
+#, elixir-autogen, elixir-format
+msgid "It is not something you want to see. This tells nobody."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:376
+#, elixir-autogen, elixir-format
+msgid "It is spam"
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:217
+#, elixir-autogen, elixir-format
+msgid "Looking for what you saved?"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:377
+#, elixir-autogen, elixir-format
+msgid "Malicious links, fake engagement, or the same thing over and over."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:280
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Muted"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:258
+#, elixir-autogen, elixir-format
+msgid "Neither of these tells a moderator anything."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:155
+#: lib/abuuba_web/live/report_live.ex:199
+#, elixir-autogen, elixir-format
+msgid "Next"
+msgstr ""
+
+#: lib/abuuba_web/live/follow_requests_live.ex:53
+#, elixir-autogen, elixir-format
+msgid "Nobody is waiting. Anybody who asks to follow you turns up here."
+msgstr ""
+
+#: lib/abuuba_web/live/saved_live.ex:101
+#, elixir-autogen, elixir-format
+msgid "Nothing bookmarked yet. The bookmark under a post files it here, and tells nobody."
+msgstr ""
+
+#: lib/abuuba_web/live/saved_live.ex:105
+#, elixir-autogen, elixir-format
+msgid "Nothing favourited yet. The star under a post lands here, and its author is told."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:195
+#, elixir-autogen, elixir-format
+msgid "Nothing of theirs is here to point at."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:94
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Report %{name}"
+msgstr ""
+
+#: lib/abuuba_web/components/status_component.ex:538
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Report this post"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:237
+#, elixir-autogen, elixir-format
+msgid "Send the report"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:383
+#, elixir-autogen, elixir-format
+msgid "Something else"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:251
+#, elixir-autogen, elixir-format
+msgid "Thank you. A moderator will read this."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:265
+#, elixir-autogen, elixir-format
+msgid "Their posts leave your home timeline. They keep following you."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:252
+#, elixir-autogen, elixir-format
+msgid "Then here is what you can do yourself."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:230
+#, elixir-autogen, elixir-format
+msgid "This account is on %{domain}. Send a copy of this report there as well, without your name."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:169
+#, elixir-autogen, elixir-format
+msgid "Tick every one a moderator should read. You can tick none."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:139
+#, elixir-autogen, elixir-format
+msgid "Tick every one that applies."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:113
+#, elixir-autogen, elixir-format, fuzzy
+msgid "What is going on?"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:138
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Which rules?"
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "While you wait, you do not have to keep seeing them."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:379
+#, elixir-autogen, elixir-format
+msgid "You believe it breaks the law here or where you are."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:393
+#, elixir-autogen, elixir-format
+msgid "You know which rule it breaks."
+msgstr ""
+
+#: lib/abuuba_web/live/report_live.ex:275
+#, elixir-autogen, elixir-format
+msgid "You stop seeing them everywhere. They can still follow you and are not told."
+msgstr ""
+
+#: lib/abuuba_web/live/settings_live.ex:219
+#, elixir-autogen, elixir-format
+msgid "and"
 msgstr ""

--- a/test/abuuba_web/follow_requests_test.exs
+++ b/test/abuuba_web/follow_requests_test.exs
@@ -1,0 +1,139 @@
+defmodule AbuubaWeb.FollowRequestsTest do
+  @moduledoc """
+  Answering the people waiting to follow a locked account.
+
+  Locking is a switch on the privacy page, and everything that switch produces
+  was unanswerable from any page: the request arrived as a notification with a
+  "hide" button, and the only control in the interface was an accept-all buried
+  in the account-migration section and worded for a move.
+  `POST /api/v1/follow_requests/:id/authorize` has always answered.
+
+  Its own screen with a counted way in, which is the shape the reference
+  implementation settled on: the link is drawn only while somebody is waiting,
+  because a permanent nav entry that is empty on all but a handful of servers
+  is a permanent reminder of nothing.
+  """
+  use AbuubaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Abuuba.AccountsFixtures
+
+  alias Abuuba.Accounts
+  alias Abuuba.Accounts.Auth
+  alias Abuuba.Relationships
+
+  setup %{conn: conn} do
+    account = account_fixture(%{username: "locked"})
+    {:ok, account} = Accounts.update_profile(account, %{locked: true})
+
+    user =
+      user_fixture(%{account_id: account.id, approved: true, confirmed_at: DateTime.utc_now()})
+
+    conn =
+      conn
+      |> Phoenix.ConnTest.init_test_session(%{})
+      |> Plug.Conn.put_session(:user_token, Auth.create_session_token(user))
+
+    %{conn: conn, account: account}
+  end
+
+  defp asks(account, username) do
+    asker = account_fixture(%{username: username, display_name: "Anna #{username}"})
+    {:ok, _} = Relationships.follow_or_request(asker, account)
+
+    asker
+  end
+
+  describe "the page" do
+    test "lists everybody waiting", %{conn: conn, account: account} do
+      one = asks(account, "askerone")
+      two = asks(account, "askertwo")
+
+      {:ok, _live, html} = live(conn, ~p"/follow-requests")
+
+      assert html =~ "Anna askerone"
+      assert html =~ "@#{one.username}"
+      assert html =~ "@#{two.username}"
+    end
+
+    test "says so plainly when nobody is", %{conn: conn} do
+      {:ok, _live, html} = live(conn, ~p"/follow-requests")
+
+      assert html =~ "Nobody is waiting"
+    end
+
+    test "lets one in", %{conn: conn, account: account} do
+      asker = asks(account, "askerone")
+
+      {:ok, live, _html} = live(conn, ~p"/follow-requests")
+
+      html =
+        live
+        |> element("button[phx-click='accept'][phx-value-id='#{asker.id}']")
+        |> render_click()
+
+      assert Relationships.following?(asker.id, account.id)
+      refute Relationships.get_follow_request(asker, account)
+      refute html =~ "Anna askerone"
+    end
+
+    test "turns one away, leaving no follow behind", %{conn: conn, account: account} do
+      asker = asks(account, "askerone")
+
+      {:ok, live, _html} = live(conn, ~p"/follow-requests")
+
+      live
+      |> element("button[phx-click='reject'][phx-value-id='#{asker.id}']")
+      |> render_click()
+
+      refute Relationships.following?(asker.id, account.id)
+      refute Relationships.get_follow_request(asker, account)
+    end
+
+    test "answers only requests that are waiting on the reader", %{conn: conn} do
+      # The id comes off the page, so the only thing it may name is a request
+      # this account has been asked to answer.
+      somebody_else = account_fixture(%{username: "elsewhere"})
+
+      {:ok, other} =
+        Accounts.update_profile(account_fixture(%{username: "other"}), %{locked: true})
+
+      {:ok, _} = Relationships.follow_or_request(somebody_else, other)
+
+      {:ok, live, _html} = live(conn, ~p"/follow-requests")
+      render_hook(live, "accept", %{"id" => to_string(somebody_else.id)})
+
+      refute Relationships.following?(somebody_else.id, other.id)
+      assert Relationships.get_follow_request(somebody_else, other)
+    end
+
+    test "is not a page for somebody signed out", %{account: account} do
+      asks(account, "askerone")
+
+      assert {:error, {:redirect, %{to: to}}} =
+               live(Phoenix.ConnTest.build_conn(), ~p"/follow-requests")
+
+      assert to == ~p"/login"
+    end
+  end
+
+  describe "the way in" do
+    test "is drawn, with a count, while somebody is waiting", %{conn: conn, account: account} do
+      asks(account, "askerone")
+      asks(account, "askertwo")
+
+      html = conn |> get(~p"/shortcuts") |> html_response(200)
+
+      assert html =~ ~s(href="/follow-requests")
+      assert html =~ "Follow requests"
+    end
+
+    test "and is not drawn when nobody is", %{conn: conn} do
+      # A permanent entry that is empty on all but a handful of servers is a
+      # permanent reminder of nothing.
+      html = conn |> get(~p"/shortcuts") |> html_response(200)
+
+      refute page(html) =~ "/follow-requests"
+    end
+  end
+end

--- a/test/abuuba_web/reader_rules_test.exs
+++ b/test/abuuba_web/reader_rules_test.exs
@@ -1,0 +1,125 @@
+defmodule AbuubaWeb.ReaderRulesTest do
+  @moduledoc """
+  Blocks and mutes, on every page that shows a stranger's posts.
+
+  `Abuuba.Timelines.public/2` and `Abuuba.Timelines.tag/3` apply them through
+  `Abuuba.Statuses.excluding_hidden/2`, and that is what the API answers with.
+  The browser's own explore and hashtag pages did not go through either: they
+  asked `Statuses.public_timeline/1` and `Statuses.tag_timeline/2` directly,
+  neither of which is told who is reading. So a person somebody had blocked
+  was hidden from their home timeline and their search results, and sat on
+  explore and on every hashtag page -- the two screens a reader lands on most
+  after their own timeline.
+
+  Written per surface rather than per rule, because the bug is not that a rule
+  was wrong. It is that two surfaces never asked.
+  """
+  use AbuubaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Abuuba.AccountsFixtures
+  import Abuuba.StatusesFixtures
+
+  alias Abuuba.Accounts.Auth
+  alias Abuuba.Relationships
+
+  @tag_name "readerrules"
+
+  setup %{conn: conn} do
+    reader = account_fixture(%{username: "reader"})
+
+    user =
+      user_fixture(%{account_id: reader.id, approved: true, confirmed_at: DateTime.utc_now()})
+
+    stranger = account_fixture(%{username: "stranger", display_name: "A Stranger"})
+
+    status =
+      status_fixture(%{
+        account_id: stranger.id,
+        text: "loud opinion about ##{@tag_name}",
+        visibility: :public
+      })
+
+    conn =
+      conn
+      |> Phoenix.ConnTest.init_test_session(%{})
+      |> Plug.Conn.put_session(:user_token, Auth.create_session_token(user))
+
+    %{conn: conn, reader: reader, stranger: stranger, status: status}
+  end
+
+  defp surfaces, do: [{"explore", "/explore"}, {"the hashtag page", "/tags/#{@tag_name}"}]
+
+  describe "before anybody is blocked or muted" do
+    test "every surface shows the post", %{conn: conn} do
+      # The control. Every assertion below is that something is absent, which a
+      # page showing nothing at all would satisfy just as well.
+      for {name, path} <- surfaces() do
+        {:ok, _live, html} = live(conn, path)
+
+        assert html =~ "loud opinion", "#{name} showed nothing to begin with"
+      end
+    end
+  end
+
+  describe "somebody the reader blocked" do
+    setup %{reader: reader, stranger: stranger} do
+      {:ok, _} = Relationships.block(reader, stranger)
+      :ok
+    end
+
+    test "is off every surface", %{conn: conn} do
+      for {name, path} <- surfaces() do
+        {:ok, _live, html} = live(conn, path)
+
+        refute html =~ "loud opinion", "#{name} showed a blocked account's post"
+      end
+    end
+  end
+
+  describe "somebody the reader muted" do
+    setup %{reader: reader, stranger: stranger} do
+      {:ok, _} = Relationships.mute(reader, stranger)
+      :ok
+    end
+
+    test "is off every surface", %{conn: conn} do
+      for {name, path} <- surfaces() do
+        {:ok, _live, html} = live(conn, path)
+
+        refute html =~ "loud opinion", "#{name} showed a muted account's post"
+      end
+    end
+  end
+
+  describe "somebody who blocked the reader" do
+    setup %{reader: reader, stranger: stranger} do
+      {:ok, _} = Relationships.block(stranger, reader)
+      :ok
+    end
+
+    test "is off every surface too", %{conn: conn} do
+      # The half a reader cannot fix themselves, and the one that matters to
+      # the person who pressed the button.
+      for {name, path} <- surfaces() do
+        {:ok, _live, html} = live(conn, path)
+
+        refute html =~ "loud opinion", "#{name} showed a post to somebody blocked by its author"
+      end
+    end
+  end
+
+  describe "a stranger reading the same pages" do
+    test "still sees it, blocks being nobody else's business", %{conn: conn} do
+      stranger_conn = Phoenix.ConnTest.build_conn()
+
+      for {name, path} <- surfaces() do
+        {:ok, _live, html} = live(stranger_conn, path)
+
+        assert html =~ "loud opinion", "#{name} hid a public post from somebody signed out"
+      end
+
+      assert conn
+    end
+  end
+end

--- a/test/abuuba_web/report_test.exs
+++ b/test/abuuba_web/report_test.exs
@@ -1,0 +1,230 @@
+defmodule AbuubaWeb.ReportTest do
+  @moduledoc """
+  Telling a moderator about somebody, from the pages rather than from an app.
+
+  `POST /api/v1/reports` has always answered and `/admin/reports` is a full
+  triage queue with categories, evidence, rule attribution and forwarding.
+  Nothing in this server's own interface could put anything into it, so the
+  queue could only be filled by an API client and a person reading a post here
+  had no way to say anything about it.
+
+  The steps are the ones the reference implementation settled on, because a
+  report is read by a moderator who has to decide something and the shape of
+  what they are given is what makes that possible: a category, the posts it is
+  about, which rules if any, and a sentence in the reporter's own words.
+
+  The first option files no report. "I do not like it" is not a moderation
+  problem, and offering mute and block there is what stops the queue filling
+  with reports that only ever needed a button the reader had not found.
+  """
+  use AbuubaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Abuuba.AccountsFixtures
+  import Abuuba.StatusesFixtures
+
+  alias Abuuba.Accounts.Auth
+  alias Abuuba.Moderation.Reports
+  alias Abuuba.Relationships
+  alias Abuuba.Settings
+
+  setup %{conn: conn} do
+    reporter = account_fixture(%{username: "reporter"})
+
+    user =
+      user_fixture(%{account_id: reporter.id, approved: true, confirmed_at: DateTime.utc_now()})
+
+    subject = account_fixture(%{username: "subject", display_name: "The Subject"})
+    status = status_fixture(%{account_id: subject.id, text: "the post in question"})
+
+    conn =
+      conn
+      |> Phoenix.ConnTest.init_test_session(%{})
+      |> Plug.Conn.put_session(:user_token, Auth.create_session_token(user))
+
+    %{conn: conn, reporter: reporter, subject: subject, status: status}
+  end
+
+  defp filed(reporter) do
+    Reports.list(%{limit: 10}) |> Enum.filter(&(&1.account_id == reporter.id))
+  end
+
+  describe "the page" do
+    test "names who it is about", %{conn: conn, subject: subject} do
+      {:ok, _live, html} = live(conn, ~p"/report/@#{subject.username}")
+
+      assert html =~ "The Subject"
+      assert html =~ "@#{subject.username}"
+    end
+
+    test "refuses to be a page about somebody who does not exist", %{conn: conn} do
+      assert_raise AbuubaWeb.NotFound, fn -> live(conn, ~p"/report/@nobodyhere") end
+    end
+
+    test "refuses to be a page about yourself", %{conn: conn, reporter: reporter} do
+      # Nothing a moderator can do with it, and the mute and block it offers
+      # would be a person blocking themselves.
+      assert {:error, {:live_redirect, %{to: to}}} = live(conn, ~p"/report/@#{reporter.username}")
+
+      assert to == ~p"/@#{reporter.username}"
+    end
+
+    test "is not a page for somebody signed out", %{subject: subject} do
+      assert {:error, {:redirect, %{to: to}}} =
+               live(Phoenix.ConnTest.build_conn(), ~p"/report/@#{subject.username}")
+
+      assert to == ~p"/login"
+    end
+  end
+
+  describe "a category that is a moderation problem" do
+    test "files the report, with the comment", %{conn: conn, reporter: reporter, subject: subject} do
+      {:ok, live, _html} = live(conn, ~p"/report/@#{subject.username}")
+
+      live |> element("button[phx-click='category'][phx-value-category='spam']") |> render_click()
+      live |> element("button[phx-click='to_comment']") |> render_click()
+
+      live
+      |> form("#report-form", report: %{"comment" => "they posted the same link nine times"})
+      |> render_submit()
+
+      assert [report] = filed(reporter)
+      assert report.category == "spam"
+      assert report.target_account_id == subject.id
+      assert report.comment =~ "nine times"
+    end
+
+    test "and the posts that were ticked as evidence", %{
+      conn: conn,
+      reporter: reporter,
+      subject: subject,
+      status: status
+    } do
+      {:ok, live, _html} = live(conn, ~p"/report/@#{subject.username}?status=#{status.id}")
+
+      live |> element("button[phx-click='category'][phx-value-category='spam']") |> render_click()
+      live |> element("button[phx-click='to_comment']") |> render_click()
+      live |> form("#report-form", report: %{"comment" => ""}) |> render_submit()
+
+      assert [report] = filed(reporter)
+      assert report.status_ids == [status.id]
+    end
+
+    test "and nothing when the reader ticks nothing", %{
+      conn: conn,
+      reporter: reporter,
+      subject: subject,
+      status: status
+    } do
+      {:ok, live, _html} = live(conn, ~p"/report/@#{subject.username}")
+
+      live
+      |> element("button[phx-click='category'][phx-value-category='other']")
+      |> render_click()
+
+      live |> element("button[phx-click='to_comment']") |> render_click()
+      live |> form("#report-form", report: %{"comment" => ""}) |> render_submit()
+
+      assert [report] = filed(reporter)
+      assert report.status_ids == []
+      assert status
+    end
+  end
+
+  describe "the rules step" do
+    test "is offered only when the server has rules", %{conn: conn, subject: subject} do
+      {:ok, live, html} = live(conn, ~p"/report/@#{subject.username}")
+
+      refute html =~ "violates"
+
+      {:ok, _rule} = Settings.create_rule(%{"text" => "Be kind to one another"})
+
+      {:ok, live2, html2} = live(conn, ~p"/report/@#{subject.username}")
+
+      assert html2 =~ "rules"
+      assert live && live2
+    end
+
+    test "records which rules were named", %{
+      conn: conn,
+      reporter: reporter,
+      subject: subject
+    } do
+      {:ok, rule} = Settings.create_rule(%{"text" => "Be kind to one another"})
+
+      {:ok, live, _html} = live(conn, ~p"/report/@#{subject.username}")
+
+      live
+      |> element("button[phx-click='category'][phx-value-category='violation']")
+      |> render_click()
+
+      live
+      |> form("#rules-form", report: %{"rule_ids" => [to_string(rule.id)]})
+      |> render_submit()
+
+      live |> element("button[phx-click='to_comment']") |> render_click()
+      live |> form("#report-form", report: %{"comment" => ""}) |> render_submit()
+
+      assert [report] = filed(reporter)
+      assert report.category == "violation"
+      assert report.rule_ids == [rule.id]
+    end
+  end
+
+  describe "\"I do not like it\"" do
+    test "files nothing at all", %{conn: conn, reporter: reporter, subject: subject} do
+      {:ok, live, _html} = live(conn, ~p"/report/@#{subject.username}")
+
+      live
+      |> element("button[phx-click='category'][phx-value-category='dislike']")
+      |> render_click()
+
+      assert filed(reporter) == []
+    end
+
+    test "and offers the buttons that actually answer it", %{conn: conn, subject: subject} do
+      {:ok, live, _html} = live(conn, ~p"/report/@#{subject.username}")
+
+      html =
+        live
+        |> element("button[phx-click='category'][phx-value-category='dislike']")
+        |> render_click()
+
+      assert html =~ "Mute"
+      assert html =~ "Block"
+    end
+
+    test "and muting from there works", %{conn: conn, reporter: reporter, subject: subject} do
+      {:ok, live, _html} = live(conn, ~p"/report/@#{subject.username}")
+
+      live
+      |> element("button[phx-click='category'][phx-value-category='dislike']")
+      |> render_click()
+
+      live |> element("button[phx-click='mute']") |> render_click()
+
+      assert Relationships.muting?(reporter.id, subject.id)
+    end
+  end
+
+  describe "after a report is filed" do
+    test "the same buttons are offered, because the wait is real", %{
+      conn: conn,
+      reporter: reporter,
+      subject: subject
+    } do
+      {:ok, live, _html} = live(conn, ~p"/report/@#{subject.username}")
+
+      live |> element("button[phx-click='category'][phx-value-category='spam']") |> render_click()
+      live |> element("button[phx-click='to_comment']") |> render_click()
+
+      html = live |> form("#report-form", report: %{"comment" => ""}) |> render_submit()
+
+      assert html =~ "Block"
+
+      live |> element("button[phx-click='block']") |> render_click()
+
+      assert Relationships.blocking?(reporter.id, subject.id)
+    end
+  end
+end

--- a/test/abuuba_web/saved_test.exs
+++ b/test/abuuba_web/saved_test.exs
@@ -1,0 +1,147 @@
+defmodule AbuubaWeb.SavedTest do
+  @moduledoc """
+  The two lists a reader builds by pressing buttons on posts.
+
+  `AbuubaWeb.StatusComponent` draws a bookmark and a favourite on every post on
+  every screen, `GET /api/v1/bookmarks` and `/api/v1/favourites` have always
+  answered, and there was nowhere in this server's own interface to see either.
+  A control that works and leads nowhere is the same shape as one that does not
+  work: the reader presses it and never finds out what it did.
+  """
+  use AbuubaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Abuuba.AccountsFixtures
+  import Abuuba.StatusesFixtures
+
+  alias Abuuba.Accounts.Auth
+  alias Abuuba.Statuses
+
+  setup %{conn: conn} do
+    reader = account_fixture(%{username: "collector"})
+
+    user =
+      user_fixture(%{account_id: reader.id, approved: true, confirmed_at: DateTime.utc_now()})
+
+    author = account_fixture(%{username: "writer"})
+
+    kept = status_fixture(%{account_id: author.id, text: "worth keeping"})
+    liked = status_fixture(%{account_id: author.id, text: "worth applauding"})
+    ignored = status_fixture(%{account_id: author.id, text: "worth nothing"})
+
+    {:ok, _} = Statuses.bookmark(reader, kept)
+    {:ok, _} = Statuses.favourite(reader, liked)
+
+    conn =
+      conn
+      |> Phoenix.ConnTest.init_test_session(%{})
+      |> Plug.Conn.put_session(:user_token, Auth.create_session_token(user))
+
+    %{conn: conn, reader: reader, kept: kept, liked: liked, ignored: ignored}
+  end
+
+  describe "bookmarks" do
+    test "shows what was bookmarked and nothing else", %{conn: conn} do
+      {:ok, _live, html} = live(conn, ~p"/bookmarks")
+
+      assert html =~ "worth keeping"
+      refute html =~ "worth applauding"
+      refute html =~ "worth nothing"
+    end
+
+    test "and the bar on them works, like on every other screen", %{
+      conn: conn,
+      reader: reader,
+      kept: kept
+    } do
+      {:ok, live, _html} = live(conn, ~p"/bookmarks")
+
+      live
+      |> element("button[phx-click='favourite'][phx-value-id='#{kept.id}']")
+      |> render_click()
+
+      assert Statuses.favourited?(reader.id, kept.id)
+    end
+
+    test "and unbookmarking takes it off the list it is on", %{
+      conn: conn,
+      reader: reader,
+      kept: kept
+    } do
+      {:ok, live, _html} = live(conn, ~p"/bookmarks")
+
+      html =
+        live
+        |> element("button[phx-click='bookmark'][phx-value-id='#{kept.id}']")
+        |> render_click()
+
+      refute Statuses.bookmarked?(reader.id, kept.id)
+      refute html =~ "worth keeping"
+    end
+  end
+
+  describe "favourites" do
+    test "shows what was favourited and nothing else", %{conn: conn} do
+      {:ok, _live, html} = live(conn, ~p"/favourites")
+
+      assert html =~ "worth applauding"
+      refute html =~ "worth keeping"
+    end
+
+    test "and unfavouriting takes it off the list it is on", %{
+      conn: conn,
+      reader: reader,
+      liked: liked
+    } do
+      {:ok, live, _html} = live(conn, ~p"/favourites")
+
+      html =
+        live
+        |> element("button[phx-click='favourite'][phx-value-id='#{liked.id}']")
+        |> render_click()
+
+      refute Statuses.favourited?(reader.id, liked.id)
+      refute html =~ "worth applauding"
+    end
+  end
+
+  describe "an empty list" do
+    setup %{reader: reader, kept: kept, liked: liked} do
+      Statuses.unbookmark(reader, kept)
+      Statuses.unfavourite(reader, liked)
+
+      :ok
+    end
+
+    test "says what the button that fills it does", %{conn: conn} do
+      {:ok, _live, bookmarks} = live(conn, ~p"/bookmarks")
+      {:ok, _live, favourites} = live(conn, ~p"/favourites")
+
+      assert bookmarks =~ "Nothing bookmarked yet"
+      assert favourites =~ "Nothing favourited yet"
+    end
+  end
+
+  describe "the way in" do
+    test "is on every page, for somebody signed in", %{conn: conn} do
+      html = conn |> get(~p"/shortcuts") |> html_response(200)
+
+      assert html =~ ~s(href="/bookmarks")
+      assert html =~ ~s(href="/favourites")
+    end
+
+    test "and is not offered to a stranger", %{conn: _conn} do
+      html = Phoenix.ConnTest.build_conn() |> get(~p"/shortcuts") |> html_response(200)
+
+      refute page(html) =~ "/bookmarks"
+      refute page(html) =~ "/favourites"
+    end
+
+    test "and neither page answers one", %{conn: _conn} do
+      for path <- [~p"/bookmarks", ~p"/favourites"] do
+        assert {:error, {:redirect, %{to: to}}} = live(Phoenix.ConnTest.build_conn(), path)
+        assert to == ~p"/login"
+      end
+    end
+  end
+end

--- a/test/abuuba_web/settings_live_test.exs
+++ b/test/abuuba_web/settings_live_test.exs
@@ -730,67 +730,6 @@ defmodule AbuubaWeb.SettingsLiveTest do
     end
   end
 
-  # Locking your account is a switch on the privacy page, and everything it
-  # produces was unanswerable: the request arrived as a notification with a
-  # "hide" button, and the only control anywhere was an accept-all buried in
-  # the account-migration section, worded for a move. `POST
-  # /api/v1/follow_requests/:id/authorize` has always answered; no page asked
-  # it.
-  describe "follow requests" do
-    setup %{account: account} do
-      {:ok, _} = Abuuba.Accounts.update_profile(account, %{locked: true})
-
-      asker = account_fixture(%{username: "asker", display_name: "Anna Asker"})
-      {:ok, _request} = Relationships.follow_or_request(asker, account)
-
-      %{asker: asker}
-    end
-
-    test "are listed where the follows are", %{conn: conn, asker: asker} do
-      {:ok, _live, html} = live(conn, ~p"/settings/follows")
-
-      assert html =~ "Anna Asker"
-      assert html =~ "@#{asker.username}"
-    end
-
-    test "can be let in, one at a time", %{conn: conn, account: account, asker: asker} do
-      {:ok, live, _html} = live(conn, ~p"/settings/follows")
-
-      live
-      |> element("button[phx-click='accept_request'][phx-value-id='#{asker.id}']")
-      |> render_click()
-
-      assert Relationships.following?(asker.id, account.id)
-      refute Relationships.get_follow_request(asker, account)
-    end
-
-    test "and turned away, which leaves no follow behind", %{
-      conn: conn,
-      account: account,
-      asker: asker
-    } do
-      {:ok, live, _html} = live(conn, ~p"/settings/follows")
-
-      live
-      |> element("button[phx-click='reject_request'][phx-value-id='#{asker.id}']")
-      |> render_click()
-
-      refute Relationships.following?(asker.id, account.id)
-      refute Relationships.get_follow_request(asker, account)
-    end
-
-    test "and one that was answered is off the list", %{conn: conn, asker: asker} do
-      {:ok, live, _html} = live(conn, ~p"/settings/follows")
-
-      html =
-        live
-        |> element("button[phx-click='reject_request'][phx-value-id='#{asker.id}']")
-        |> render_click()
-
-      refute html =~ "Anna Asker"
-    end
-  end
-
   describe "security" do
     test "changes the password when the old one is right", %{conn: conn, user: user} do
       {:ok, live, _html} = live(conn, ~p"/settings/security")

--- a/test/abuuba_web/settings_live_test.exs
+++ b/test/abuuba_web/settings_live_test.exs
@@ -730,6 +730,67 @@ defmodule AbuubaWeb.SettingsLiveTest do
     end
   end
 
+  # Locking your account is a switch on the privacy page, and everything it
+  # produces was unanswerable: the request arrived as a notification with a
+  # "hide" button, and the only control anywhere was an accept-all buried in
+  # the account-migration section, worded for a move. `POST
+  # /api/v1/follow_requests/:id/authorize` has always answered; no page asked
+  # it.
+  describe "follow requests" do
+    setup %{account: account} do
+      {:ok, _} = Abuuba.Accounts.update_profile(account, %{locked: true})
+
+      asker = account_fixture(%{username: "asker", display_name: "Anna Asker"})
+      {:ok, _request} = Relationships.follow_or_request(asker, account)
+
+      %{asker: asker}
+    end
+
+    test "are listed where the follows are", %{conn: conn, asker: asker} do
+      {:ok, _live, html} = live(conn, ~p"/settings/follows")
+
+      assert html =~ "Anna Asker"
+      assert html =~ "@#{asker.username}"
+    end
+
+    test "can be let in, one at a time", %{conn: conn, account: account, asker: asker} do
+      {:ok, live, _html} = live(conn, ~p"/settings/follows")
+
+      live
+      |> element("button[phx-click='accept_request'][phx-value-id='#{asker.id}']")
+      |> render_click()
+
+      assert Relationships.following?(asker.id, account.id)
+      refute Relationships.get_follow_request(asker, account)
+    end
+
+    test "and turned away, which leaves no follow behind", %{
+      conn: conn,
+      account: account,
+      asker: asker
+    } do
+      {:ok, live, _html} = live(conn, ~p"/settings/follows")
+
+      live
+      |> element("button[phx-click='reject_request'][phx-value-id='#{asker.id}']")
+      |> render_click()
+
+      refute Relationships.following?(asker.id, account.id)
+      refute Relationships.get_follow_request(asker, account)
+    end
+
+    test "and one that was answered is off the list", %{conn: conn, asker: asker} do
+      {:ok, live, _html} = live(conn, ~p"/settings/follows")
+
+      html =
+        live
+        |> element("button[phx-click='reject_request'][phx-value-id='#{asker.id}']")
+        |> render_click()
+
+      refute html =~ "Anna Asker"
+    end
+  end
+
   describe "security" do
     test "changes the password when the old one is right", %{conn: conn, user: user} do
       {:ok, live, _html} = live(conn, ~p"/settings/security")


### PR DESCRIPTION
A third account joined the two from the last pass and the three of them talked to each other. Two bugs came out of it, and three capabilities turned out to have a full API and a full admin side with nothing a person could reach.

## The two bugs

**A locked account could not answer its own follow requests.** Locking is a switch on the privacy page; everything it produced was unanswerable. The request arrived as a notification with a **Hide** button, and the only control anywhere was an accept-all buried in the account-migration section, worded for a move.

**Explore and the hashtag pages showed a reader the posts of people they had blocked.** Both asked `Statuses.public_timeline/1` and `Statuses.tag_timeline/2` directly, and neither of those is told who is reading. `Timelines.public/2` and `Timelines.tag/3` — the ones the API answers with — apply blocks and mutes through `Statuses.excluding_hidden/2`. So the two screens people land on most after their own timeline were the two that never asked, while home, search and every API client hid them. What is trending arrives from a counter that knows nobody, so those rows are asked one at a time through `Statuses.hidden_for?/2`. The user guide already promised muting reached everywhere.

## The three missing screens

Shapes taken from the reference implementation, since it has already been argued about. Read for behaviour only — no code, CSS or assets.

**Follow requests** get their own screen at `/follow-requests`, with a navigation entry that appears only while somebody is waiting, badged with the count. That is Mastodon's rule (its `FollowRequestsLink` returns null at zero), and it is the only way the entry earns a place in a navigation this short: on a server where nobody approves followers a permanent entry is a permanent reminder of nothing.

**Reporting** at `/report/@user`, optionally `?status=id`, reachable from a profile beside Mute and Block and from the **…** on any post. Four questions in Mastodon's order — category, then rules if the server has any, then which posts, then a sentence — asked one at a time on one page rather than as a five-screen wizard, because nothing is written until the last press and Back is the browser's Back. The first option, **I do not like it**, files no report and jumps to mute and block; those two are offered after a real report as well. The forward-a-copy question appears only for a remote account, and the rules question only where rules exist.

**Bookmarks and favourites** as two tabs of one screen. Mastodon gives them a sidebar entry each; here they are in the sidebar footer beside Keyboard shortcuts, because the six-item list above it is also the bar along the bottom of a phone. The settings overview links them for that phone. Taking a mark back while reading the list takes the post off it.

The post's **…** menu now appears wherever a post is drawn rather than only inside a thread. Report is a link and needs no screen to answer it; the mute-conversation button inside is still gated on `@menu`, which is a screen saying it answers that event, so no dead control is added anywhere.

## Checked and found correct

Direct replies not bumping public reply counters (deliberate, `count_status/3`); content warnings folding into `<details>`; keyword filters collapsing a matching post; poll totals and plurals with two voters; a reply surviving its parent's deletion; notify-on-post; `follow/3` bypassing the lock, which is what it is for.

Version to 1.1.0 — this adds three screens. 4,449 tests, `mix precommit` clean on a fresh `_build`, German complete with no fuzzies, user guide updated in both languages.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01AcqNbR7MQMHFiaJBjD9ExS
