### PR TITLE
One table of streams for both transports, and a filter that fails closed

### DIFF
--- a/lib/abuuba_web/controllers/api/streaming_controller.ex
+++ b/lib/abuuba_web/controllers/api/streaming_controller.ex
@@ -19,10 +19,9 @@ defmodule AbuubaWeb.API.StreamingController do
   alias Abuuba.Accounts
   alias Abuuba.OAuth
   alias Abuuba.OAuth.Scopes
-  alias Abuuba.Settings
   alias Abuuba.Streaming
   alias AbuubaWeb.Streaming.Filter
-  alias AbuubaWeb.Streaming.Payload
+  alias AbuubaWeb.Streaming.Subscription
 
   @heartbeat_ms 15_000
 
@@ -88,9 +87,9 @@ defmodule AbuubaWeb.API.StreamingController do
   def stream(conn, %{"stream" => stream} = params) do
     state = connect_state(conn, params)
 
-    case topic_for(stream, params, state) do
-      {:ok, topic} ->
-        if allowed?(state, stream) do
+    case Subscription.topic_for(stream, params, state) do
+      {:ok, name, topic} ->
+        if Subscription.allowed?(state, stream) do
           Streaming.subscribe(topic)
 
           # The token and the announcements, shared with the websocket so a
@@ -101,7 +100,7 @@ defmodule AbuubaWeb.API.StreamingController do
           |> put_resp_header("content-type", "text/event-stream")
           |> put_resp_header("cache-control", "no-cache")
           |> send_chunked(200)
-          |> loop(%{state | topics: MapSet.put(state.topics, {stream, topic})})
+          |> loop(%{state | topics: MapSet.put(state.topics, {name, topic})})
         else
           AbuubaWeb.API.error(conn, 401, "This method requires an authenticated user")
         end
@@ -161,55 +160,6 @@ defmodule AbuubaWeb.API.StreamingController do
         }
     end
   end
-
-  defp allowed?(state, stream) do
-    timelines_readable?(state, stream) and scope_allows?(state, stream)
-  end
-
-  defp scope_allows?(state, stream) do
-    case Payload.required_scope(stream) do
-      nil -> true
-      required -> state.account != nil and Scopes.covers_all?(state.scopes, [required])
-    end
-  end
-
-  # An admin who closes the timelines has said strangers do not read this
-  # server. The API refuses them and the front page refuses them; this is the
-  # third door, and it was answering. Matched on the name rather than on a
-  # list, so a public stream added later is covered without anybody
-  # remembering to add it here.
-  defp timelines_readable?(state, stream) do
-    if String.starts_with?(stream, "public") or String.starts_with?(stream, "hashtag") do
-      Settings.public_timelines_readable?(state.account)
-    else
-      true
-    end
-  end
-
-  defp topic_for("user", _params, %{account: nil}), do: :error
-  defp topic_for("user", _params, state), do: {:ok, Streaming.account_topic(state.account)}
-  defp topic_for("user:notification", _params, %{account: nil}), do: :error
-
-  defp topic_for("user:notification", _params, state),
-    do: {:ok, Streaming.account_topic(state.account)}
-
-  defp topic_for("direct", _params, %{account: nil}), do: :error
-  defp topic_for("direct", _params, state), do: {:ok, Streaming.account_topic(state.account)}
-  defp topic_for("public", _params, _state), do: {:ok, Streaming.public_topic()}
-  defp topic_for("public/local", _params, _state), do: {:ok, Streaming.public_topic(local: true)}
-
-  defp topic_for("public/remote", _params, _state),
-    do: {:ok, Streaming.public_topic(remote: true)}
-
-  defp topic_for("hashtag", params, _state) do
-    case params["tag"] do
-      tag when is_binary(tag) and tag != "" -> {:ok, Streaming.hashtag_topic(tag)}
-      _ -> :error
-    end
-  end
-
-  defp topic_for("hashtag/local", params, state), do: topic_for("hashtag", params, state)
-  defp topic_for(_stream, _params, _state), do: :error
 
   defp bearer(conn) do
     case get_req_header(conn, "authorization") do

--- a/lib/abuuba_web/streaming/filter.ex
+++ b/lib/abuuba_web/streaming/filter.ex
@@ -166,13 +166,24 @@ defmodule AbuubaWeb.Streaming.Filter do
 
   defp belongs_on?(stream, status)
        when stream in ["public:media", "public:local:media", "public:remote:media"] do
-    status.ordered_media_attachment_ids != []
+    status.ordered_media_attachment_ids != [] and local_side?(stream, status)
   end
 
   defp belongs_on?("public:local", status), do: status.local
   defp belongs_on?("public:remote", status), do: not status.local
   defp belongs_on?("hashtag:local", status), do: status.local
-  defp belongs_on?(_stream, _status), do: true
+  defp belongs_on?(stream, _status) when stream in ["public", "hashtag", "list"], do: true
+
+  # A name nobody wrote a rule for carries nothing. This used to answer `true`,
+  # which is the shape that let the SSE side's own spelling of `public:local`
+  # through unfiltered: `Subscription` is what makes the names agree, and this
+  # is what makes a disagreement show up as an empty stream rather than as
+  # every post.
+  defp belongs_on?(_stream, _status), do: false
+
+  defp local_side?("public:local:media", status), do: status.local
+  defp local_side?("public:remote:media", status), do: not status.local
+  defp local_side?(_stream, _status), do: true
 
   # The same rules a timeline applies, asked one post at a time. An anonymous
   # socket sees public posts and nothing else.

--- a/lib/abuuba_web/streaming/subscription.ex
+++ b/lib/abuuba_web/streaming/subscription.ex
@@ -1,0 +1,138 @@
+defmodule AbuubaWeb.Streaming.Subscription do
+  @moduledoc """
+  What a client may subscribe to, and which topic that means.
+
+  ## One table, because two had already drifted apart
+
+  A WebSocket and an SSE connection are two ways of asking for the same
+  streams, and each carried its own copy of the answer: the same
+  `timelines_readable?/2` down to its five-line comment, the same
+  `account_of/1`, one scope rule spelled twice, and two tables of stream names
+  that were no longer the same table. The socket knew `public:media`,
+  `public:local:media`, `public:remote:media` and `list`; the SSE side knew
+  none of them and spelled two of its own with a slash.
+
+  That last part is what made it worth fixing rather than watching.
+  `AbuubaWeb.Streaming.Filter` decides whether a post belongs on a stream by
+  matching its name, and ended `belongs_on?(_stream, _status), do: true` --
+  so a name it did not recognise let everything through. A client on the SSE
+  side asking for `public/local` got every public post, local or not, and one
+  asking for a media stream that transport did not know got posts with no
+  media in them.
+
+  ## The canonical spelling is the colon one
+
+  `topic_for/3` answers with the name as well as the topic, and both
+  transports store what it answers rather than what the client typed. A slash
+  is accepted and normalised on the way in, because a client that used it was
+  reaching a real stream and should keep reaching one -- it is a spelling, not
+  a different thing to subscribe to.
+  """
+
+  alias Abuuba.OAuth.Scopes
+  alias Abuuba.Settings
+  alias Abuuba.Streaming
+  alias AbuubaWeb.Streaming.Payload
+
+  # Every stream this server serves. `Filter` is exhaustive over this list, so
+  # a name added here without a rule there is a compile-time gap rather than a
+  # stream that quietly carries everything.
+  @streams ~w(
+    user user:notification direct
+    public public:local public:remote
+    public:media public:local:media public:remote:media
+    hashtag hashtag:local
+    list
+  )
+
+  @doc """
+  Every stream name this server answers to.
+  """
+  @spec streams() :: [String.t()]
+  def streams, do: @streams
+
+  @doc """
+  The canonical spelling of what a client asked for.
+
+  `public/local` and `hashtag/local` are the two a client may have sent, from
+  the days when this endpoint took two path segments.
+  """
+  @spec normalise(String.t()) :: String.t()
+  def normalise(stream) when is_binary(stream), do: String.replace(stream, "/", ":")
+  def normalise(stream), do: stream
+
+  @doc """
+  The topic one subscription listens on, and the name it is known by.
+
+  `{:ok, name, topic}` where the client may have it, `:error` where the stream
+  does not exist or needs an account the connection has not got. The name
+  comes back because it is what `AbuubaWeb.Streaming.Filter` is keyed on, and
+  a transport storing the client's spelling instead is how the two came apart.
+  """
+  @spec topic_for(String.t(), map(), map()) :: {:ok, String.t(), String.t()} | :error
+  def topic_for(stream, params, state) do
+    name = normalise(stream)
+
+    case topic(name, params, state) do
+      {:ok, topic} -> {:ok, name, topic}
+      :error -> :error
+    end
+  end
+
+  @doc """
+  Whether this connection may listen to this stream at all.
+
+  Two questions. The scope one is the token's: a stream that carries
+  somebody's own posts or notifications needs a token that says so. The other
+  is the server's -- an admin who closes the timelines has said strangers do
+  not read this server, and a socket is the third door onto them after the API
+  and the pages. Matched on the name rather than a list, so a public stream
+  added later is covered without anybody remembering to come back here.
+  """
+  @spec allowed?(map(), String.t()) :: boolean()
+  def allowed?(state, stream) do
+    name = normalise(stream)
+
+    timelines_readable?(state, name) and scope_allows?(state, name)
+  end
+
+  defp timelines_readable?(state, stream) do
+    if String.starts_with?(stream, "public") or String.starts_with?(stream, "hashtag") do
+      Settings.public_timelines_readable?(state.account)
+    else
+      true
+    end
+  end
+
+  defp scope_allows?(state, stream) do
+    case Payload.required_scope(stream) do
+      nil -> true
+      required -> state.account != nil and Scopes.covers_all?(state.scopes, [required])
+    end
+  end
+
+  defp topic(stream, _params, %{account: nil})
+       when stream in ~w(user user:notification direct list),
+       do: :error
+
+  defp topic(stream, _params, state) when stream in ~w(user user:notification direct list),
+    do: {:ok, Streaming.account_topic(state.account)}
+
+  defp topic(stream, _params, _state) when stream in ~w(public public:media),
+    do: {:ok, Streaming.public_topic()}
+
+  defp topic(stream, _params, _state) when stream in ~w(public:local public:local:media),
+    do: {:ok, Streaming.public_topic(local: true)}
+
+  defp topic(stream, _params, _state) when stream in ~w(public:remote public:remote:media),
+    do: {:ok, Streaming.public_topic(remote: true)}
+
+  defp topic(stream, params, _state) when stream in ~w(hashtag hashtag:local) do
+    case Map.get(params, "tag") do
+      tag when is_binary(tag) and tag != "" -> {:ok, Streaming.hashtag_topic(tag)}
+      _ -> :error
+    end
+  end
+
+  defp topic(_stream, _params, _state), do: :error
+end

--- a/lib/abuuba_web/streaming_socket.ex
+++ b/lib/abuuba_web/streaming_socket.ex
@@ -29,10 +29,9 @@ defmodule AbuubaWeb.StreamingSocket do
   alias Abuuba.Accounts
   alias Abuuba.OAuth
   alias Abuuba.OAuth.Scopes
-  alias Abuuba.Settings
   alias Abuuba.Streaming
   alias AbuubaWeb.Streaming.Filter
-  alias AbuubaWeb.Streaming.Payload
+  alias AbuubaWeb.Streaming.Subscription
 
   @doc """
   Builds the socket's state from the request that is about to be upgraded.
@@ -117,91 +116,29 @@ defmodule AbuubaWeb.StreamingSocket do
   ## Subscription
 
   defp subscribe(state, stream, params) do
-    with :ok <- check_scope(state, stream),
-         true <- timelines_readable?(state, stream),
-         {:ok, topic} <- topic_for(stream, params, state) do
+    with true <- Subscription.allowed?(state, stream),
+         {:ok, name, topic} <- Subscription.topic_for(stream, params, state) do
       Streaming.subscribe(topic)
 
-      %{state | topics: MapSet.put(state.topics, {stream, topic})}
+      # The name `Subscription` answers with, not the one the client typed:
+      # `AbuubaWeb.Streaming.Filter` is keyed on it.
+      %{state | topics: MapSet.put(state.topics, {name, topic})}
     else
       _ -> state
     end
   end
 
   defp unsubscribe(state, stream, params) do
-    case topic_for(stream, params, state) do
-      {:ok, topic} ->
+    case Subscription.topic_for(stream, params, state) do
+      {:ok, name, topic} ->
         Streaming.unsubscribe(topic)
 
-        %{state | topics: MapSet.delete(state.topics, {stream, topic})}
+        %{state | topics: MapSet.delete(state.topics, {name, topic})}
 
       _ ->
         state
     end
   end
-
-  # A public stream needs nothing; anything naming a person needs a token that
-  # was granted the right to read that thing. Checked per subscription rather
-  # than at connect, because one socket carries several streams.
-  # An admin who closes the timelines has said strangers do not read this
-  # server. The API refuses them and the front page refuses them; this is the
-  # third door, and it was answering. Matched on the name rather than on a
-  # list, so a public stream added later is covered without anybody
-  # remembering to add it here.
-  defp timelines_readable?(state, stream) do
-    if String.starts_with?(stream, "public") or String.starts_with?(stream, "hashtag") do
-      Settings.public_timelines_readable?(state.account)
-    else
-      true
-    end
-  end
-
-  defp check_scope(state, stream) do
-    required = Payload.required_scope(stream)
-
-    cond do
-      is_nil(required) -> :ok
-      is_nil(state.account) -> :error
-      Scopes.covers_all?(state.scopes, [required]) -> :ok
-      true -> :error
-    end
-  end
-
-  defp topic_for("user", _params, %{account: nil}), do: :error
-  defp topic_for("user", _params, state), do: {:ok, Streaming.account_topic(state.account)}
-
-  defp topic_for("user:notification", _params, %{account: nil}), do: :error
-
-  defp topic_for("user:notification", _params, state),
-    do: {:ok, Streaming.account_topic(state.account)}
-
-  defp topic_for("direct", _params, %{account: nil}), do: :error
-  defp topic_for("direct", _params, state), do: {:ok, Streaming.account_topic(state.account)}
-
-  defp topic_for("public", _params, _state), do: {:ok, Streaming.public_topic()}
-  defp topic_for("public:local", _params, _state), do: {:ok, Streaming.public_topic(local: true)}
-
-  defp topic_for("public:remote", _params, _state),
-    do: {:ok, Streaming.public_topic(remote: true)}
-
-  defp topic_for("public:media", _params, _state), do: {:ok, Streaming.public_topic()}
-
-  defp topic_for("public:local:media", _params, _state),
-    do: {:ok, Streaming.public_topic(local: true)}
-
-  defp topic_for("public:remote:media", _params, _state),
-    do: {:ok, Streaming.public_topic(remote: true)}
-
-  defp topic_for(hashtag, params, _state) when hashtag in ["hashtag", "hashtag:local"] do
-    case Map.get(params, "tag") do
-      tag when is_binary(tag) and tag != "" -> {:ok, Streaming.hashtag_topic(tag)}
-      _ -> :error
-    end
-  end
-
-  defp topic_for("list", _params, %{account: nil}), do: :error
-  defp topic_for("list", _params, state), do: {:ok, Streaming.account_topic(state.account)}
-  defp topic_for(_stream, _params, _state), do: :error
 
   ## Token
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.7",
+      version: "1.0.8",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba_web/api/streaming_controller_test.exs
+++ b/test/abuuba_web/api/streaming_controller_test.exs
@@ -2,9 +2,12 @@ defmodule AbuubaWeb.API.StreamingControllerTest do
   use AbuubaWeb.ConnCase, async: false
 
   import Abuuba.AccountsFixtures
+  import Abuuba.StatusesFixtures
 
   alias Abuuba.OAuth
   alias Abuuba.Settings
+  alias AbuubaWeb.Streaming.Filter
+  alias AbuubaWeb.Streaming.Subscription
 
   setup %{conn: conn} do
     account = account_fixture()
@@ -216,6 +219,70 @@ defmodule AbuubaWeb.API.StreamingControllerTest do
       Abuuba.Streaming.publish_announcement(announcement)
 
       assert_receive {:streaming, "announcement", _payload}, 2_000
+    end
+  end
+
+  describe "one table of streams, for both transports" do
+    # The two transports each carried their own copy: the socket knew the
+    # media streams and `list`, the SSE side knew neither and spelled two of
+    # its own with a slash. `AbuubaWeb.Streaming.Filter` matches on the name,
+    # and ended in a catch-all `true` -- so a name it did not recognise let
+    # every post through. These hold the three against each other.
+    setup %{account: account} do
+      %{state: %{account: account, scopes: [:read], topics: MapSet.new(), token_id: nil}}
+    end
+
+    test "every stream it advertises resolves to a topic", %{state: state} do
+      for stream <- Subscription.streams() do
+        assert {:ok, ^stream, _topic} =
+                 Subscription.topic_for(stream, %{"tag" => "cats"}, state),
+               "#{stream} is in the table and cannot be subscribed to"
+      end
+    end
+
+    test "and Filter answers each of them deliberately", %{account: account} do
+      # The table, written out. One local public post with no media, offered
+      # to every stream in turn: what matters is that nothing answers by
+      # accident, which is what the catch-all `true` used to arrange.
+      status = status_fixture(%{account_id: account.id, visibility: :public})
+
+      carries = ~w(user public public:local hashtag hashtag:local list)
+      ignores = ~w(user:notification direct public:remote)
+      no_media = ~w(public:media public:local:media public:remote:media)
+
+      assert Enum.sort(carries ++ ignores ++ no_media) == Enum.sort(Subscription.streams()),
+             "a stream was added without saying what it does with a post"
+
+      for stream <- carries do
+        assert {:ok, _frame} = offer(status, account, stream), "#{stream} dropped a post"
+      end
+
+      for stream <- ignores ++ no_media do
+        assert offer(status, account, stream) == :skip, "#{stream} carried a post it should not"
+      end
+    end
+
+    defp offer(status, account, stream) do
+      Filter.for_viewer("update", status, %{
+        account: account,
+        scopes: [:read],
+        topics: MapSet.new([{stream, "t"}]),
+        token_id: nil
+      })
+    end
+
+    test "a stream nobody wrote a rule for carries nothing", %{account: account} do
+      status = status_fixture(%{account_id: account.id, visibility: :public})
+
+      assert offer(status, account, "public/local") == :skip,
+             "the catch-all used to answer `true` here, which is every post"
+    end
+
+    test "the slash spelling reaches the stream it meant", %{state: state} do
+      # Kept working, and normalised: a client that used it was reaching a
+      # real stream, and what it stores is what Filter is keyed on.
+      assert {:ok, "public:local", topic} = Subscription.topic_for("public/local", %{}, state)
+      assert {:ok, "public:local", ^topic} = Subscription.topic_for("public:local", %{}, state)
     end
   end
 


### PR DESCRIPTION
`AbuubaWeb.Streaming.Subscription` owns `topic_for/3` and `allowed?/2`, and
both transports store the name it answers with rather than the one the client
typed — which is what `Filter` is keyed on, and how the two came apart.

The interesting half is the catch-all. `Filter` ended
`belongs_on?(_stream, _status), do: true`, so a name it did not recognise let
every post through: an SSE client asking for `public/local` was reading the
whole public timeline, not the local half. It is `false` now, so a
disagreement between the table and the filter shows up as an empty stream
rather than as everything. That also closed a smaller one in passing —
`public:remote:media` checked for media and never for the remote side.

The slash spelling still reaches the stream it meant, normalised on the way in.
A client that used it was reaching a real stream; it is a spelling, not a
different thing to subscribe to.

The new test writes the table out: every stream in `Subscription.streams()` is
declared as carrying a given post or not, and the list is asserted to be
exhaustive, so adding a stream without saying what it does with a post fails
rather than silently inheriting a default.

Closes #10

An AI agent wrote this text in my name. I know that is problematic.
