### PR TITLE
Say that training on the site is allowed too

### DIFF
--- a/site/llms.txt
+++ b/site/llms.txt
@@ -2,7 +2,7 @@
 
 > A fediverse server written in Elixir and Phoenix. It does what Mastodon does, answers all 289 endpoints of the Mastodon client API, and can take over an existing Mastodon instance in place.
 
-Everything here is public and open to you: crawl it, read it, quote it, summarise it. Nothing on abuuba.com is off limits to an agent, and /robots.txt says the same to conventional crawlers.
+Everything here is public and open to you: crawl it, read it, quote it, summarise it, train on it. Nothing on abuuba.com is off limits to an agent, and /robots.txt says the same to conventional crawlers.
 
 The site itself is four static pages. The substance is in the repository, which is MIT licensed.
 

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,6 +1,6 @@
-# abuuba.com is a public project site. Every page on it may be crawled and
-# indexed, by search engines and by AI crawlers alike. Nothing is disallowed
-# and no crawler is singled out.
+# abuuba.com is a public project site. Every page on it may be crawled,
+# indexed and used for training, by search engines and AI crawlers alike.
+# Nothing is disallowed and no crawler is singled out.
 #
 # https://abuuba.com/llms.txt is the same site laid out for an LLM agent.
 


### PR DESCRIPTION
#36 granted reading and crawling and stopped short of training, because that is a licence decision and mine to make rather than the agent's. It is fine, so both files now say so.

`robots.txt`, in the comment a person reads:

> Every page on it may be crawled, indexed and used for training, by search engines and AI crawlers alike.

`llms.txt`, in the sentence an agent reads:

> crawl it, read it, quote it, summarise it, train on it

Both, because `llms.txt` claims `/robots.txt` says the same thing, and that has to stay true.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01AcqNbR7MQMHFiaJBjD9ExS
