### PR TITLE
Give the press page the same share card

### DIFF
--- a/site/press.html
+++ b/site/press.html
@@ -9,6 +9,12 @@
 <meta property="og:description" content="Descriptions to copy, the numbers with their method, screenshots, the logo, and a person who answers email.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://abuuba.com/press.html">
+<meta property="og:image" content="https://abuuba.com/og.png">
+<meta property="og:image:type" content="image/png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="The abuuba wordmark.">
+<meta name="twitter:card" content="summary_large_image">
 <link rel="canonical" href="https://abuuba.com/press.html">
 <link rel="icon" href="favicon.svg" type="image/svg+xml">
 <link rel="stylesheet" href="site.css">


### PR DESCRIPTION
The other half of #39. `press.html` had `og:title` and `og:description` and no image, so a link to the press kit came out as a grey box.

It points at `https://abuuba.com/og.png`, the card #39 added, rather than getting one of its own: a second image is a second thing to keep in step with the brand, and this is the same site.

That card is already live from #39's deploy (200, `image/png`, 71,813 bytes), so the absolute URL here resolves the moment this lands. No window where the tag points at a 404.

Both pages now carry the same six tags. Verified on the live homepage as well: `og:image` and `twitter:card` are being served.

An AI agent wrote this text in my name. I know that is problematic.

https://claude.ai/code/session_01AcqNbR7MQMHFiaJBjD9ExS
