### PR TITLE
Update the JavaScript count, tighten three site sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ of numbers, and they compound:
 | Restart, until it answers again | 2,695 ms | 4,816 ms | **1.8x faster** |
 | Docker Containers | 2 | 5 | **2.5x fewer** |
 
-And the browser code, which is the same story told in a third way: 364 lines of
+And the browser code, which is the same story told in a third way: 453 lines of
 JavaScript against 97,209, with no npm dependencies at all against a lockfile
 of 1,428 entries.
 

--- a/site/index.html
+++ b/site/index.html
@@ -117,8 +117,8 @@
 
   <section class="band" id="screens">
     <div class="wrap reveal">
-      <h2>No client application. <em>Still an application.</em></h2>
-      <p>Every screen is HTML the server rendered, patched over a websocket as things change. These come straight from a running instance, cropped and not otherwise touched, in the dark theme abuuba takes from your system settings. Pick one to see it whole.</p>
+      <h2>Example <em>screenshots</em>.</h2>
+      <p>Straight from a running instance, cropped and not otherwise touched. Pick one to see it whole.</p>
       <div class="gallery">
           <a class="tile" href="#screen-compose">
             <img src="shots/thumb/compose.avif" width="760" height="704" loading="lazy" decoding="async"

--- a/site/index.html
+++ b/site/index.html
@@ -67,7 +67,7 @@
 
   <section class="band">
     <div class="wrap reveal">
-      <h2>That is <em>one</em> instance.</h2>
+      <h2>A smaller <em>server footprint</em>.</h2>
       <p>What decides how many a host can carry is a different set of numbers, and they compound.</p>
       <div style="overflow-x:auto">
         <table class="sheet">
@@ -84,13 +84,12 @@
 
   <section class="band">
     <div class="wrap reveal">
-      <h2>The same story, told in <em>JavaScript</em>.</h2>
-      <p>Open Mastodon in a browser and it hands you a second program to run: the JavaScript that fetches the timeline and draws it on your screen. abuuba has no such program. The server builds every page, and as posts arrive it sends the browser only the parts that changed. That is what LiveView does, the piece of Phoenix abuuba is built on, and it is why there is no <code>package.json</code>, no <code>node_modules</code>, no lockfile.</p>
+      <h2>Less JavaScript is <em>better</em>.</h2>
+      <p>Less JavaScript means fewer potential security problems to take care of. And more speed.</p>
       <div class="pair">
-        <div class="big a"><span class="n num">364</span><span class="l"><b>abuuba</b> · lines of JavaScript · 0 npm dependencies</span></div>
+        <div class="big a"><span class="n num">453</span><span class="l"><b>abuuba</b> · lines of JavaScript · 0 npm dependencies</span></div>
         <div class="big"><span class="n num">97,209</span><span class="l"><b>Mastodon</b> · lines of JavaScript · 1,428 lockfile entries</span></div>
       </div>
-      <p>Less JavaScript is better. Fewer security problems to take care of.</p>
     </div>
   </section>
 

--- a/site/press.html
+++ b/site/press.html
@@ -84,7 +84,7 @@
           <dt>Client API</dt><dd>All 289 endpoints Mastodon 4.6 declares under <code>/api/v1</code> and <code>/api/v2</code></dd>
           <dt>Federation</dt><dd>Tested against Mastodon 4.4.7 and GoToSocial 0.19.1 in Docker, 32 scenarios</dd>
           <dt>Migration</dt><dd>Takes over a Mastodon instance in place, on the same domain, with one command against the old database</dd>
-          <dt>Size</dt><dd>About 84,000 lines of application code, 4,387 tests, 364 lines of JavaScript, no npm dependencies</dd>
+          <dt>Size</dt><dd>About 85,000 lines of application code, 4,458 tests, 453 lines of JavaScript, no npm dependencies</dd>
           <dt>Author</dt><dd>Stefan Wintermeyer, Koblenz, Germany</dd>
           <dt>Source</dt><dd><a href="https://github.com/wintermeyer/abuuba">github.com/wintermeyer/abuuba</a></dd>
           <dt>Website</dt><dd><a href="https://abuuba.com/">abuuba.com</a></dd>


### PR DESCRIPTION
#34 added `assets/js/localtime.js`, so the homepage stat claiming 364 lines of JavaScript was stale.

Counted the way the 364 was, `wc -l assets/js/*.js` without `assets/vendor/`:

app.js 113 · compose.js 110 · hotkeys.js 68 · localtime.js 87 · posts.js 75 → **453**

Three places carried it: the stat, the press kit's Size line, the README. The press kit's neighbours had drifted too: 4,387 tests to 4,458, "about 84,000" to 85,000. Mastodon's 97,209 I left alone, having not re-measured it.

Three sections got shorter, each now headed with what it holds: "Less JavaScript is better", "A smaller server footprint", "Example screenshots". The server-rendered-HTML explanation goes with them; Phoenix and LiveView stay named in the lede, the comparison table and the facts list.

Correcting my own text in #34: localtime.js is 87 lines, not the 68 I claimed there.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01AcqNbR7MQMHFiaJBjD9ExS
