### PR TITLE
One viewer-aware door for reading a status

### DIFF
--- a/lib/abuuba/statuses.ex
+++ b/lib/abuuba/statuses.ex
@@ -74,6 +74,51 @@ defmodule Abuuba.Statuses do
   def not_deleted, do: from(s in Status, as: :status, where: is_nil(s.deleted_at))
 
   @doc """
+  Removes what the author will not show this reader.
+
+  The author's own side of a block and nothing else: to somebody they have
+  blocked, a blocker is a stranger, and public posts are exactly what
+  strangers are otherwise handed. Asked of the post's author and of whoever a
+  boost is carrying, because a block is about the person whose words these
+  are, not about who passed them along.
+
+  The narrow half of `excluding_hidden/2`, for the surfaces a reader reaches
+  on purpose. Their own blocks and mutes are not here: those say what may be
+  delivered, and "the one place you still see them is their own profile, if
+  you go and look" is a promise the user guide makes about the other
+  direction. `readable/2` is what composes this.
+
+  Needs the `:status` binding that `not_deleted/0` carries.
+  """
+  @spec excluding_refused(Ecto.Query.t(), Account.t() | integer() | nil) :: Ecto.Query.t()
+  def excluding_refused(query, nil), do: query
+
+  def excluding_refused(query, %Account{id: viewer_id}), do: excluding_refused(query, viewer_id)
+
+  def excluding_refused(query, viewer_id) do
+    query
+    |> where(
+      [s],
+      not exists(
+        from b in Block,
+          where:
+            b.target_account_id == ^viewer_id and
+              b.account_id == parent_as(:status).account_id
+      )
+    )
+    |> where(
+      [s],
+      is_nil(s.reblog_of_id) or
+        not exists(
+          from o in Status,
+            join: b in Block,
+            on: b.target_account_id == ^viewer_id and b.account_id == o.account_id,
+            where: o.id == parent_as(:status).reblog_of_id
+        )
+    )
+  end
+
+  @doc """
   Removes what a reader's blocks and mutes hide, in both directions.
 
   Separate from `visible_to/2` because the two answer different questions:
@@ -138,6 +183,37 @@ defmodule Abuuba.Statuses do
       )
     )
     |> excluding_hidden_boosts(viewer_id, now)
+  end
+
+  @doc """
+  Removes the threads this reader has put down.
+
+  Apart from `excluding_hidden/2` because it answers a different question: not
+  whether the two are on speaking terms, but whether this conversation is one
+  the reader has stopped following. A timeline applies it and a search does
+  not, which is why it is a filter of its own rather than folded into that
+  one.
+
+  Needs the `:status` binding that `not_deleted/0` carries.
+  """
+  @spec excluding_muted_threads(Ecto.Query.t(), Account.t() | integer() | nil) :: Ecto.Query.t()
+  def excluding_muted_threads(query, nil), do: query
+
+  def excluding_muted_threads(query, %Account{id: viewer_id}),
+    do: excluding_muted_threads(query, viewer_id)
+
+  def excluding_muted_threads(query, viewer_id) do
+    where(
+      query,
+      [s],
+      is_nil(s.conversation_id) or
+        not exists(
+          from c in ConversationMute,
+            where:
+              c.account_id == ^viewer_id and
+                c.conversation_id == parent_as(:status).conversation_id
+        )
+    )
   end
 
   @doc """
@@ -955,8 +1031,12 @@ defmodule Abuuba.Statuses do
   Statuses by id, in the order the ids were given, narrowed to what `viewer`
   may see. Pass `nil` for a logged out reader.
 
-  `get_statuses/1` without the narrowing is for callers whose ids are public
-  by construction; anything shown to a person goes through this one.
+  Audience only, the batch twin of `get_status/2`. `get_statuses/1` without the
+  narrowing is for callers whose ids are public by construction. What a reader
+  is about to be shown goes through `readable_many/2`, which asks their blocks
+  and mutes as well; this one is left for the notification and conversation
+  envelopes, where a row referring to a post the reader has since hidden is a
+  question of its own.
   """
   @spec get_visible_statuses([integer() | String.t()], Account.t() | nil) :: [Status.t()]
   def get_visible_statuses(ids, viewer), do: by_ids(ids, visible_to(not_deleted(), viewer))
@@ -1004,8 +1084,16 @@ defmodule Abuuba.Statuses do
   defp to_id(_value), do: nil
 
   @doc """
-  Fetches a status `viewer` may read, or `nil`. Pass `nil` for a logged out
-  reader, which restricts the result to public and unlisted statuses.
+  Fetches a status `viewer` was addressed widely enough to reach, or `nil`.
+
+  Audience only. It answers whether the post was public, or private to people
+  including this reader — not whether the two are on speaking terms. For
+  anything a person is about to be shown, use `readable/2`, which asks both.
+
+  This one is for a caller acting on a post the reader named from a list that
+  was not filtered for them. `bookmarks/2` and `favourites/2` are that list:
+  they answer what somebody saved, whatever they have done about the author
+  since, and the action bar drawn over them has to reach every row it draws.
 
   A viewer is required rather than optional: the version of this function that
   took an id alone was one autocomplete away from serving direct messages.
@@ -1017,6 +1105,109 @@ defmodule Abuuba.Statuses do
 
   def get_status(id, viewer) do
     not_deleted() |> visible_to(viewer) |> Repo.get(id)
+  end
+
+  @doc """
+  Fetches a status to show to `viewer`, or `nil`. Pass `nil` for a logged out
+  reader, which restricts the result to public and unlisted statuses.
+
+  The one door for handing a reader a post they asked for by id. Two questions
+  in a single query: `visible_to/2` for the audience, and `excluding_refused/2`
+  for the author's own block — of the reader, and of the reader by whoever a
+  boost is carrying.
+
+  Only `visible_to/2` used to be asked here, so `GET /statuses/:id`, the batch,
+  a poll, an annual report and the post pages all handed a reader posts from
+  an account that had blocked them. The rule was written down once in the
+  timeline queries and enforced only there. The embed and the oEmbed have no
+  reader to ask about and come through for the sake of one door, not because
+  they leaked.
+
+  The reader's *own* blocks and mutes are deliberately not part of it. Those
+  decide what is delivered, not what may be opened: "the one place you still
+  see them is their own profile, if you go and look" is a promise the user
+  guide makes, and a profile that lists a post whose link answers nothing
+  breaks it. `readable?/2` is the twin that asks the reader's side, for the
+  paths where a post arrives unasked.
+  """
+  @spec readable(integer() | nil, Account.t() | integer() | nil) :: Status.t() | nil
+  def readable(nil, _viewer), do: nil
+  def readable(id, viewer), do: not_deleted() |> reading_scope(viewer) |> Repo.get(id)
+
+  @doc """
+  The same read for several ids at once, in the order they were given.
+
+  One query rather than one per id, and one answer rather than a caller's
+  choice of filters.
+  """
+  @spec readable_many([integer() | String.t()], Account.t() | integer() | nil) :: [Status.t()]
+  def readable_many([], _viewer), do: []
+  def readable_many(ids, viewer), do: by_ids(ids, reading_scope(not_deleted(), viewer))
+
+  @doc """
+  Fetches a status `viewer` may take one of their own marks off, or `nil`.
+
+  `readable/2`, or failing that a post they have already favourited,
+  bookmarked, boosted or muted the thread of. `bookmarks/2` and `favourites/2`
+  answer what somebody saved whatever they have done about the author since,
+  so the button drawn over a saved row has to reach it — and having a mark on
+  a post is proof they could read it when they made it.
+
+  Only for taking a mark back. Putting one on is being shown the post, so
+  `favourite`, `bookmark`, `reblog`, `mute` and `pin` go through `readable/2`
+  like any other read: the reference implementation draws the line in the same
+  place, refusing all five to a reader the author has blocked.
+  """
+  @spec actionable(integer() | nil, Account.t() | integer() | nil) :: Status.t() | nil
+  def actionable(id, viewer), do: readable(id, viewer) || own_mark(id, viewer)
+
+  defp own_mark(id, viewer) do
+    with %Status{} = status <- get_status(id, viewer),
+         true <- marked_by?(status, viewer_id(viewer)) do
+      status
+    else
+      _unmarked -> nil
+    end
+  end
+
+  defp marked_by?(_status, nil), do: false
+
+  defp marked_by?(%Status{id: status_id} = status, viewer_id) do
+    favourited?(viewer_id, status_id) or bookmarked?(viewer_id, status_id) or
+      boosted?(viewer_id, status_id) or thread_muted?(viewer_id, status)
+  end
+
+  @doc """
+  Whether a post that arrived unasked may be handed to `viewer`.
+
+  Everything `readable/2` asks and the reader's own side as well — their
+  blocks, their mutes, the servers they have shut out and the threads they
+  have put down. That is the difference between the two: opening a link is
+  deliberate, and a timeline is where all four are meant to take effect.
+
+  The streaming transports ask this once per post per open socket, and a
+  boolean is all they want, so it is one `EXISTS` rather than a row fetch
+  followed by `hidden_for?/2` — three round trips for one answer, on the
+  hottest path in the server.
+  """
+  @spec readable?(Status.t(), Account.t() | integer() | nil) :: boolean()
+  def readable?(%Status{} = status, viewer) do
+    not_deleted()
+    |> delivery_scope(viewer)
+    |> where([s], s.id == ^status.id)
+    |> Repo.exists?()
+  end
+
+  # What a reader may open, and what may be pushed at them. Two scopes because
+  # they are two questions, and the second is the first plus the reader's own
+  # side of it.
+  defp reading_scope(query, viewer), do: query |> visible_to(viewer) |> excluding_refused(viewer)
+
+  defp delivery_scope(query, viewer) do
+    query
+    |> visible_to(viewer)
+    |> excluding_hidden(viewer)
+    |> excluding_muted_threads(viewer)
   end
 
   defp stamp_edit(attrs, now) do

--- a/lib/abuuba/timelines.ex
+++ b/lib/abuuba/timelines.ex
@@ -30,7 +30,6 @@ defmodule Abuuba.Timelines do
   alias Abuuba.Relationships.Follow
   alias Abuuba.Repo
   alias Abuuba.Statuses
-  alias Abuuba.Statuses.ConversationMute
   alias Abuuba.Statuses.Status
   alias Abuuba.Statuses.Tag
   alias Abuuba.Timelines.Feed
@@ -148,16 +147,7 @@ defmodule Abuuba.Timelines do
     # word should hide.
     query
     |> Statuses.excluding_hidden(account_id)
-    |> where(
-      [s],
-      is_nil(s.conversation_id) or
-        not exists(
-          from c in ConversationMute,
-            where:
-              c.account_id == ^account_id and
-                c.conversation_id == parent_as(:status).conversation_id
-        )
-    )
+    |> Statuses.excluding_muted_threads(account_id)
   end
 
   # The same authors the public timeline keeps out, for the reason written next

--- a/lib/abuuba_web/api/entities.ex
+++ b/lib/abuuba_web/api/entities.ex
@@ -1797,13 +1797,11 @@ defmodule AbuubaWeb.API.Entities do
       |> Enum.flat_map(&Map.get(&1.data, "top_statuses", []))
       |> Enum.map(&API.parse_id(&1["id"]))
       |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
 
     # Through the viewer-aware read, so a report never carries a post the
     # person reading it may not see — a shared report is read by strangers.
-    found =
-      if ids == [],
-        do: [],
-        else: Enum.flat_map(ids, fn id -> List.wrap(Statuses.get_status(id, viewer)) end)
+    found = Statuses.readable_many(ids, viewer)
 
     %{
       "annual_reports" => Enum.map(reports, &annual_report/1),
@@ -2094,15 +2092,7 @@ defmodule AbuubaWeb.API.Entities do
       |> Enum.reject(&is_nil/1)
       |> Enum.uniq()
 
-    if ids == [] do
-      []
-    else
-      Statuses.not_deleted()
-      |> Statuses.visible_to(viewer)
-      |> where([s], s.id in ^ids)
-      |> Repo.all()
-      |> statuses(viewer)
-    end
+    ids |> Statuses.get_visible_statuses(viewer) |> statuses(viewer)
   end
 
   @doc """

--- a/lib/abuuba_web/controllers/api/poll_controller.ex
+++ b/lib/abuuba_web/controllers/api/poll_controller.ex
@@ -47,7 +47,7 @@ defmodule AbuubaWeb.API.PollController do
     viewer = current_account(conn)
     poll = Abuuba.Repo.get(Poll, API.id_param(%{"id" => id}, "id") || 0)
 
-    case poll && Statuses.get_status(poll.status_id, viewer) do
+    case poll && Statuses.readable(poll.status_id, viewer) do
       nil -> API.error(conn, 404, "Record not found")
       _status -> fun.(poll, viewer)
     end

--- a/lib/abuuba_web/controllers/api/status_controller.ex
+++ b/lib/abuuba_web/controllers/api/status_controller.ex
@@ -353,7 +353,7 @@ defmodule AbuubaWeb.API.StatusController do
         {:ok, nil}
 
       id ->
-        id |> Statuses.get_status(account) |> quotable(account)
+        id |> Statuses.readable(account) |> quotable(account)
     end
   end
 
@@ -371,7 +371,7 @@ defmodule AbuubaWeb.API.StatusController do
   author's own post would publish the assertion for them.
   """
   def quotes(conn, %{"id" => id}) do
-    with_status(conn, id, fn status, viewer ->
+    with_readable_status(conn, id, fn status, viewer ->
       json(conn, Entities.statuses(Quotes.quoting(status), viewer))
     end)
   end
@@ -425,7 +425,7 @@ defmodule AbuubaWeb.API.StatusController do
   One post.
   """
   def show(conn, %{"id" => id}) do
-    with_status(conn, id, fn status, viewer -> render_status(conn, status, viewer) end)
+    with_readable_status(conn, id, fn status, viewer -> render_status(conn, status, viewer) end)
   end
 
   @doc """
@@ -437,7 +437,7 @@ defmodule AbuubaWeb.API.StatusController do
 
     ids = params |> API.id_list("id") |> Enum.take(40)
 
-    statuses = Enum.flat_map(ids, fn id -> List.wrap(Statuses.get_status(id, viewer)) end)
+    statuses = Statuses.readable_many(ids, viewer)
 
     json(conn, Entities.statuses(statuses, viewer, filter_context: "thread"))
   end
@@ -484,7 +484,7 @@ defmodule AbuubaWeb.API.StatusController do
   The conversation a post sits in.
   """
   def context(conn, %{"id" => id}) do
-    with_status(conn, id, fn status, viewer ->
+    with_readable_status(conn, id, fn status, viewer ->
       json(conn, status |> Statuses.context(viewer) |> Entities.context(viewer))
     end)
   end
@@ -502,7 +502,7 @@ defmodule AbuubaWeb.API.StatusController do
   Every earlier version of a post.
   """
   def history(conn, %{"id" => id}) do
-    with_status(conn, id, fn status, _viewer ->
+    with_readable_status(conn, id, fn status, _viewer ->
       # The current version closes the list. Each stored row is the state
       # *before* one edit, so a post edited twice has two rows and neither says
       # what it reads now -- and the newest edit is the one somebody opened the
@@ -527,7 +527,7 @@ defmodule AbuubaWeb.API.StatusController do
   issue; the endpoint is here so a client can ask and be told.
   """
   def translate(conn, %{"id" => id} = params) do
-    with_status(conn, id, fn status, viewer ->
+    with_readable_status(conn, id, fn status, viewer ->
       target = params["lang"] || reader_language(viewer, conn)
 
       case Translation.translate(status, target) do
@@ -573,7 +573,7 @@ defmodule AbuubaWeb.API.StatusController do
   ## Interactions
 
   def reblog(conn, %{"id" => id}) do
-    with_status(conn, id, fn status, account ->
+    with_readable_status(conn, id, fn status, account ->
       if Statuses.boostable?(account, status) do
         act(conn, id, &Statuses.boost/2)
       else
@@ -582,16 +582,16 @@ defmodule AbuubaWeb.API.StatusController do
     end)
   end
 
-  def unreblog(conn, %{"id" => id}), do: act(conn, id, &Statuses.unboost/2)
+  def unreblog(conn, %{"id" => id}), do: undo(conn, id, &Statuses.unboost/2)
   def favourite(conn, %{"id" => id}), do: act(conn, id, &Statuses.favourite/2)
-  def unfavourite(conn, %{"id" => id}), do: act(conn, id, &Statuses.unfavourite/2)
+  def unfavourite(conn, %{"id" => id}), do: undo(conn, id, &Statuses.unfavourite/2)
   def bookmark(conn, %{"id" => id}), do: act(conn, id, &Statuses.bookmark/2)
-  def unbookmark(conn, %{"id" => id}), do: act(conn, id, &Statuses.unbookmark/2)
+  def unbookmark(conn, %{"id" => id}), do: undo(conn, id, &Statuses.unbookmark/2)
   def mute(conn, %{"id" => id}), do: act(conn, id, &Statuses.mute_thread/2)
-  def unmute(conn, %{"id" => id}), do: act(conn, id, &Statuses.unmute_thread/2)
+  def unmute(conn, %{"id" => id}), do: undo(conn, id, &Statuses.unmute_thread/2)
 
   def pin(conn, %{"id" => id}) do
-    with_status(conn, id, fn status, account ->
+    with_readable_status(conn, id, fn status, account ->
       case Statuses.pin(account, status) do
         {:ok, _pin} ->
           render_status(conn, reload(status), account)
@@ -612,12 +612,12 @@ defmodule AbuubaWeb.API.StatusController do
     end)
   end
 
-  def unpin(conn, %{"id" => id}), do: act(conn, id, &Statuses.unpin/2)
+  def unpin(conn, %{"id" => id}), do: undo(conn, id, &Statuses.unpin/2)
 
   ## Who did what
 
   def reblogged_by(conn, %{"id" => id} = params) do
-    with_status(conn, id, fn status, viewer ->
+    with_readable_status(conn, id, fn status, viewer ->
       accounts = Statuses.boosted_by(status, Pagination.params(params, default: 40))
 
       conn
@@ -627,7 +627,7 @@ defmodule AbuubaWeb.API.StatusController do
   end
 
   def favourited_by(conn, %{"id" => id} = params) do
-    with_status(conn, id, fn status, viewer ->
+    with_readable_status(conn, id, fn status, viewer ->
       accounts = Statuses.favourited_by(status, Pagination.params(params, default: 40))
 
       conn
@@ -640,8 +640,15 @@ defmodule AbuubaWeb.API.StatusController do
 
   # Every interaction is the same three steps, and the state a client wants
   # back is always the post as it now reads.
-  defp act(conn, id, fun) do
-    with_status(conn, id, fn status, account ->
+  #
+  # Putting a mark on is being shown the post, so it comes through the reading
+  # door; taking one back off is `undo/3` below.
+  defp act(conn, id, fun), do: interact(conn, id, fun, &with_readable_status/3)
+
+  defp undo(conn, id, fun), do: interact(conn, id, fun, &with_actionable_status/3)
+
+  defp interact(conn, id, fun, door) do
+    door.(conn, id, fn status, account ->
       case fun.(account, status) do
         {:error, :no_conversation} ->
           API.error(conn, 422, "Validation failed")
@@ -655,10 +662,32 @@ defmodule AbuubaWeb.API.StatusController do
     end)
   end
 
+  # For the endpoints that hand a post back to be read: `Statuses.readable/2`
+  # answers the reader's blocks and mutes as well as the audience, so a post
+  # from somebody they will not deal with is a 404 here rather than a body.
+  defp with_readable_status(conn, id, fun) do
+    fetch(conn, id, &Statuses.readable/2, fun)
+  end
+
+  # For taking a mark back off: readable, or already marked by this reader.
+  # `/bookmarks` and `/favourites` list what somebody saved whatever they have
+  # done about the author since, so the button drawn over a row those lists
+  # still return has to reach it.
+  defp with_actionable_status(conn, id, fun) do
+    fetch(conn, id, &Statuses.actionable/2, fun)
+  end
+
+  # Audience only, for a caller that has its own reason to reach past the
+  # reader's blocks and mutes. `with_own_status/3` is the one left: a post is
+  # never hidden from the person who wrote it, and ownership is the check.
   defp with_status(conn, id, fun) do
+    fetch(conn, id, &Statuses.get_status/2, fun)
+  end
+
+  defp fetch(conn, id, read, fun) do
     viewer = current_account(conn)
 
-    case Statuses.get_status(API.id_param(%{"id" => id}, "id"), viewer) do
+    case read.(API.id_param(%{"id" => id}, "id"), viewer) do
       nil -> API.error(conn, 404, "Record not found")
       status -> fun.(status, viewer)
     end

--- a/lib/abuuba_web/controllers/embed_controller.ex
+++ b/lib/abuuba_web/controllers/embed_controller.ex
@@ -26,7 +26,7 @@ defmodule AbuubaWeb.EmbedController do
 
   def show(conn, %{"id" => id}) do
     with {number, ""} <- Integer.parse(to_string(id)),
-         status when not is_nil(status) <- Statuses.get_status(number, nil) do
+         status when not is_nil(status) <- Statuses.readable(number, nil) do
       conn
       |> put_root_layout(false)
       |> put_layout(false)

--- a/lib/abuuba_web/controllers/media_controller.ex
+++ b/lib/abuuba_web/controllers/media_controller.ex
@@ -27,7 +27,7 @@ defmodule AbuubaWeb.MediaController do
   def show(conn, %{"id" => id}) do
     with %Attachment{status_id: status_id} when not is_nil(status_id) <- attachment(id),
          %{account: %{username: username}} = status <-
-           Statuses.get_status(status_id, nil) |> Abuuba.Repo.preload(:account) do
+           Statuses.readable(status_id, nil) |> Abuuba.Repo.preload(:account) do
       redirect(conn, to: ~p"/@#{username}/#{status.id}")
     else
       # A file with no post is a file nobody can see in context, and there is

--- a/lib/abuuba_web/controllers/oembed_controller.ex
+++ b/lib/abuuba_web/controllers/oembed_controller.ex
@@ -43,7 +43,7 @@ defmodule AbuubaWeb.OEmbedController do
          true <- host == URIs.local_host(),
          [_, "@" <> _username, id] <- String.split(path, "/"),
          {number, ""} <- Integer.parse(id) do
-      Statuses.get_status(number, nil)
+      Statuses.readable(number, nil)
     else
       _ -> nil
     end

--- a/lib/abuuba_web/live/home_live.ex
+++ b/lib/abuuba_web/live/home_live.ex
@@ -204,15 +204,9 @@ defmodule AbuubaWeb.HomeLive do
   end
 
   def handle_info({:composed, status}, socket) do
-    account = socket.assigns.account
+    fresh = Statuses.readable(status.id, socket.assigns.account)
 
-    case Statuses.get_status(status.id, account) do
-      nil ->
-        {:noreply, socket}
-
-      fresh ->
-        {:noreply, insert_one(socket, fresh, at: 0)}
-    end
+    {:noreply, insert_one(socket, fresh, at: 0)}
   end
 
   def handle_info(_message, socket), do: {:noreply, socket}
@@ -288,7 +282,7 @@ defmodule AbuubaWeb.HomeLive do
       status ->
         Statuses.unmute_thread(account, status)
 
-        {:noreply, insert_one(socket, Statuses.get_status(status.id, account))}
+        {:noreply, insert_one(socket, Statuses.readable(status.id, account))}
     end
   end
 
@@ -392,7 +386,13 @@ defmodule AbuubaWeb.HomeLive do
   # a live arrival without naming the context meant the same post was filtered
   # on reload and not while somebody watched, which reads as the filter being
   # unreliable rather than as two code paths disagreeing.
-  defp insert_one(socket, status, opts \\ []) do
+  defp insert_one(socket, status, opts \\ [])
+
+  # The read that fed this may have answered nothing: the post was deleted, or
+  # the reader has since blocked or muted whoever wrote it.
+  defp insert_one(socket, nil, _opts), do: socket
+
+  defp insert_one(socket, status, opts) do
     case render_all([status], socket.assigns.account) do
       [rendered] -> stream_insert(socket, :statuses, rendered, opts)
       # Hidden by one of the reader's own rules. Nothing to insert, and
@@ -407,12 +407,16 @@ defmodule AbuubaWeb.HomeLive do
   defp newest_id([]), do: nil
   defp newest_id(statuses), do: statuses |> Enum.map(& &1.id) |> Enum.max()
 
+  # `readable/2`, the same door the timeline itself came through: every id here
+  # names a post already drawn on this screen. Unmuting a thread still finds
+  # its post, because a muted thread is the one rule `readable/2` leaves out.
+  #
   # Through the id type rather than a lenient parse. `to_integer/1` happily
   # answers with a number too large for a bigint column, which reaches Postgres
   # as an encode error rather than as a post that is not there.
   defp status_by_id(id, viewer) do
     case Snowflake.cast(id) do
-      {:ok, id} -> Statuses.get_status(id, viewer)
+      {:ok, id} -> Statuses.readable(id, viewer)
       :error -> nil
     end
   end

--- a/lib/abuuba_web/live/post_actions.ex
+++ b/lib/abuuba_web/live/post_actions.ex
@@ -82,7 +82,7 @@ defmodule AbuubaWeb.PostActions do
 
         # Re-read rather than returning what the write handed back: the
         # counters live on another row, and the caller is about to draw them.
-        {:ok, Statuses.get_status(status.id, viewer)}
+        {:ok, Statuses.actionable(status.id, viewer)}
     end
   end
 
@@ -106,9 +106,13 @@ defmodule AbuubaWeb.PostActions do
   def vote(viewer, poll_id, choices)
 
   def vote(%Account{} = viewer, poll_id, choices) when is_list(choices) do
+    # Through the post rather than the poll alone: a poll is reachable exactly
+    # when the post carrying it is, and asking the poll separately would be a
+    # second set of rules to keep in step with the first.
     with %Poll{} = poll <- Statuses.fetch_poll(poll_id),
+         %Status{} = status <- Statuses.readable(poll.status_id, viewer),
          {:ok, _voted} <- Statuses.vote(poll, viewer, to_indexes(choices)) do
-      {:ok, Statuses.get_status(poll.status_id, viewer)}
+      {:ok, Statuses.readable(status.id, viewer)}
     else
       _refused -> :error
     end
@@ -269,8 +273,11 @@ defmodule AbuubaWeb.PostActions do
   def own?(%Status{account_id: account_id}, %Account{id: account_id}), do: true
   def own?(_status, _viewer), do: false
 
-  # `get_status/2` is what applies the viewer's own visibility, so a post
-  # somebody cannot see answers nil here rather than being acted on.
+  # `actionable/2`: readable, or a post this reader has already marked. The
+  # bookmarks and favourites screens list what somebody saved whatever they
+  # have done about the author since, so the button drawn over a row has to
+  # reach it -- and nothing else does, so a made-up id cannot favourite a post
+  # from an account that blocked them and draw it into their timeline.
   #
   # `Snowflake.cast/1` rather than `Integer.parse/1`, which reads a number too
   # big for the column and hands it to Ecto, where it is a cast error that
@@ -278,7 +285,7 @@ defmodule AbuubaWeb.PostActions do
   # so one id nobody could have meant emptied the page.
   defp find(viewer, id) do
     case Snowflake.cast(id) do
-      {:ok, number} -> Statuses.get_status(number, viewer)
+      {:ok, number} -> Statuses.actionable(number, viewer)
       :error -> nil
     end
   end

--- a/lib/abuuba_web/live/status_live.ex
+++ b/lib/abuuba_web/live/status_live.ex
@@ -46,7 +46,6 @@ defmodule AbuubaWeb.StatusLive do
     viewer = current_account(socket)
 
     with %{} = author <- Accounts.lookup(username),
-         false <- blocked?(author, viewer),
          %{} = status <- own_status(author, id, viewer) do
       {:ok, socket |> assign(author: author, status: status, viewer: viewer) |> load_thread()}
     else
@@ -331,13 +330,14 @@ defmodule AbuubaWeb.StatusLive do
     text |> to_string() |> String.replace(~r/\s+/u, " ") |> String.trim()
   end
 
-  # Under this author, and visible to whoever is asking. Both checks are the
+  # Under this author, and readable by whoever is asking. Both checks are the
   # query's rather than an afterthought: one that cannot return the wrong row
-  # cannot leak one.
+  # cannot leak one. That covers the author having blocked this reader too,
+  # which the page used to ask separately.
   defp own_status(author, id, viewer) do
     with {number, ""} <- Integer.parse(to_string(id)),
          %{account_id: account_id} = status when account_id == author.id <-
-           Statuses.get_status(number, viewer) do
+           Statuses.readable(number, viewer) do
       status
     else
       _ -> nil
@@ -368,9 +368,11 @@ defmodule AbuubaWeb.StatusLive do
     {:noreply, load_thread(socket)}
   end
 
+  # The same door the page itself came through: every id here names a post
+  # already drawn in this thread.
   defp find(socket, id) do
     case Integer.parse(to_string(id)) do
-      {number, ""} -> Statuses.get_status(number, socket.assigns.viewer)
+      {number, ""} -> Statuses.readable(number, socket.assigns.viewer)
       _ -> nil
     end
   end
@@ -380,9 +382,4 @@ defmodule AbuubaWeb.StatusLive do
 
     socket
   end
-
-  # Somebody who blocked you is not showing you their posts, and the page is
-  # the one place where a direct link would otherwise walk around that.
-  defp blocked?(_author, nil), do: false
-  defp blocked?(author, viewer), do: Abuuba.Relationships.blocking?(author, viewer)
 end

--- a/lib/abuuba_web/streaming/filter.ex
+++ b/lib/abuuba_web/streaming/filter.ex
@@ -178,10 +178,8 @@ defmodule AbuubaWeb.Streaming.Filter do
   # socket sees public posts and nothing else.
   defp visible?(%Status{} = status, %{account: nil}), do: status.visibility == :public
 
-  defp visible?(%Status{} = status, %{account: account}) do
-    Statuses.get_status(status.id, account) != nil and
-      not Statuses.hidden_for?(status, account)
-  end
+  defp visible?(%Status{} = status, %{account: account}),
+    do: Statuses.readable?(status, account)
 
   defp subscribed?(state, stream) do
     Enum.any?(state.topics, fn {name, _topic} -> name == stream end)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.0",
+      version: "1.0.1",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba/statuses_test.exs
+++ b/test/abuuba/statuses_test.exs
@@ -371,6 +371,123 @@ defmodule Abuuba.StatusesTest do
     end
   end
 
+  describe "readable/2, the door a reader comes through" do
+    setup do
+      author = account_fixture()
+      reader = account_fixture()
+
+      %{author: author, reader: reader}
+    end
+
+    test "answers the same audience question get_status/2 does", %{author: author} do
+      public = status_fixture(%{account_id: author.id})
+      secret = status_fixture(%{account_id: author.id, visibility: :direct})
+
+      assert Statuses.readable(public.id, nil)
+      assert Statuses.readable(secret.id, author)
+      refute Statuses.readable(secret.id, nil)
+      refute Statuses.readable(nil, author)
+    end
+
+    test "and the block question get_status/2 does not", %{author: author, reader: reader} do
+      status = status_fixture(%{account_id: author.id})
+      {:ok, _} = Relationships.block(author, reader)
+
+      assert Statuses.get_status(status.id, reader), "the audience gate lets it through"
+      refute Statuses.readable(status.id, reader)
+    end
+
+    test "a boost of somebody who blocked the reader is refused too", %{
+      author: author,
+      reader: reader
+    } do
+      original = status_fixture(%{account_id: author.id})
+      booster = account_fixture()
+      {:ok, boost} = Statuses.boost(booster, original)
+      {:ok, _} = Relationships.block(author, reader)
+
+      refute Statuses.readable(boost.id, reader),
+             "a third party passing the words along does not undo the block"
+    end
+
+    test "the reader's own blocks and mutes do not close a link they followed", %{
+      author: author,
+      reader: reader
+    } do
+      # "The one place you still see them is their own profile, if you go and
+      # look" -- docs/user/safety.md. A profile that lists a post whose link
+      # answers nothing breaks that promise, and a mute is the softer tool
+      # still. All three say what may be delivered, not what may be opened.
+      blocked = status_fixture(%{account_id: author.id})
+      {:ok, _} = Relationships.block(reader, author)
+
+      muted_author = account_fixture()
+      muted = status_fixture(%{account_id: muted_author.id})
+      {:ok, _} = Relationships.mute(reader, muted_author)
+
+      elsewhere = remote_account_fixture()
+      abroad = status_fixture(%{account_id: elsewhere.id})
+      {:ok, _} = Relationships.block_domain(reader, elsewhere.domain)
+
+      conversation = conversation_fixture()
+      thread = status_fixture(%{account_id: author.id, conversation_id: conversation.id})
+      {:ok, _} = Statuses.mute_thread(reader, thread)
+
+      for status <- [blocked, muted, abroad, thread] do
+        assert Statuses.readable(status.id, reader)
+        refute Statuses.readable?(status, reader), "and none of them is delivered"
+      end
+    end
+
+    test "readable?/2 refuses what the audience refuses", %{author: author, reader: reader} do
+      secret = status_fixture(%{account_id: author.id, visibility: :direct})
+
+      refute Statuses.readable?(secret, reader)
+      refute Statuses.readable?(secret, nil)
+      assert Statuses.readable?(secret, author)
+    end
+
+    test "readable_many/2 keeps the caller's order and drops what is refused", %{
+      author: author,
+      reader: reader
+    } do
+      first = status_fixture(%{account_id: author.id})
+      refuser = account_fixture()
+      refused = status_fixture(%{account_id: refuser.id})
+      last = status_fixture(%{account_id: author.id})
+      {:ok, _} = Relationships.block(refuser, reader)
+
+      ids = [last.id, refused.id, first.id]
+
+      assert Enum.map(Statuses.readable_many(ids, reader), & &1.id) == [last.id, first.id]
+      assert Statuses.readable_many([], reader) == []
+    end
+
+    test "actionable/2 reaches a mark the reader made before hiding the author", %{
+      author: author,
+      reader: reader
+    } do
+      status = status_fixture(%{account_id: author.id})
+      {:ok, _} = Statuses.bookmark(reader, status)
+      {:ok, _} = Relationships.block(author, reader)
+
+      refute Statuses.readable(status.id, reader), "no longer theirs to read"
+
+      assert Statuses.actionable(status.id, reader),
+             "but the bookmarks list still returns it, and the button has to work"
+    end
+
+    test "actionable/2 is not a way past a block for a post nobody marked", %{
+      author: author,
+      reader: reader
+    } do
+      status = status_fixture(%{account_id: author.id})
+      {:ok, _} = Relationships.block(author, reader)
+
+      refute Statuses.actionable(status.id, reader)
+    end
+  end
+
   describe "the public timeline" do
     test "shows public posts newest first" do
       first = status_fixture()

--- a/test/abuuba_web/api/status_controller_test.exs
+++ b/test/abuuba_web/api/status_controller_test.exs
@@ -8,6 +8,7 @@ defmodule AbuubaWeb.API.StatusControllerTest do
   alias Abuuba.Media
   alias Abuuba.Media.Attachment
   alias Abuuba.OAuth
+  alias Abuuba.Relationships
   alias Abuuba.Repo
   alias Abuuba.Statuses
   alias Abuuba.Statuses.ScheduledStatus
@@ -746,6 +747,76 @@ defmodule AbuubaWeb.API.StatusControllerTest do
 
       assert json_response(get(stranger, "/api/v1/statuses/#{private.id}"), 404)["error"]
     end
+
+    test "nor is a public one, once its author has blocked them", %{
+      account: account,
+      status: status,
+      application: application
+    } do
+      blocked = account_fixture()
+      {:ok, _} = Relationships.block(account, blocked)
+      conn = token_for(application, blocked)
+
+      assert json_response(get(conn, "/api/v1/statuses/#{status.id}"), 404)["error"]
+
+      for path <- ~w(context history reblogged_by favourited_by quotes) do
+        assert json_response(get(conn, "/api/v1/statuses/#{status.id}/#{path}"), 404)["error"],
+               "#{path} is a way of reading the same post"
+      end
+
+      assert json_response(post(conn, "/api/v1/statuses/#{status.id}/translate"), 404)["error"],
+             "and so is asking for it in another language"
+    end
+
+    test "and neither does putting a mark on it", %{
+      account: account,
+      status: status,
+      application: application
+    } do
+      # Being shown the post is what these do, so they come through the same
+      # door. The reference implementation refuses all five in the same place.
+      blocked = account_fixture()
+      {:ok, _} = Relationships.block(account, blocked)
+      conn = token_for(application, blocked)
+
+      for action <- ~w(favourite bookmark reblog mute pin) do
+        assert json_response(post(conn, "/api/v1/statuses/#{status.id}/#{action}"), 404)["error"],
+               "#{action} handed back the body of a post its author refused them"
+      end
+    end
+
+    test "a reader's own block does not close the link they followed", %{
+      status: status,
+      account: account,
+      application: application
+    } do
+      # The other direction, and deliberately not symmetrical: "the one place
+      # you still see them is their own profile, if you go and look".
+      reader = account_fixture()
+      {:ok, _} = Relationships.block(reader, account)
+      conn = token_for(application, reader)
+
+      assert json_response(get(conn, "/api/v1/statuses/#{status.id}"), 200)["content"]
+    end
+
+    test "and the batch drops it rather than answering it", %{
+      account: account,
+      status: status,
+      application: application
+    } do
+      blocked = account_fixture()
+      mine = status_fixture(%{account_id: blocked.id})
+      {:ok, _} = Relationships.block(account, blocked)
+      conn = token_for(application, blocked)
+
+      body =
+        json_response(
+          get(conn, "/api/v1/statuses", %{"id" => [to_string(status.id), to_string(mine.id)]}),
+          200
+        )
+
+      assert Enum.map(body, & &1["id"]) == [to_string(mine.id)]
+    end
   end
 
   describe "editing and deleting" do
@@ -991,6 +1062,32 @@ defmodule AbuubaWeb.API.StatusControllerTest do
       refute json_response(post(conn, "/api/v1/statuses/#{status.id}/unmute"), 200)["muted"]
     end
 
+    test "and the mark still comes off a post whose author has since blocked them", %{
+      conn: conn,
+      status: status,
+      account: account,
+      author: author
+    } do
+      # `/bookmarks` lists what somebody saved whatever has happened since, so
+      # taking a mark back reads through `Statuses.actionable/2` rather than
+      # `readable/2`. A sweep moving it would leave the button in every client
+      # doing nothing, with a green suite.
+      assert json_response(post(conn, "/api/v1/statuses/#{status.id}/bookmark"), 200)[
+               "bookmarked"
+             ]
+
+      {:ok, _} = Relationships.block(author, account)
+
+      assert Enum.any?(Statuses.bookmarks(account), &(&1.status.id == status.id))
+
+      refute json_response(post(conn, "/api/v1/statuses/#{status.id}/unbookmark"), 200)[
+               "bookmarked"
+             ]
+
+      assert json_response(get(conn, "/api/v1/statuses/#{status.id}"), 404)["error"],
+             "reading it is still refused"
+    end
+
     test "every un-action is a POST, because that is what clients send", %{
       conn: conn,
       status: status
@@ -1063,6 +1160,24 @@ defmodule AbuubaWeb.API.StatusControllerTest do
 
       assert body["own_votes"] == [0]
       assert body["voters_count"] == 1
+    end
+
+    test "neither, once the author has blocked the reader", %{
+      conn: conn,
+      poll: poll,
+      author: author,
+      voter: voter
+    } do
+      # The poll is reachable exactly when its status is, and the status is now
+      # not: a block reaches the poll form the same way it reaches the words.
+      {:ok, _} = Relationships.block(author, voter)
+
+      assert json_response(get(conn, "/api/v1/polls/#{poll.id}"), 404)["error"]
+
+      assert json_response(
+               post(conn, "/api/v1/polls/#{poll.id}/votes", %{"choices" => ["0"]}),
+               404
+             )["error"]
     end
 
     test "voting twice is refused with a message a client can show", %{conn: conn, poll: poll} do

--- a/test/abuuba_web/reader_rules_test.exs
+++ b/test/abuuba_web/reader_rules_test.exs
@@ -109,6 +109,42 @@ defmodule AbuubaWeb.ReaderRulesTest do
     end
   end
 
+  describe "a link straight to the post, which is not a surface" do
+    # Deliberately not in `surfaces/0`. A timeline is what reaches a reader and
+    # a permalink is what they went and opened, so the two answer differently
+    # -- `Statuses.readable/2` asks the author's side of a block and
+    # `readable?/2` asks the reader's as well. Kept here because the asymmetry
+    # is the thing somebody will otherwise "fix" into a leak or a dead link.
+    defp permalink(stranger, status), do: "/@#{stranger.username}/#{status.id}"
+
+    test "opens for a reader who blocked or muted the author", %{
+      conn: conn,
+      reader: reader,
+      stranger: stranger,
+      status: status
+    } do
+      # The profile still lists these posts, and the user guide promises it.
+      # A row whose link answers nothing would break that promise.
+      {:ok, _} = Relationships.block(reader, stranger)
+      {:ok, _} = Relationships.mute(reader, stranger)
+
+      {:ok, _live, html} = live(conn, permalink(stranger, status))
+
+      assert html =~ "loud opinion"
+    end
+
+    test "and answers nothing to a reader the author blocked", %{
+      conn: conn,
+      reader: reader,
+      stranger: stranger,
+      status: status
+    } do
+      {:ok, _} = Relationships.block(stranger, reader)
+
+      assert_raise AbuubaWeb.NotFound, fn -> live(conn, permalink(stranger, status)) end
+    end
+  end
+
   describe "a stranger reading the same pages" do
     test "still sees it, blocks being nobody else's business", %{conn: conn} do
       stranger_conn = Phoenix.ConnTest.build_conn()


### PR DESCRIPTION
`Statuses.readable/2` and `readable_many/2` ask the audience and the author's
block in one query, and every reading caller is on them: `GET /statuses/:id`,
the batch, `/context`, `/history`, `/translate`, `/quotes`, `/reblogged_by`,
`/favourited_by`, `/polls/:id`, the embed, the oEmbed, the media redirect,
annual reports, the post page and the two home-timeline inserts.

**One deviation from the issue.** It asked for `get_status/2` plus
`hidden_for?/2`. That closes more than it should: the profile deliberately
lists what an account the reader blocked wrote, and `docs/user/safety.md`
promises it ("the one place you still see them is their own profile"), so
applying the reader's own blocks and mutes to a permalink leaves every row on
that profile a dead link. It also turns a mute into a block for direct fetches
and diverges from the reference on eight endpoints. So the reader's side lives
in `readable?/2`, which streaming calls — one round trip per post per socket
instead of three.

`actionable/2` is the third answer, for taking a mark back off: `/bookmarks`
returns what somebody saved whatever has happened since. Putting one on
(favourite, bookmark, reblog, mute, pin) is being shown the post and goes
through `readable/2` — those five were answering 200 with the full body to a
reader the author had blocked.

Closes #5

An AI agent wrote this text in my name. I know that is problematic.
