### PR TITLE
Ask who is reading a follower list, rather than hoping the caller said

### DIFF
--- a/lib/abuuba/imports/csv_rows.ex
+++ b/lib/abuuba/imports/csv_rows.ex
@@ -36,7 +36,9 @@ defmodule Abuuba.Imports.CSVRows do
   @spec clear(atom(), map()) :: :ok
   def clear(:following, account) do
     account
-    |> Relationships.following(%{limit: 100_000})
+    # `nil`: an export is somebody's own data, and quietly dropping the people
+    # they muted would make the file disagree with the account it came from.
+    |> Relationships.following(nil, %{limit: 100_000})
     |> Enum.each(&Relationships.unfollow(account, &1))
   end
 

--- a/lib/abuuba/relationships.ex
+++ b/lib/abuuba/relationships.ex
@@ -384,7 +384,7 @@ defmodule Abuuba.Relationships do
     |> join(:inner, [e], a in Account, on: a.id == e.target_account_id)
     |> where([e], e.account_id == ^account_id)
     |> where([_e, a], is_nil(a.suspended_at))
-    |> paginate_by_account(page, :target_account_id)
+    |> paginate_by_account(nil, page, :target_account_id)
   end
 
   @doc """
@@ -913,7 +913,7 @@ defmodule Abuuba.Relationships do
   Who this account has blocked, newest first.
   """
   @spec blocked_accounts(Account.t() | integer(), map()) :: [Account.t()]
-  def blocked_accounts(account, page \\ %{}), do: edge_targets(Block, account, page)
+  def blocked_accounts(account, page \\ %{}), do: edge_targets_query(Block, account, page)
 
   @doc """
   Who this account has muted, newest first. Expired mutes are not mutes.
@@ -986,7 +986,7 @@ defmodule Abuuba.Relationships do
     FollowRequest
     |> join(:inner, [r], a in Account, on: a.id == r.account_id)
     |> where([r], r.target_account_id == ^account_id)
-    |> paginate_by_account(page, :account_id)
+    |> paginate_by_account(nil, page, :account_id)
   end
 
   @doc """
@@ -1027,24 +1027,37 @@ defmodule Abuuba.Relationships do
   end
 
   @doc """
-  This account's followers, newest first.
-  """
-  @spec followers(Account.t() | integer(), map()) :: [Account.t()]
-  def followers(account, page \\ %{})
-  def followers(%Account{id: id}, page), do: followers(id, page)
+  This account's followers, newest first, as `viewer` may see them.
 
-  def followers(account_id, page) do
+  `viewer` is positional and required, the shape `Abuuba.Statuses` uses for
+  every read that answers to somebody. It was an optional key inside the
+  pagination map, which meant the filter was a no-op unless a caller
+  remembered to fill it in: the REST endpoint did, and the profile page
+  showing the same list did not, so blocking somebody hid them from an app
+  and left them in the browser.
+
+  `nil` for a list nobody is reading on their own behalf -- an export, or the
+  federation side, which wants the edges themselves.
+  """
+  @spec followers(Account.t() | integer(), Account.t() | integer() | nil, map()) :: [Account.t()]
+  def followers(account, viewer, page \\ %{})
+  def followers(%Account{id: id}, viewer, page), do: followers(id, viewer, page)
+
+  def followers(account_id, viewer, page) do
     Follow
     |> join(:inner, [f], a in Account, on: a.id == f.account_id)
     |> where([f], f.target_account_id == ^account_id)
-    |> paginate_by_account(page, :account_id)
+    |> paginate_by_account(viewer, page, :account_id)
   end
 
   @doc """
-  Who this account follows, newest first.
+  Who this account follows, newest first, as `viewer` may see them.
+
+  Same shape and the same rule as `followers/3`.
   """
-  @spec following(Account.t() | integer(), map()) :: [Account.t()]
-  def following(account, page \\ %{}), do: edge_targets(Follow, account, page)
+  @spec following(Account.t() | integer(), Account.t() | integer() | nil, map()) :: [Account.t()]
+  def following(account, viewer, page \\ %{}),
+    do: edge_targets(Follow, account, viewer, page)
 
   @doc """
   Removes somebody from this account's followers without blocking them.
@@ -1101,16 +1114,20 @@ defmodule Abuuba.Relationships do
     end)
   end
 
-  defp edge_targets(schema, account, page), do: edge_targets_query(schema, account, page)
+  defp edge_targets(schema, account, viewer, page),
+    do: edge_targets_query(schema, account, viewer, page)
 
-  defp edge_targets_query(schema, %Account{id: id}, page),
-    do: edge_targets_query(schema, id, page)
+  defp edge_targets_query(schema, account, page),
+    do: edge_targets_query(schema, account, nil, page)
 
-  defp edge_targets_query(schema, account_id, page) do
+  defp edge_targets_query(schema, %Account{id: id}, viewer, page),
+    do: edge_targets_query(schema, id, viewer, page)
+
+  defp edge_targets_query(schema, account_id, viewer, page) do
     schema
     |> join(:inner, [e], a in Account, on: a.id == e.target_account_id)
     |> where([e], e.account_id == ^account_id)
-    |> paginate_by_account(page, :target_account_id)
+    |> paginate_by_account(viewer, page, :target_account_id)
   end
 
   # Paged on the account id, because that is the id a client gets back and
@@ -1118,9 +1135,9 @@ defmodule Abuuba.Relationships do
   # table's copy of it — equal to `a.id` by the join, but only the edge
   # column is in the index that serves the scan, and Postgres never pushes an
   # inequality through a join.
-  defp paginate_by_account(query, page, cursor_field) do
+  defp paginate_by_account(query, viewer, page, cursor_field) do
     query
-    |> exclude_hidden_from(Map.get(page, :viewer_id))
+    |> exclude_hidden_from(viewer)
     |> maybe_older_than(Map.get(page, :max_id), cursor_field)
     |> maybe_newer_than(Map.get(page, :min_id) || Map.get(page, :since_id), cursor_field)
     |> order_by([e, _a], [{^Pagination.direction(page), field(e, ^cursor_field)}])
@@ -1131,15 +1148,26 @@ defmodule Abuuba.Relationships do
   end
 
   # A list of people is still a list of people the reader has opinions about,
-  # and somebody they blocked or muted does not belong on it. Optional because
-  # most callers of these lists are not rendering them for anybody -- the
-  # federation side wants the edges themselves.
+  # and somebody they blocked, muted, or shut a whole server out over does not
+  # belong on it. `nil` for a list nobody is reading on their own behalf.
+  #
+  # The domain was missing while the other two were here, which is the shape
+  # this file keeps producing: a rule written down where somebody was looking
+  # and nowhere else.
   defp exclude_hidden_from(query, nil), do: query
+
+  defp exclude_hidden_from(query, %Account{id: viewer_id}),
+    do: exclude_hidden_from(query, viewer_id)
 
   defp exclude_hidden_from(query, viewer_id) do
     query
     |> where([_e, a], a.id not in subquery(edge_targets_of(Block, viewer_id)))
     |> where([_e, a], a.id not in subquery(edge_targets_of(Mute, viewer_id)))
+    |> where([_e, a], is_nil(a.domain) or a.domain not in subquery(blocked_domains_of(viewer_id)))
+  end
+
+  defp blocked_domains_of(account_id) do
+    from(d in DomainBlock, where: d.account_id == ^account_id, select: d.domain)
   end
 
   defp edge_targets_of(schema, account_id) do

--- a/lib/abuuba_web/controllers/api/account_controller.ex
+++ b/lib/abuuba_web/controllers/api/account_controller.ex
@@ -385,11 +385,11 @@ defmodule AbuubaWeb.API.AccountController do
   defp presence(_value), do: nil
 
   def followers(conn, %{"id" => id} = params) do
-    with_collection(conn, id, params, &Relationships.followers/2)
+    with_collection(conn, id, params, &Relationships.followers/3)
   end
 
   def following(conn, %{"id" => id} = params) do
-    with_collection(conn, id, params, &Relationships.following/2)
+    with_collection(conn, id, params, &Relationships.following/3)
   end
 
   # The web profile has honoured `hide_collections` since it was written and
@@ -402,9 +402,7 @@ defmodule AbuubaWeb.API.AccountController do
       if collection_hidden?(account, viewer) do
         json(conn, [])
       else
-        page = params |> Pagination.params() |> Map.put(:viewer_id, viewer && viewer.id)
-
-        collection(conn, viewer, list.(account, page))
+        collection(conn, viewer, list.(account, viewer, Pagination.params(params)))
       end
     end)
   end

--- a/lib/abuuba_web/live/profile_live.ex
+++ b/lib/abuuba_web/live/profile_live.ex
@@ -657,13 +657,15 @@ defmodule AbuubaWeb.ProfileLive do
 
   defp load_people(socket) do
     subject = socket.assigns.subject
+    viewer = socket.assigns.viewer
     hidden? = collections_hidden?(socket, subject)
+    page = %{limit: @page_size}
 
     people =
       cond do
         hidden? -> []
-        socket.assigns.tab == :followers -> Relationships.followers(subject, %{limit: @page_size})
-        socket.assigns.tab == :following -> Relationships.following(subject, %{limit: @page_size})
+        socket.assigns.tab == :followers -> Relationships.followers(subject, viewer, page)
+        socket.assigns.tab == :following -> Relationships.following(subject, viewer, page)
         true -> []
       end
 

--- a/lib/abuuba_web/live/settings_live.ex
+++ b/lib/abuuba_web/live/settings_live.ex
@@ -1745,8 +1745,14 @@ defmodule AbuubaWeb.SettingsLive do
     offered? = section == :privacy and EmailSubscriptions.enabled?()
 
     [
+      # `nil`, not `account`: this is the screen you come to in order to
+      # unfollow somebody, and filtering it by your own mutes would hide the
+      # row with the button on it.
       following:
-        if(section == :follows, do: Relationships.following(account, %{limit: 200}), else: []),
+        if(section == :follows,
+          do: Relationships.following(account, nil, %{limit: 200}),
+          else: []
+        ),
       applications:
         if(section == :applications, do: OAuth.authorized_applications(user), else: []),
       severances: if(section == :strikes, do: Domains.severance_summary(account), else: []),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.5",
+      version: "1.0.6",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba/accounts_api_test.exs
+++ b/test/abuuba/accounts_api_test.exs
@@ -195,8 +195,8 @@ defmodule Abuuba.AccountsAPITest do
     test "your followers and who you follow", %{account: account, other: other} do
       {:ok, _} = Relationships.follow(other, account)
 
-      assert Enum.map(Relationships.followers(account), & &1.id) == [other.id]
-      assert Enum.map(Relationships.following(other), & &1.id) == [account.id]
+      assert Enum.map(Relationships.followers(account, nil), & &1.id) == [other.id]
+      assert Enum.map(Relationships.following(other, nil), & &1.id) == [account.id]
     end
   end
 

--- a/test/abuuba/relationships_test.exs
+++ b/test/abuuba/relationships_test.exs
@@ -34,9 +34,44 @@ defmodule Abuuba.RelationshipsTest do
       [oldest, middle, _newest] = Enum.sort_by(followers, & &1.id)
 
       assert Enum.map(
-               Relationships.followers(alice, %{min_id: oldest.id, limit: 1}),
+               Relationships.followers(alice, nil, %{min_id: oldest.id, limit: 1}),
                & &1.id
              ) == [middle.id]
+    end
+
+    test "a follower list answers to the reader, on every surface", %{alice: alice, bob: bob} do
+      # The viewer used to be an optional key inside the pagination map, so
+      # the filter was a no-op unless a caller remembered to fill it in: the
+      # REST endpoint did and the profile page did not, and blocking somebody
+      # hid them from an app while leaving them in the browser.
+      {:ok, _} = Relationships.follow(bob, alice)
+
+      elsewhere = remote_account_fixture(%{domain: "loud.example"})
+      {:ok, _} = Relationships.follow(elsewhere, alice)
+
+      reader = account_fixture()
+
+      assert length(Relationships.followers(alice, reader)) == 2
+
+      {:ok, _} = Relationships.block(reader, bob)
+      {:ok, _} = Relationships.block_domain(reader, "loud.example")
+
+      assert Relationships.followers(alice, reader) == [],
+             "a block and a blocked server both count, which the domain half did not"
+
+      assert length(Relationships.followers(alice, nil)) == 2,
+             "and a list nobody is reading on their own behalf is untouched"
+    end
+
+    test "so does the list of who somebody follows", %{alice: alice, bob: bob} do
+      {:ok, _} = Relationships.follow(alice, bob)
+      reader = account_fixture()
+
+      assert Enum.map(Relationships.following(alice, reader), & &1.id) == [bob.id]
+
+      {:ok, _} = Relationships.mute(reader, bob)
+
+      assert Relationships.following(alice, reader) == []
     end
 
     test "familiar followers cap at five per target, newest first", %{alice: alice, bob: bob} do
@@ -98,7 +133,7 @@ defmodule Abuuba.RelationshipsTest do
       {:ok, _} = Relationships.follow(alice, bob)
 
       assert Abuuba.Accounts.get_account(bob.id) |> then(& &1.id) == bob.id
-      assert length(Relationships.followers(bob, %{})) == 1
+      assert length(Relationships.followers(bob, nil, %{})) == 1
     end
 
     test "cannot point at yourself", %{alice: alice} do

--- a/test/abuuba_web/account_deletion_test.exs
+++ b/test/abuuba_web/account_deletion_test.exs
@@ -125,7 +125,7 @@ defmodule AbuubaWeb.AccountDeletionTest do
       # of them goes until that row does.
       assert is_nil(Repo.reload(account))
       assert is_nil(Repo.get(Abuuba.Statuses.Status, status.id))
-      assert Relationships.following(other, %{limit: 10}) == []
+      assert Relationships.following(other, nil, %{limit: 10}) == []
       assert Filters.all(account.id) == []
     end
 

--- a/test/abuuba_web/profile_live_test.exs
+++ b/test/abuuba_web/profile_live_test.exs
@@ -255,6 +255,27 @@ defmodule AbuubaWeb.ProfileLiveTest do
       refute html =~ "carol"
     end
 
+    test "and it leaves out somebody the reader blocked, as the API does", %{
+      signed_in: signed_in,
+      subject: subject,
+      reader: reader
+    } do
+      # The other direction, and the one the page got wrong: the viewer was an
+      # optional key inside a pagination map, the REST endpoint filled it in
+      # and this page did not. Blocking somebody hid them from an app and left
+      # them here.
+      blocked = account_fixture(%{username: "erin"})
+      kept = account_fixture(%{username: "frank"})
+      {:ok, _} = Relationships.follow(blocked, subject)
+      {:ok, _} = Relationships.follow(kept, subject)
+      {:ok, _} = Relationships.block(reader, blocked)
+
+      html = signed_in |> get("/@bob/followers") |> html_response(200)
+
+      refute html =~ "erin"
+      assert html =~ "frank"
+    end
+
     test "and open to everybody else", %{signed_in: signed_in, subject: subject} do
       # The control: hiding the list from everyone would satisfy the test
       # above without the block having anything to do with it.

--- a/test/mix/abuuba_ops_tasks_test.exs
+++ b/test/mix/abuuba_ops_tasks_test.exs
@@ -665,7 +665,7 @@ defmodule Mix.Tasks.AbuubaOpsTest do
       output = run(AccountsTask, ["unfollow", "spam@spam.example"])
 
       assert output =~ "2 follows was affected" or output =~ "2 follows"
-      assert Relationships.followers(spammer) == []
+      assert Relationships.followers(spammer, nil) == []
     end
 
     test "refuses a command it does not know" do


### PR DESCRIPTION
`followers/3` and `following/3` take the viewer positionally, the shape
`account_timeline/3` already uses. As an optional key inside a pagination map
the filter was a no-op unless a caller remembered to fill it in — the REST
endpoint did, the profile page did not.

Two of the four callers pass `nil` deliberately, and say why in a comment: the
settings screen is where somebody goes to *unfollow* a person, and the export
is their own data. Filtering either by their own mutes would hide the row with
the button on it, or make the file disagree with the account it came from.
That is the same lesson as the bookmarks list in #44.

`exclude_hidden_from/2` also gains the blocked-domain rule, which sat beside
the block and the mute and was simply never written.

Both halves have a test, and I checked the profile-page one fails without the
fix.

Closes #8

An AI agent wrote this text in my name. I know that is problematic.
