### PR TITLE
Call it 1.0 everywhere and say it is not for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![CI](https://github.com/wintermeyer/abuuba/actions/workflows/ci.yml/badge.svg)](https://github.com/wintermeyer/abuuba/actions/workflows/ci.yml)
 
+> **Version 1.0. Do not run this in production.** It has bugs nobody has found
+> yet, and it has never run a real community. Put it on a lab machine, break
+> it, and tell me what broke.
+
 abuuba is a fediverse server written in [Elixir](https://elixir-lang.org) and
 [Phoenix](https://www.phoenixframework.org). It speaks
 [Mastodon](https://joinmastodon.org)'s protocols: [ActivityPub](https://www.w3.org/TR/activitypub/)
@@ -9,7 +13,8 @@ for federation and the complete [Mastodon client API](https://docs.joinmastodon.
 for apps. Every one of the 289 endpoints Mastodon 4.6 declares under `/api/v1`
 and `/api/v2` is answered here, a test fails the build when one goes missing,
 and existing apps work unchanged. It exists for one reason: Mastodon is too
-slow.
+slow. I needed a fast peer to test [vutuv](https://vutuv.de), my ultrafast
+business network, against, and Mastodon could not keep up.
 
 | Same machine, same data, same Postgres | abuuba | Mastodon | |
 | --- | ---: | ---: | ---: |
@@ -111,11 +116,11 @@ instead, and went with abuuba.
 
 ## Not for the faint of heart
 
-This is a 1.0. It has bugs, and nobody knows yet where they are. abuuba is
-version 1.1.0, it has never served real members on the open internet, and
-nobody but me has tested any of it. Mastodon's bugs have had a decade and
-thousands of admins to surface them; abuuba's have had me. Every number above
-is measured and reproducible, and that is all it says.
+This is version 1.0. It has bugs, and nobody knows yet where they are: it has
+never served real members on the open internet, and nobody but me has tested
+any of it. Mastodon's bugs have had a decade and thousands of admins to
+surface them; abuuba's have had me. Every number above is measured and
+reproducible, and that is all it says.
 
 **Do not put abuuba into production right now.** Not under a community you
 would be sorry to lose, not under accounts somebody depends on. Run it in a

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.1.0",
+      version: "1.0.0",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/site/datenschutz.html
+++ b/site/datenschutz.html
@@ -43,7 +43,7 @@
 </main>
 
 <footer class="wrap">
-  <span>abuuba 1.0.0 · MIT licence · built by the founder of <a href="https://vutuv.de">vutuv</a>, because vutuv is fast and its peer was not.</span>
+  <span>abuuba 1.0 · MIT licence · built by the founder of <a href="https://vutuv.de">vutuv</a>, because vutuv is fast and its peer was not.</span>
   <nav aria-label="Secondary"><a href="press.html">Press</a><a href="impressum.html">Impressum</a><a href="datenschutz.html">Datenschutz</a><a href="https://github.com/wintermeyer/abuuba">GitHub</a></nav>
 </footer>
 </body>

--- a/site/impressum.html
+++ b/site/impressum.html
@@ -42,7 +42,7 @@
 </main>
 
 <footer class="wrap">
-  <span>abuuba 1.0.0 · MIT licence · built by the founder of <a href="https://vutuv.de">vutuv</a>, because vutuv is fast and its peer was not.</span>
+  <span>abuuba 1.0 · MIT licence · built by the founder of <a href="https://vutuv.de">vutuv</a>, because vutuv is fast and its peer was not.</span>
   <nav aria-label="Secondary"><a href="press.html">Press</a><a href="impressum.html">Impressum</a><a href="datenschutz.html">Datenschutz</a><a href="https://github.com/wintermeyer/abuuba">GitHub</a></nav>
 </footer>
 </body>

--- a/site/index.html
+++ b/site/index.html
@@ -43,7 +43,8 @@
       <div class="hero-grid">
         <div>
           <h1>The cheetah that outran the mastodon.</h1>
-          <p class="lede">abuuba is a fediverse server written in <a href="https://elixir-lang.org">Elixir</a> and <a href="https://www.phoenixframework.org">Phoenix</a>. It speaks <a href="https://joinmastodon.org">Mastodon</a>'s protocols: ActivityPub for federation and the complete Mastodon client API, all 289 endpoints, so existing apps work unchanged. Think of it as a drop-in replacement for Mastodon. It takes an instance over in place, keeping the domain, the accounts, the posts and the tokens on people's phones. It exists for one reason: <strong>Mastodon is too slow.</strong></p>
+          <p class="lede">abuuba is a fediverse server written in <a href="https://elixir-lang.org">Elixir</a> and <a href="https://www.phoenixframework.org">Phoenix</a>. It speaks <a href="https://joinmastodon.org">Mastodon</a>'s protocols: ActivityPub for federation and the complete Mastodon client API, all 289 endpoints, so existing apps work unchanged. Think of it as a drop-in replacement for Mastodon. It takes an instance over in place, keeping the domain, the accounts, the posts and the tokens on people's phones. It exists for one reason: <strong>Mastodon is too slow.</strong> I needed a fast peer to test <a href="https://vutuv.de">vutuv</a>, my ultrafast business network, against, and Mastodon could not keep up.</p>
+          <p class="warn"><strong>Version 1.0. Do not run this in production.</strong> It has bugs nobody has found yet, and it has never run a real community. Put it on a lab machine, break it, and tell me what broke.</p>
         </div>
         <div class="giant" aria-live="polite">
           <span class="giant-num" id="giant-num">68<span class="times">×</span></span>
@@ -400,7 +401,7 @@ docker compose up -d</pre>
             <dt>Speaks</dt><dd>ActivityPub, the complete Mastodon client API (289 endpoints)</dd>
             <dt>Verified against</dt><dd>Mastodon 4.4.7 and GoToSocial 0.19.1, 32 scenarios</dd>
             <dt>Licence</dt><dd>MIT</dd>
-            <dt>Version</dt><dd>1.0.0</dd>
+            <dt>Version</dt><dd>1.0, and not ready for production</dd>
           </dl>
         </div>
       </div>
@@ -452,7 +453,7 @@ docker compose up -d</pre>
 </main>
 
 <footer class="wrap">
-  <span>abuuba 1.0.1 · MIT licence · built by the founder of <a href="https://vutuv.de">vutuv</a>, because vutuv is fast and its peer was not.</span>
+  <span>abuuba 1.0 · MIT licence · built by the founder of <a href="https://vutuv.de">vutuv</a>, because vutuv is fast and its peer was not.</span>
   <nav aria-label="Secondary"><a href="press.html">Press</a><a href="impressum.html">Impressum</a><a href="datenschutz.html">Datenschutz</a><a href="https://github.com/wintermeyer/abuuba">GitHub</a></nav>
 </footer>
 

--- a/site/press.html
+++ b/site/press.html
@@ -60,7 +60,7 @@
       </div>
       <div class="copyblock">
         <h3>A paragraph</h3>
-        <p>abuuba is a fediverse server written in Elixir and Phoenix, published under the MIT licence by Stefan Wintermeyer in Koblenz. It federates over ActivityPub and answers all 289 endpoints of the Mastodon client API, so existing Mastodon apps work against it unchanged. It exists because Mastodon is slow: measured on one machine against Mastodon 4.4.7, abuuba serves the home timeline 12 times faster at the median and fans a post out to 10,000 followers 68 times faster. It runs as one application process next to one Postgres database, with no Redis, no worker process and no JavaScript build. An existing Mastodon instance can be taken over in place, on its own domain, with its accounts, posts, follows and moderation history.</p>
+        <p>abuuba is a fediverse server written in Elixir and Phoenix, published under the MIT licence by Stefan Wintermeyer in Koblenz. It federates over ActivityPub and answers all 289 endpoints of the Mastodon client API, so existing Mastodon apps work against it unchanged. It exists because Mastodon is slow: measured on one machine against Mastodon 4.4.7, abuuba serves the home timeline 12 times faster at the median and fans a post out to 10,000 followers 68 times faster. It runs as one application process next to one Postgres database, with no Redis, no worker process and no JavaScript build. An existing Mastodon instance can be taken over in place, on its own domain, with its accounts, posts, follows and moderation history. It is version 1.0 and not ready for production: it has bugs nobody has found yet, and it belongs in a lab rather than under a live community.</p>
       </div>
       <div class="copyblock" lang="de">
         <h3>Ein Satz</h3>
@@ -68,7 +68,7 @@
       </div>
       <div class="copyblock" lang="de">
         <h3>Fünfzig Wörter</h3>
-        <p>abuuba ist ein Fediverse-Server, geschrieben in Elixir und Phoenix. Er föderiert über ActivityPub und beantwortet alle 289 Endpunkte der Mastodon-Client-API, sodass vorhandene Mastodon-Apps unverändert funktionieren. Auf derselben Hardware liefert er Timelines 12- bis 18-mal schneller als Mastodon. MIT-Lizenz, eine Anwendung, eine Postgres-Datenbank.</p>
+        <p>abuuba ist ein Fediverse-Server, geschrieben in Elixir und Phoenix. Er föderiert über ActivityPub und beantwortet alle 289 Endpunkte der Mastodon-Client-API, sodass vorhandene Mastodon-Apps unverändert funktionieren. Auf derselben Hardware liefert er Timelines 12- bis 18-mal schneller als Mastodon. MIT-Lizenz, eine Anwendung, eine Postgres-Datenbank. Version 1.0 und noch nicht produktionsreif: abuuba gehört ins Labor, nicht unter eine laufende Community.</p>
       </div>
     </div>
   </section>
@@ -80,7 +80,8 @@
         <dl>
           <dt>Name</dt><dd>abuuba, always lowercase</dd>
           <dt>What it is</dt><dd>A fediverse server: ActivityPub for federation, the Mastodon client API for apps</dd>
-          <dt>Version</dt><dd>1.0.0</dd>
+          <dt>Version</dt><dd>1.0</dd>
+          <dt>Status</dt><dd>Not ready for production. It has bugs nobody has found yet and has never run a real community; a lab is the right place for it.</dd>
           <dt>Public since</dt><dd>28 August 2026</dd>
           <dt>Licence</dt><dd>MIT</dd>
           <dt>Written in</dt><dd>Elixir, Phoenix, LiveView</dd>
@@ -332,7 +333,7 @@
 </main>
 
 <footer class="wrap">
-  <span>abuuba 1.0.0 · MIT licence · built by the founder of <a href="https://vutuv.de">vutuv</a>, because vutuv is fast and its peer was not.</span>
+  <span>abuuba 1.0 · MIT licence · built by the founder of <a href="https://vutuv.de">vutuv</a>, because vutuv is fast and its peer was not.</span>
   <nav aria-label="Secondary"><a href="press.html">Press</a><a href="impressum.html">Impressum</a><a href="datenschutz.html">Datenschutz</a><a href="https://github.com/wintermeyer/abuuba">GitHub</a></nav>
 </footer>
 </body>

--- a/site/site.css
+++ b/site/site.css
@@ -45,6 +45,8 @@
   h1 { margin: 0; font: 400 clamp(2.8rem, 6.4vw, 5.4rem)/1.02 var(--display); letter-spacing: -0.012em; text-wrap: balance; }
   .lede { max-width: 56ch; margin: 22px 0 0; font-size: 1.12rem; color: var(--muted); }
   .lede strong { color: var(--ink); font-weight: 500; }
+  .warn { max-width: 56ch; margin: 20px 0 0; padding: 12px 16px; background: var(--surface); border-left: 3px solid var(--accent); color: var(--muted); font-size: .98rem; }
+  .warn strong { color: var(--accent); font-weight: 600; }
 
   .giant { position: relative; text-align: center; padding: 20px 0; min-height: 300px; display: flex; flex-direction: column; justify-content: center; }
   .giant::before { content: ""; position: absolute; inset: 0; z-index: -1; background: radial-gradient(closest-side, rgba(229,167,46,.16), transparent 70%); }


### PR DESCRIPTION
The version was 1.0.0 on the site, 1.0.1 in the footer and 1.1.0 in
`mix.exs`. Everything now says 1.0, `mix.exs` included, which is the version
the API reports.

The warning no longer waits until somebody scrolls: the README opens with it
under the badge, and the homepage carries it under the lede. The press page
gets a `Status` row and a sentence in the boilerplate paragraphs, English and
German, because that is the text a journalist copies. The lede also names
vutuv as the reason abuuba was written.

`mix precommit` green, 4,458 tests. Checked in Chrome.

*An AI agent wrote this text in my name. I know that is problematic.*

https://claude.ai/code/session_01C3UhUFqAJWjLCFoqya44iJ