### PR TITLE
Write each reader rule once, ask it of whichever author it is about

### DIFF
--- a/lib/abuuba/statuses.ex
+++ b/lib/abuuba/statuses.ex
@@ -118,6 +118,61 @@ defmodule Abuuba.Statuses do
     )
   end
 
+  # The three questions a reader's own rules come down to, each written once
+  # and asked of whichever account an argument names: the author of a post, or
+  # the author of what that post repeats.
+  #
+  # Macros rather than one set of author ids, which is what this looked like
+  # for an afternoon. `a.id in subquery(...)` reads better and Postgres hoists
+  # it into an anti-join over the whole `accounts` table: the public timeline
+  # measured 1,230 ms and 2.7 million buffers against 6 ms and 1,363. Asked of
+  # one id at a time, every one of these is an index probe.
+  defmacrop blocked_either_way(viewer_id, subject) do
+    quote do
+      from(b in Block,
+        where:
+          (b.account_id == ^unquote(viewer_id) and b.target_account_id == unquote(subject)) or
+            (b.target_account_id == ^unquote(viewer_id) and b.account_id == unquote(subject)),
+        select: 1
+      )
+    end
+  end
+
+  defmacrop actively_muted(viewer_id, now, subject) do
+    quote do
+      from(m in Mute,
+        where:
+          m.account_id == ^unquote(viewer_id) and m.target_account_id == unquote(subject) and
+            (is_nil(m.expires_at) or m.expires_at > ^unquote(now)),
+        select: 1
+      )
+    end
+  end
+
+  # Blocking a domain is blocking everybody on it, and it was enforced only
+  # where a post is written into a feed. The public and hashtag timelines and
+  # search are live queries with no feed in front of them, so a reader who had
+  # shut out a whole server still met it on all three.
+  defmacrop on_a_blocked_server(viewer_id, subject) do
+    quote do
+      from(a in Account,
+        join: d in DomainBlock,
+        on: d.domain == a.domain and d.account_id == ^unquote(viewer_id),
+        where: a.id == unquote(subject),
+        select: 1
+      )
+    end
+  end
+
+  # None of the three, of whichever account `subject` names.
+  defmacrop wanted_author(viewer_id, now, subject) do
+    quote do
+      not exists(blocked_either_way(unquote(viewer_id), unquote(subject))) and
+        not exists(actively_muted(unquote(viewer_id), unquote(now), unquote(subject))) and
+        not exists(on_a_blocked_server(unquote(viewer_id), unquote(subject)))
+    end
+  end
+
   @doc """
   Removes what a reader's blocks and mutes hide, in both directions.
 
@@ -141,48 +196,19 @@ defmodule Abuuba.Statuses do
     now = DateTime.utc_now()
 
     query
+    |> where([s], wanted_author(viewer_id, now, parent_as(:status).account_id))
     |> where(
       [s],
-      not exists(
-        from b in Block,
-          where:
-            b.account_id == ^viewer_id and
-              b.target_account_id == parent_as(:status).account_id
-      )
+      is_nil(s.reblog_of_id) or
+        exists(
+          from(o in Status,
+            as: :carried,
+            where: o.id == parent_as(:status).reblog_of_id,
+            where: wanted_author(viewer_id, now, parent_as(:carried).account_id),
+            select: 1
+          )
+        )
     )
-    |> where(
-      [s],
-      not exists(
-        from b in Block,
-          where:
-            b.target_account_id == ^viewer_id and
-              b.account_id == parent_as(:status).account_id
-      )
-    )
-    |> where(
-      [s],
-      not exists(
-        from m in Mute,
-          where:
-            m.account_id == ^viewer_id and
-              m.target_account_id == parent_as(:status).account_id and
-              (is_nil(m.expires_at) or m.expires_at > ^now)
-      )
-    )
-    # Blocking a domain is blocking everybody on it, and it was enforced only
-    # where a post is written into a feed. The public and hashtag timelines and
-    # search are live queries with no feed in front of them, so a reader who
-    # had shut out a whole server still met it on all three.
-    |> where(
-      [s],
-      not exists(
-        from a in Account,
-          join: d in DomainBlock,
-          on: d.domain == a.domain and d.account_id == ^viewer_id,
-          where: a.id == parent_as(:status).account_id
-      )
-    )
-    |> excluding_hidden_boosts(viewer_id, now)
   end
 
   @doc """
@@ -234,11 +260,12 @@ defmodule Abuuba.Statuses do
     # thousand questions to answer one. The rules are unchanged; they are asked
     # together instead of in turn.
     viewer_id = viewer_id(viewer)
+    now = DateTime.utc_now()
 
     Account
     |> from(as: :author)
     |> where([a], a.id in subquery(author_ids(status)))
-    |> where(^unwanted_author(viewer_id))
+    |> where([a], not wanted_author(viewer_id, now, parent_as(:author).id))
     |> Repo.exists?() or thread_muted?(viewer, status)
   end
 
@@ -248,52 +275,6 @@ defmodule Abuuba.Statuses do
     carried = status.reblog_of_id || status.id
 
     from(s in Status, where: s.id == ^status.id or s.id == ^carried, select: s.account_id)
-  end
-
-  defp unwanted_author(viewer_id) do
-    dynamic(
-      [a],
-      ^blocked_either_way(viewer_id) or ^actively_muted(viewer_id) or
-        ^on_a_blocked_server(viewer_id)
-    )
-  end
-
-  defp blocked_either_way(viewer_id) do
-    dynamic(
-      exists(
-        from(b in Block,
-          where:
-            (b.account_id == ^viewer_id and b.target_account_id == parent_as(:author).id) or
-              (b.target_account_id == ^viewer_id and b.account_id == parent_as(:author).id)
-        )
-      )
-    )
-  end
-
-  defp actively_muted(viewer_id) do
-    now = DateTime.utc_now()
-
-    dynamic(
-      exists(
-        from(m in Mute,
-          where:
-            m.account_id == ^viewer_id and m.target_account_id == parent_as(:author).id and
-              (is_nil(m.expires_at) or m.expires_at > ^now)
-        )
-      )
-    )
-  end
-
-  defp on_a_blocked_server(viewer_id) do
-    dynamic(
-      [a],
-      not is_nil(a.domain) and
-        exists(
-          from(d in DomainBlock,
-            where: d.account_id == ^viewer_id and d.domain == parent_as(:author).domain
-          )
-        )
-    )
   end
 
   defp viewer_id(%Account{id: id}), do: id

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.8",
+      version: "1.0.9",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
The three rules are written once now, as macros over an account-id expression,
and asked of the post's author and of the author of what a boost carries.
`hidden_for?/2` asks the same three of its own binding, so a fourth rule is a
one-place change — which was the point.

**Not the shape the issue asked for, and this is the reason.** Building one
author set and testing `a.id in subquery(...)` is the tidier code, and I wrote
it first. Postgres hoists it into an anti-join over the whole `accounts` table:

| shape | buffers | time |
| --- | --- | --- |
| before | 1,363 | 6.0 ms |
| one author set (`a.id in subquery`) | 2,699,049 | 1,230 ms |
| **kept** — asked of one id at a time | 1,400 | 5.8 ms |

Public timeline, 60k accounts and 300k statuses, median of six warm runs. That
is a 205x regression on the query behind every timeline, so the duplication
comes out the other way and the measurement is in a comment beside it — this
is the second time this session that the set-shaped rewrite has looked right
and planned badly, and I would rather the next person read the number than
rediscover it.

`excluding_boosts_of_hidden/2` keeps its own three functions: it is the
profile's deliberate "their posts but not their boosts of somebody you
blocked", which is a different question, not a copy of this one.

Closes #11

An AI agent wrote this text in my name. I know that is problematic.
