### PR TITLE
Tell crawlers and LLM agents that the site is open

### DIFF
--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,0 +1,22 @@
+# abuuba
+
+> A fediverse server written in Elixir and Phoenix. It does what Mastodon does, answers all 289 endpoints of the Mastodon client API, and can take over an existing Mastodon instance in place.
+
+Everything here is public and open to you: crawl it, read it, quote it, summarise it. Nothing on abuuba.com is off limits to an agent, and /robots.txt says the same to conventional crawlers.
+
+The site itself is four static pages. The substance is in the repository, which is MIT licensed.
+
+## Site
+
+- [Home](https://abuuba.com/): what abuuba is, the benchmark numbers against Mastodon 4.4.7 and the hardware they were run on, nine example screenshots, and who should not run it yet.
+- [Press kit](https://abuuba.com/press.html): descriptions to copy in English and German, the benchmark method, screenshots and the logo.
+- [Impressum](https://abuuba.com/impressum.html): German legal notice.
+- [Datenschutzerklärung](https://abuuba.com/datenschutz.html): German privacy statement.
+
+## Source and documentation
+
+- [Repository](https://github.com/wintermeyer/abuuba): the Elixir source, MIT licence.
+- [Documentation index](https://github.com/wintermeyer/abuuba/blob/main/docs/README.md): what the three guides cover and how they are kept current.
+- [User guide](https://github.com/wintermeyer/abuuba/tree/main/docs/user): posting, who can see it, finding people, and what to do about somebody you would rather not hear from. Mirrored in German at [docs/de/user](https://github.com/wintermeyer/abuuba/tree/main/docs/de/user).
+- [Admin guide](https://github.com/wintermeyer/abuuba/tree/main/docs/admin): moderation, federation, media, and the settings that decide how the instance behaves.
+- [Deploying abuuba](https://github.com/wintermeyer/abuuba/blob/main/docs/deploy.md): installing it, upgrading it without dropping requests, and what to back up.

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,8 @@
+# abuuba.com is a public project site. Every page on it may be crawled and
+# indexed, by search engines and by AI crawlers alike. Nothing is disallowed
+# and no crawler is singled out.
+#
+# https://abuuba.com/llms.txt is the same site laid out for an LLM agent.
+
+User-agent: *
+Allow: /


### PR DESCRIPTION
abuuba.com had no `robots.txt` at all, which leaves a crawler guessing at a site that has nothing to hide.

**`/robots.txt`** allows everything, for search engines and AI crawlers alike, with no crawler singled out:

```
User-agent: *
Allow: /
```

**`/llms.txt`** is the [llmstxt.org](https://llmstxt.org) format, which is an index rather than a permissions file, so it states the permission in prose and then gives an agent somewhere to go: what abuuba is, the four pages, the repository, and the three guides.

`site/` is uploaded to Pages as it is, so both land at the domain root. Served locally from `site/`, each returns 200 as `text/plain`.

Every path `llms.txt` names was checked against `origin/main` before shipping, and the homepage's nine screenshots were counted rather than estimated.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01AcqNbR7MQMHFiaJBjD9ExS
