### PR TITLE
One answer to who may see who follows an account

### DIFF
--- a/lib/abuuba/relationships.ex
+++ b/lib/abuuba/relationships.ex
@@ -569,6 +569,33 @@ defmodule Abuuba.Relationships do
   @spec blocking?(Account.t() | integer(), Account.t() | integer()) :: boolean()
   def blocking?(blocker, target), do: get_edge(Block, blocker, target) != nil
 
+  @doc """
+  Whether `viewer` may see who `subject` follows and who follows them.
+
+  Three questions in one order. Your own lists are always yours to see, and
+  the setting outranks everything after it -- `hide_collections` is somebody
+  saying "do not show who I know", and a reader they have not blocked is no
+  more entitled than one they have. Then a block: a profile that shows the
+  person it blocked who its followers are has not blocked them, and the list
+  is the part they came for.
+
+  Here rather than at each surface because it was written four times in four
+  shapes: a function head in the REST controller, a `cond` with two private
+  helpers in the profile page, a single pattern match in the ActivityPub
+  controller, and a fourth spelling guarding the featured strip. The tell that
+  nobody could reuse it is that two of the comments each said the *other*
+  surfaces already honoured the setting.
+
+  `nil` for a reader with no account, and for the federation side, whose
+  documented answer to a hidden collection is an empty one rather than a
+  refusal.
+  """
+  @spec collections_visible?(Account.t(), Account.t() | nil) :: boolean()
+  def collections_visible?(%Account{id: id}, %Account{id: id}), do: true
+  def collections_visible?(%Account{hide_collections: true}, _viewer), do: false
+  def collections_visible?(_subject, nil), do: true
+  def collections_visible?(subject, viewer), do: not blocking?(subject, viewer)
+
   ## Muting
 
   @doc """

--- a/lib/abuuba_web/controllers/activity_pub_controller.ex
+++ b/lib/abuuba_web/controllers/activity_pub_controller.ex
@@ -30,6 +30,7 @@ defmodule AbuubaWeb.ActivityPubController do
   alias Abuuba.Federation.Quotes
   alias Abuuba.Federation.Serializer
   alias Abuuba.Federation.URIs
+  alias Abuuba.Relationships
   alias Abuuba.Relationships.Follow
   alias Abuuba.Repo
   alias Abuuba.Stats
@@ -523,24 +524,30 @@ defmodule AbuubaWeb.ActivityPubController do
   # both shapes arrive here.
   defp collection(conn, params, which) do
     case author(params) do
-      nil ->
-        not_found(conn)
+      nil -> not_found(conn)
+      account -> serve_collection(conn, params, which, account)
+    end
+  end
 
-      %Account{hide_collections: true} = account ->
-        # Empty, not forbidden. A 403 would tell a stranger there is something
-        # here worth hiding, and the point of hiding is that nobody learns
-        # anything at all.
-        conn
-        |> put_resp_content_type(@content_type)
-        |> json(Actor.hidden_collection("#{Actor.id(account)}/#{which}"))
+  # `nil` for the viewer: a peer fetching a document is nobody in particular,
+  # so this asks the setting and stops there, which is the answer this
+  # endpoint has always given.
+  defp serve_collection(conn, params, which, account) do
+    collection_id = "#{Actor.id(account)}/#{which}"
 
-      account ->
-        collection_id = "#{Actor.id(account)}/#{which}"
-        total = follow_count(account, which)
+    if Relationships.collections_visible?(account, nil) do
+      total = follow_count(account, which)
 
-        respond_collection(conn, collection_id, total, params, fn page ->
-          account |> follow_page(which, page) |> Enum.map(&actor_uri_for/1)
-        end)
+      respond_collection(conn, collection_id, total, params, fn page ->
+        account |> follow_page(which, page) |> Enum.map(&actor_uri_for/1)
+      end)
+    else
+      # Empty, not forbidden. A 403 would tell a stranger there is something
+      # here worth hiding, and the point of hiding is that nobody learns
+      # anything at all.
+      conn
+      |> put_resp_content_type(@content_type)
+      |> json(Actor.hidden_collection(collection_id))
     end
   end
 

--- a/lib/abuuba_web/controllers/api/account_controller.ex
+++ b/lib/abuuba_web/controllers/api/account_controller.ex
@@ -399,19 +399,13 @@ defmodule AbuubaWeb.API.AccountController do
   # it blocked has not blocked them.
   defp with_collection(conn, id, params, list) do
     with_account(conn, id, fn account, viewer ->
-      if collection_hidden?(account, viewer) do
-        json(conn, [])
-      else
+      if Relationships.collections_visible?(account, viewer) do
         collection(conn, viewer, list.(account, viewer, Pagination.params(params)))
+      else
+        json(conn, [])
       end
     end)
   end
-
-  defp collection_hidden?(%Account{id: id}, %Account{id: id}), do: false
-  defp collection_hidden?(%Account{hide_collections: true}, _viewer), do: true
-  defp collection_hidden?(_account, nil), do: false
-
-  defp collection_hidden?(account, viewer), do: Relationships.blocking?(account, viewer)
 
   ## Acting on somebody
 

--- a/lib/abuuba_web/live/profile_live.ex
+++ b/lib/abuuba_web/live/profile_live.ex
@@ -628,13 +628,14 @@ defmodule AbuubaWeb.ProfileLive do
   # Every account here is one the subject follows, so this list is a slice of
   # the follows list — and hiding that list while publishing a slice of it on
   # the tab next to it would be the setting quietly not meaning what it says.
-  # Only the first tab shows the strip, so only that tab asks for it.
+  # The same question, then, and not a fourth spelling of it. Only the first
+  # tab shows the strip, so only that tab asks.
   defp assign_featured(socket) do
     subject = socket.assigns.subject
 
     featured =
       if socket.assigns.tab == :posts and
-           (not subject.hide_collections or own_profile?(socket)) do
+           Relationships.collections_visible?(subject, socket.assigns.viewer) do
         Relationships.endorsements(subject, %{limit: @featured_limit})
       else
         []
@@ -658,7 +659,7 @@ defmodule AbuubaWeb.ProfileLive do
   defp load_people(socket) do
     subject = socket.assigns.subject
     viewer = socket.assigns.viewer
-    hidden? = collections_hidden?(socket, subject)
+    hidden? = not Relationships.collections_visible?(subject, viewer)
     page = %{limit: @page_size}
 
     people =
@@ -672,35 +673,9 @@ defmodule AbuubaWeb.ProfileLive do
     assign(socket, people: people, hidden?: hidden?)
   end
 
-  # Two reasons to close the lists, and the API has honoured both since it was
-  # written: the setting, and a block. A profile that shows the person it
-  # blocked who its followers are has not blocked them, and the list is the
-  # part they came for.
-  defp collections_hidden?(socket, subject) do
-    cond do
-      own_profile?(socket) -> false
-      subject.hide_collections -> true
-      true -> blocked_reader?(socket, subject)
-    end
-  end
-
-  defp blocked_reader?(socket, subject) do
-    case socket.assigns.viewer do
-      %Account{} = viewer -> Relationships.blocking?(subject, viewer)
-      _ -> false
-    end
-  end
-
   # Somebody may always see their own. `hide_collections` is about strangers,
   # and a setting that hid the lists from the person who set it would look like
   # a bug the first time they checked it worked.
-  defp own_profile?(socket) do
-    case socket.assigns.viewer do
-      %Account{id: id} -> id == socket.assigns.subject.id
-      _ -> false
-    end
-  end
-
   defp collection?(tab), do: tab in [:followers, :following]
 
   defp filters(:posts), do: %{exclude_replies: true}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.6",
+      version: "1.0.7",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba_web/collections_visibility_test.exs
+++ b/test/abuuba_web/collections_visibility_test.exs
@@ -1,0 +1,145 @@
+defmodule AbuubaWeb.CollectionsVisibilityTest do
+  @moduledoc """
+  Who may see who follows an account, on every surface that answers it.
+
+  The question was written four times in four shapes: a function head in the
+  REST controller, a `cond` with two private helpers on the profile page, a
+  single pattern match in the ActivityPub controller, and a fourth spelling
+  guarding the featured strip. Each of them was right about the rule it
+  remembered and silent about the rest, and two of the comments each said the
+  *other* surfaces already honoured the setting.
+
+  Written per surface rather than per rule, for the reason
+  `AbuubaWeb.ReaderRulesTest` gives: the bug is not that a rule was wrong, it
+  is that a surface never asked.
+  """
+  use AbuubaWeb.ConnCase, async: false
+
+  import Abuuba.AccountsFixtures
+
+  alias Abuuba.Accounts
+  alias Abuuba.Accounts.Auth
+  alias Abuuba.OAuth
+  alias Abuuba.Relationships
+
+  setup %{conn: conn} do
+    subject = account_fixture(%{username: "alice"})
+    follower = account_fixture(%{username: "carol"})
+    {:ok, _} = Relationships.follow(follower, subject)
+
+    reader = account_fixture(%{username: "reader"})
+
+    user =
+      user_fixture(%{account_id: reader.id, approved: true, confirmed_at: DateTime.utc_now()})
+
+    signed_in =
+      conn
+      |> Phoenix.ConnTest.init_test_session(%{})
+      |> Plug.Conn.put_session(:user_token, Auth.create_session_token(user))
+
+    # A session cookie is not a token: on an API route it leaves the viewer
+    # `nil`, which reads as "a stranger" and would pass every assertion below
+    # for the wrong reason.
+    {:ok, application, _secret} =
+      OAuth.create_application(%{name: "test", redirect_uris: "urn:ietf:wg:oauth:2.0:oob"})
+
+    {:ok, _token, raw} = OAuth.issue_token(application, user, ["read"])
+    with_token = put_req_header(build_conn(), "authorization", "Bearer " <> raw)
+
+    %{
+      conn: conn,
+      signed_in: signed_in,
+      with_token: with_token,
+      subject: subject,
+      reader: reader
+    }
+  end
+
+  # The three doors onto one list. ActivityPub is here as a peer rather than a
+  # reader, which is why it takes no viewer at all.
+  defp listed_for_reader?(signed_in) do
+    signed_in |> get(~p"/@alice/followers") |> html_response(200) =~ "carol"
+  end
+
+  defp listed_for_api?(with_token) do
+    subject = Accounts.lookup("alice")
+
+    with_token
+    |> get(~p"/api/v1/accounts/#{subject.id}/followers")
+    |> json_response(200)
+    |> Enum.any?(&(&1["username"] == "carol"))
+  end
+
+  defp listed_for_peer?(conn) do
+    conn |> get(~p"/users/alice/followers") |> json_response(200) |> Map.get("totalItems") > 0
+  end
+
+  describe "an account that has asked for nothing in particular" do
+    test "shows the list on all three", %{
+      conn: conn,
+      signed_in: signed_in,
+      with_token: with_token
+    } do
+      # The control. Every assertion below is that something is absent, which
+      # a server showing nobody anything would satisfy just as well.
+      assert listed_for_reader?(signed_in)
+      assert listed_for_api?(with_token)
+      assert listed_for_peer?(conn)
+    end
+  end
+
+  describe "an account that hid its collections" do
+    setup %{subject: subject} do
+      {:ok, _} = Accounts.update_profile(subject, %{"hide_collections" => true})
+      :ok
+    end
+
+    test "shows it on none of them", %{
+      conn: conn,
+      signed_in: signed_in,
+      with_token: with_token
+    } do
+      refute listed_for_reader?(signed_in)
+      refute listed_for_api?(with_token)
+      refute listed_for_peer?(conn)
+    end
+
+    test "and still shows the owner their own", %{subject: subject, conn: conn} do
+      owner =
+        user_fixture(%{
+          account_id: subject.id,
+          approved: true,
+          confirmed_at: DateTime.utc_now()
+        })
+
+      as_owner =
+        conn
+        |> Phoenix.ConnTest.init_test_session(%{})
+        |> Plug.Conn.put_session(:user_token, Auth.create_session_token(owner))
+
+      assert listed_for_reader?(as_owner)
+    end
+  end
+
+  describe "a reader the account has blocked" do
+    setup %{subject: subject, reader: reader} do
+      {:ok, _} = Relationships.block(subject, reader)
+      :ok
+    end
+
+    test "is refused by the two that know who is asking", %{
+      signed_in: signed_in,
+      with_token: with_token
+    } do
+      refute listed_for_reader?(signed_in)
+      refute listed_for_api?(with_token)
+    end
+
+    test "and the federation side is unchanged, because it has no reader", %{conn: conn} do
+      # A peer fetching a document is nobody in particular. Answering the
+      # setting and stopping there is what this endpoint has always done, and
+      # a block is between two accounts rather than between two servers.
+      assert listed_for_peer?(conn)
+    end
+  end
+end


### PR DESCRIPTION
`Relationships.collections_visible?/2` replaces four spellings of one question.
Each was right about the rule it remembered and silent about the rest.

The federation side passes `nil` and keeps its documented exemption — a peer
fetching a document is nobody in particular, so it reads the setting and stops,
which is what it has always done.

One small behaviour change falls out: the featured strip now honours the block
it never asked about. Its own comment already argued for that — the strip is a
slice of the follows list, and publishing a slice of a list closed to this
reader is the setting quietly not meaning what it says.

`AbuubaWeb.CollectionsVisibilityTest` holds the three surfaces against each
other. Worth noting for whoever writes the next one of these: a session cookie
leaves the viewer `nil` on an API route, so the REST assertions there need a
bearer token — the first version of that test passed for the wrong reason.

Closes #9

An AI agent wrote this text in my name. I know that is problematic.
