### PR TITLE
Ask the reader's rules when notifications are read

### DIFF
--- a/lib/abuuba/notifications.ex
+++ b/lib/abuuba/notifications.ex
@@ -10,6 +10,19 @@ defmodule Abuuba.Notifications do
   relationships change: somebody would accept a request, then see the same
   mention reappear as a request a week later because a follow lapsed.
 
+  ## Who it is from, decided on the way out
+
+  *Which* list is a write-time question; whether the reader wants to hear from
+  this person at all is not. `decide/4` runs once, against the relationships as
+  they stood that second, so blocking somebody afterwards left every favourite
+  they had ever made sitting in the tab with the badge counting them --
+  nothing here ever asked again.
+
+  So `excluding_unwanted/2` is composed by every read: the list, the grouped
+  list, one group, one notification, and all three counts. A badge that
+  disagrees with the list under it is the same bug wearing a different number,
+  and the counts are the half nobody remembers.
+
   ## Grouping
 
   Twenty people boosting one post is one thing that happened and a client shows
@@ -31,6 +44,9 @@ defmodule Abuuba.Notifications do
   alias Abuuba.Notifications.Request
   alias Abuuba.Pagination
   alias Abuuba.Relationships
+  alias Abuuba.Relationships.Block
+  alias Abuuba.Relationships.DomainBlock
+  alias Abuuba.Relationships.Mute
   alias Abuuba.Repo
   alias Abuuba.Statuses.Status
   alias Abuuba.Streaming
@@ -363,29 +379,129 @@ defmodule Abuuba.Notifications do
   def list(account_id, page) do
     from(n in Notification, as: :notification)
     |> where([n], n.account_id == ^account_id)
-    |> exclude_deleted_posts()
+    |> excluding_unwanted(account_id)
     |> filter_state(page)
     |> filter_sender(page)
     |> filter_types(page)
     |> paginate(page)
   end
 
-  # A notification whose post has gone points at nothing a reader can open.
-  # The removals on the undo paths take most of these away as they happen;
-  # this is the backstop, because a post can also be deleted by a moderator,
-  # by its own server, or by a path nobody has written yet, and a list that
-  # filters is what catches whatever they miss.
-  defp exclude_deleted_posts(query) do
-    where(
-      query,
+  # Two shapes, because the four rules are not alike.
+  #
+  # Blocks and mutes are the reader's own rows, so "everybody I will not hear
+  # from" is a set bounded by how many people *they* have shut out -- a handful
+  # for almost everyone. Postgres hashes it once per query and probes it per
+  # row, which beats three correlated lookups per row on a query that runs on
+  # every signed-in page render.
+  #
+  # `NOT IN` is safe here only because both columns are `NOT NULL`: a single
+  # NULL in the set would make the whole predicate answer NULL and hide every
+  # notification. That is checked by the schema, not by luck.
+  defp silenced_ids(account_id) do
+    now = DateTime.utc_now()
+
+    blocked = from(b in Block, where: b.account_id == ^account_id, select: b.target_account_id)
+
+    blocking = from(b in Block, where: b.target_account_id == ^account_id, select: b.account_id)
+
+    # `hide_notifications` is why this is not the timeline's mute rule. A mute
+    # that left notifications on is somebody saying "off my timeline, still
+    # tell me", and the write side honours that -- so read time has to as
+    # well, or the flag means nothing the moment anybody reloads.
+    muted =
+      from(m in Mute,
+        where:
+          m.account_id == ^account_id and m.hide_notifications and
+            (is_nil(m.expires_at) or m.expires_at > ^now),
+        select: m.target_account_id
+      )
+
+    blocked |> union_all(^blocking) |> union_all(^muted)
+  end
+
+  # The domain rule is the exception, and stays correlated. Written as a set it
+  # would be every account on the blocked server: one domain block against a
+  # large instance turned this into a sequential scan of `accounts` per
+  # notification on the benchmark database -- 145 million buffer hits for a
+  # badge. Asked per row it is one primary-key probe.
+  defmacrop on_a_blocked_server(account_id, subject) do
+    quote do
+      from(a in Account,
+        join: d in DomainBlock,
+        on: d.domain == a.domain and d.account_id == ^unquote(account_id),
+        where: a.id == unquote(subject),
+        select: 1
+      )
+    end
+  end
+
+  @doc """
+  Drops what this reader has since said they do not want.
+
+  One rule asked of everybody a notification implicates: the sender, the
+  author of the post it points at, and the author of whatever that post is
+  carrying if it is a boost. That last one is the half the write side never
+  had -- it asked about the sender and stopped, so a mention inside somebody
+  else's boost of a blocked account arrived with the blocked account's words
+  in it.
+
+  The rule is `Relationships.notifications_silenced?/2`'s, not its call: that
+  one answers about a pair in three round trips and cannot compose into a
+  query. Same four questions, `hide_notifications` included, plus a block in
+  either direction rather than only the reader's own.
+
+  A deleted post is dropped on the way past, because a notification pointing
+  at one points at nothing a reader can open. The undo paths take most of
+  those away as they happen; this is the backstop for a moderator's removal or
+  a path nobody has written yet.
+
+  Correlated `EXISTS` rather than `NOT IN` over a set of ids: one domain block
+  against a large server makes that set every account on it, and this runs on
+  every page a signed-in reader loads. Needs the `:notification` binding.
+  """
+  @spec excluding_unwanted(Ecto.Query.t(), Account.t() | integer() | nil) :: Ecto.Query.t()
+  def excluding_unwanted(query, nil), do: query
+
+  def excluding_unwanted(query, %Account{id: id}), do: excluding_unwanted(query, id)
+
+  def excluding_unwanted(query, account_id) do
+    silenced = silenced_ids(account_id)
+
+    query
+    |> where([n], n.from_account_id not in subquery(silenced))
+    |> where(
       [n],
-      is_nil(n.status_id) or
-        exists(
-          from(s in Status,
-            where: s.id == parent_as(:notification).status_id and is_nil(s.deleted_at),
-            select: 1
-          )
-        )
+      not exists(on_a_blocked_server(account_id, parent_as(:notification).from_account_id))
+    )
+    |> where([n], is_nil(n.status_id) or exists(wanted_post(account_id, silenced)))
+  end
+
+  # The post's author, and the author of what it repeats if it is a boost. On
+  # every type this server writes the author is the sender or the reader, so
+  # the sender clauses have answered already -- but a notification is a row
+  # anything can write, and an invariant nothing enforces is not a check.
+  #
+  # A block is about the person whose words these are, not about who passed
+  # them along, which is why the carried author is asked separately.
+  defp wanted_post(account_id, silenced) do
+    from(s in Status,
+      as: :post,
+      where: s.id == parent_as(:notification).status_id and is_nil(s.deleted_at),
+      where: s.account_id not in subquery(silenced),
+      where: not exists(on_a_blocked_server(account_id, parent_as(:post).account_id)),
+      where: is_nil(s.reblog_of_id) or not exists(silenced_carried_author(account_id, silenced)),
+      select: 1
+    )
+  end
+
+  defp silenced_carried_author(account_id, silenced) do
+    from(carried in Status,
+      as: :carried,
+      where: carried.id == parent_as(:post).reblog_of_id,
+      where:
+        carried.account_id in subquery(silenced) or
+          exists(on_a_blocked_server(account_id, parent_as(:carried).account_id)),
+      select: 1
     )
   end
 
@@ -438,22 +554,26 @@ defmodule Abuuba.Notifications do
   def group(%Account{id: id}, key, opts), do: group(id, key, opts)
 
   def group(account_id, key, opts) do
-    Notification
+    from(n in Notification, as: :notification)
     |> where([n], n.account_id == ^account_id and n.group_key == ^key)
+    |> excluding_unwanted(account_id)
     |> order_by([n], desc: n.id)
     |> limit(^Keyword.get(opts, :limit, @group_cap))
     |> Repo.all()
   end
 
   @doc """
-  One notification, if it is this account's.
+  One notification, if it is this account's and they still want it.
   """
   @spec get(Account.t() | integer(), integer() | nil) :: Notification.t() | nil
   def get(%Account{id: id}, notification_id), do: get(id, notification_id)
   def get(_account_id, nil), do: nil
 
   def get(account_id, notification_id) do
-    Repo.get_by(Notification, id: notification_id, account_id: account_id)
+    from(n in Notification, as: :notification)
+    |> where([n], n.id == ^notification_id and n.account_id == ^account_id)
+    |> excluding_unwanted(account_id)
+    |> Repo.one()
   end
 
   @doc """
@@ -518,7 +638,9 @@ defmodule Abuuba.Notifications do
   end
 
   defp unread_scope(account_id) do
-    where(Notification, [n], n.account_id == ^account_id and not n.filtered)
+    from(n in Notification, as: :notification)
+    |> where([n], n.account_id == ^account_id and not n.filtered)
+    |> excluding_unwanted(account_id)
   end
 
   # The cap lives in the query, so counting stops at a thousand rather than

--- a/lib/abuuba/web_push.ex
+++ b/lib/abuuba/web_push.ex
@@ -25,6 +25,7 @@ defmodule Abuuba.WebPush do
   alias Abuuba.OAuth.AccessToken
   alias Abuuba.Relationships
   alias Abuuba.Repo
+  alias Abuuba.Statuses
   alias Abuuba.Statuses.Formatter
   alias Abuuba.WebPush.Subscription
 
@@ -215,8 +216,13 @@ defmodule Abuuba.WebPush do
   # post. Whoever taps it gets the whole thing from the API.
   defp body(%Notification{status_id: nil}), do: ""
 
-  defp body(%Notification{status_id: status_id}) do
-    case Repo.get(Abuuba.Statuses.Status, status_id) do
+  defp body(%Notification{status_id: status_id, account_id: account_id}) do
+    # Through `Statuses` and with the reader named, which a bare `Repo.get`
+    # was neither: a push is the one copy of a post that arrives somewhere the
+    # reader cannot be shown a filtered list, so a post they may no longer read
+    # -- deleted, or from somebody they have since blocked -- must not be the
+    # thing on their lock screen.
+    case Statuses.readable(status_id, account_id) do
       nil ->
         ""
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.1",
+      version: "1.0.2",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba/notifications_test.exs
+++ b/test/abuuba/notifications_test.exs
@@ -85,6 +85,130 @@ defmodule Abuuba.NotificationsTest do
     end
   end
 
+  describe "who the reader stopped wanting to hear from afterwards" do
+    # The write-time check above runs once, against the relationships as they
+    # stood that second. Everything below is decided later, and the list never
+    # asked again -- so blocking somebody left every favourite they had ever
+    # made sitting in the notifications tab, with the badge counting them.
+    setup %{reader: reader, sender: sender} do
+      {:ok, notification} = Notifications.notify(reader, sender, "favourite")
+
+      %{notification: notification}
+    end
+
+    defp visible(reader) do
+      {Enum.map(Notifications.list(reader), & &1.id), Notifications.unread_badge(reader.id),
+       Notifications.unread_count(reader), Notifications.unread_group_count(reader),
+       length(Notifications.grouped(reader))}
+    end
+
+    test "a block made afterwards takes it off the list and out of the counts", %{
+      reader: reader,
+      sender: sender,
+      notification: notification
+    } do
+      assert {[id], 1, 1, 1, 1} = visible(reader)
+      assert id == notification.id
+
+      {:ok, _} = Relationships.block(reader, sender)
+
+      assert visible(reader) == {[], 0, 0, 0, 0},
+             "the list and every count that feeds a badge answer together"
+    end
+
+    test "and unblocking brings it back, nothing having been deleted", %{
+      reader: reader,
+      sender: sender
+    } do
+      {:ok, _} = Relationships.block(reader, sender)
+      :ok = Relationships.unblock(reader, sender)
+
+      assert {[_id], 1, 1, 1, 1} = visible(reader)
+    end
+
+    test "a block the sender made counts too", %{reader: reader, sender: sender} do
+      # The half the reader cannot make themselves, and the one the write-time
+      # check never asked about at all.
+      {:ok, _} = Relationships.block(sender, reader)
+
+      assert visible(reader) == {[], 0, 0, 0, 0}
+    end
+
+    test "so does shutting out their whole server", %{reader: reader} do
+      elsewhere = remote_account_fixture(%{domain: "loud.example"})
+      {:ok, _} = Notifications.notify(reader, elsewhere, "follow")
+      {:ok, _} = Relationships.block_domain(reader, "loud.example")
+
+      refute Enum.any?(Notifications.list(reader), &(&1.from_account_id == elsewhere.id))
+    end
+
+    test "a mute hides it only if it was asked to", %{reader: reader, sender: sender} do
+      # `hide_notifications` is why the two questions are not the same one. A
+      # mute that left notifications on is somebody saying "off my timeline,
+      # still tell me", and read time has to honour that as write time does.
+      {:ok, _} = Relationships.mute(reader, sender, %{hide_notifications: false})
+
+      assert {[_id], 1, 1, 1, 1} = visible(reader)
+
+      :ok = Relationships.unmute(reader, sender)
+      {:ok, _} = Relationships.mute(reader, sender, %{hide_notifications: true})
+
+      assert visible(reader) == {[], 0, 0, 0, 0}
+    end
+
+    test "and that holds for one carrying a post, not only a bare favourite", %{
+      reader: reader,
+      sender: sender,
+      notification: notification
+    } do
+      # The half that made the rule easy to get wrong: the sender is asked
+      # about on every notification, the post only on the ones that have one.
+      # Filtering the post with the timeline's rule instead of this one hid a
+      # mention while leaving the favourite beside it, from the same person.
+      status = status_fixture(%{account_id: sender.id})
+      {:ok, mention} = Notifications.notify(reader, sender, "mention", status_id: status.id)
+
+      {:ok, _} = Relationships.mute(reader, sender, %{hide_notifications: false})
+
+      assert Enum.sort(elem(visible(reader), 0)) == Enum.sort([notification.id, mention.id])
+    end
+
+    test "a post the reader may no longer read takes its notification with it", %{
+      reader: reader,
+      sender: sender
+    } do
+      author = account_fixture()
+      status = status_fixture(%{account_id: author.id})
+      {:ok, mention} = Notifications.notify(reader, sender, "mention", status_id: status.id)
+
+      assert mention.id in elem(visible(reader), 0)
+
+      {:ok, _} = Relationships.block(author, reader)
+
+      refute mention.id in elem(visible(reader), 0)
+    end
+
+    test "including one carried inside somebody else's boost", %{
+      reader: reader,
+      sender: sender
+    } do
+      # The third gap: the check asked about the sender and never about whose
+      # words the post actually holds. A boost is somebody passing them along.
+      author = account_fixture()
+      original = status_fixture(%{account_id: author.id})
+      {:ok, boost} = Abuuba.Statuses.boost(sender, original)
+
+      {:ok, mention} = Notifications.notify(reader, sender, "mention", status_id: boost.id)
+
+      assert mention.id in elem(visible(reader), 0)
+
+      {:ok, _} = Relationships.block(reader, author)
+
+      refute mention.id in elem(visible(reader), 0),
+             "a third party passing the words along does not undo the block"
+    end
+  end
+
   describe "grouping" do
     test "puts everybody boosting one post on one line", %{reader: reader} do
       status = status_fixture(%{account_id: reader.id})

--- a/test/abuuba/web_push_test.exs
+++ b/test/abuuba/web_push_test.exs
@@ -6,6 +6,7 @@ defmodule Abuuba.WebPushTest do
 
   alias Abuuba.Notifications
   alias Abuuba.OAuth
+  alias Abuuba.Relationships
   alias Abuuba.WebPush
   alias Abuuba.WebPush.Encryption
   alias Abuuba.WebPush.Subscription
@@ -392,6 +393,34 @@ defmodule Abuuba.WebPushTest do
       payload = WebPush.payload(notification, subscription, "token")
 
       assert String.length(payload["body"]) == WebPush.body_limit()
+    end
+
+    test "carries no words from a post the reader may no longer read", %{
+      account: account,
+      subscription: subscription
+    } do
+      # A push is the one copy that arrives somewhere the reader cannot be
+      # shown a filtered list, so it is the last place a bare `Repo.get` on
+      # `statuses` belongs -- whatever is in the payload is on a lock screen.
+      sender = account_fixture()
+      status = status_fixture(%{account_id: sender.id, text: "words from a blocker"})
+      {:ok, notification} = Notifications.notify(account, sender, "mention", status_id: status.id)
+
+      assert WebPush.payload(notification, subscription, "t")["body"] == "words from a blocker"
+
+      {:ok, _} = Relationships.block(sender, account)
+
+      assert WebPush.payload(notification, subscription, "t")["body"] == ""
+    end
+
+    test "nor from one that has been deleted", %{account: account, subscription: subscription} do
+      sender = account_fixture()
+      status = status_fixture(%{account_id: sender.id, text: "taken back"})
+      {:ok, notification} = Notifications.notify(account, sender, "mention", status_id: status.id)
+
+      {:ok, _} = Abuuba.Statuses.delete_status(status)
+
+      assert WebPush.payload(notification, subscription, "t")["body"] == ""
     end
 
     test "falls back to a username where somebody set no display name", %{


### PR DESCRIPTION
`Notifications.excluding_unwanted/2` is composed by every read: the list, the
grouped list, one group, one notification, and all three counts. Filtering the
list alone would leave the badge counting what the list no longer shows, which
is the same bug wearing a different number.

It adds the two halves the write side never had — a block in either direction,
and the author of whatever a boosted post carries. `hide_notifications` stays
as the mute rule, deliberately: a mute that left notifications on is somebody
saying "off my timeline, still tell me", and `decide/4` honours that, so read
time has to as well or the flag means nothing after a reload. That is one of
the three differences the issue lists; the other two are fixed.

`web_push.ex` now reads through `Statuses.readable/2`. A push is the one copy
that lands somewhere the reader cannot be shown a filtered list.

**Cost, measured.** This runs on every signed-in page render, so the shape
matters. Against the benchmark database with 1,000 unread:

| shape | buffers | time |
| --- | --- | --- |
| `main`, no filter | 14 | 0.06 ms |
| one set of silenced ids, domain rule included | 145,651,270 | — |
| every rule correlated | 14,710 | 35.8 ms |
| kept: ids hashed once, domain rule correlated | 9,984 | 4.24 ms |

The domain rule cannot be a set: it is every account on the blocked server.

Closes #6

An AI agent wrote this text in my name. I know that is problematic.
