### PR TITLE
Ask Domains whether a domain is blocked, and spell the key one way

### DIFF
--- a/lib/abuuba/federation/availability.ex
+++ b/lib/abuuba/federation/availability.ex
@@ -25,6 +25,7 @@ defmodule Abuuba.Federation.Availability do
 
   import Ecto.Query
 
+  alias Abuuba.Moderation.DomainBlock
   alias Abuuba.Repo
 
   @failure_days_before_unavailable 7
@@ -210,5 +211,8 @@ defmodule Abuuba.Federation.Availability do
     end
   end
 
-  defp normalise(domain), do: domain |> to_string() |> String.downcase()
+  # `DomainBlock.normalise/1` rather than a fourth spelling: this one dropped
+  # the trim and the trailing dot, and it keys `instance_availability`
+  # alongside `Abuuba.Federation.Instances`, which did not.
+  defp normalise(domain), do: DomainBlock.normalise(domain)
 end

--- a/lib/abuuba/federation/instances.ex
+++ b/lib/abuuba/federation/instances.ex
@@ -29,6 +29,8 @@ defmodule Abuuba.Federation.Instances do
 
   alias Abuuba.Accounts.Account
   alias Abuuba.Federation.Availability
+  alias Abuuba.Moderation.DomainBlock
+  alias Abuuba.Moderation.Domains
   alias Abuuba.Repo
   alias Abuuba.Statuses.Status
 
@@ -166,15 +168,16 @@ defmodule Abuuba.Federation.Instances do
 
   # The severity where there is a block, so the screen can say "blocked" rather
   # than offering to block a server that already is.
-  defp blocks_for([]), do: %{}
-
+  #
+  # Through `Abuuba.Moderation.Domains`, which is what decides this everywhere
+  # else. Reading `domain_blocks` here with an exact match answered about a
+  # different question: a block on `bad.example` covers `mail.bad.example`, so
+  # this screen called a subdomain unblocked while `Domains.suspended?/1`
+  # called it suspended, from the same rows.
   defp blocks_for(domains) do
-    from(b in "domain_blocks",
-      where: b.domain in ^domains,
-      select: {b.domain, b.severity}
-    )
-    |> Repo.all()
-    |> Map.new()
+    domains
+    |> Domains.blocks_for()
+    |> Map.new(fn {domain, block} -> {domain, block.severity} end)
   end
 
   defp details_for([]), do: %{}
@@ -223,7 +226,10 @@ defmodule Abuuba.Federation.Instances do
     :ok
   end
 
-  defp normalise(domain), do: domain |> to_string() |> String.trim() |> String.downcase()
+  # One spelling of the key, and `DomainBlock.normalise/1` is it. This one
+  # kept a trailing dot, and `instance_availability` is keyed on the result --
+  # so `bad.example.` and `bad.example` were two rows for one host.
+  defp normalise(domain), do: DomainBlock.normalise(domain)
 
   defp normalise_note(nil), do: nil
 

--- a/lib/abuuba/moderation/domain_lists.ex
+++ b/lib/abuuba/moderation/domain_lists.ex
@@ -25,6 +25,7 @@ defmodule Abuuba.Moderation.DomainLists do
   """
 
   alias Abuuba.Accounts.Account
+  alias Abuuba.Moderation.DomainBlock
   alias Abuuba.Moderation.Domains
 
   @doc """
@@ -84,8 +85,7 @@ defmodule Abuuba.Moderation.DomainLists do
     end)
   end
 
-  defp normalise(nil), do: ""
-  defp normalise(domain), do: domain |> String.trim() |> String.downcase()
+  defp normalise(domain), do: DomainBlock.normalise(domain)
 
   # An unknown severity is a silence rather than a suspension. A file from
   # somebody else must not be able to delete accounts here because a column

--- a/lib/abuuba/moderation/domains.ex
+++ b/lib/abuuba/moderation/domains.ex
@@ -181,17 +181,52 @@ defmodule Abuuba.Moderation.Domains do
   @spec block_for(String.t() | nil) :: DomainBlock.t() | nil
   def block_for(nil), do: nil
 
-  def block_for(domain) do
-    case candidates(domain) do
-      [] ->
-        nil
+  def block_for(domain), do: [domain] |> blocks_for() |> Map.get(domain)
 
-      candidates ->
-        DomainBlock
-        |> where([b], b.domain in ^candidates)
-        |> Repo.all()
-        |> Enum.max_by(&String.length(&1.domain), fn -> nil end)
-    end
+  @doc """
+  The block that applies to each of these domains, in one query.
+
+  A domain is covered by a block on any of its parents, so `mail.bad.example`
+  is blocked by a block on `bad.example` and the most specific of the two
+  wins. Anything reading `domain_blocks` has to expand a domain the same way
+  or it answers about a different question: the admin instances screen matched
+  the column exactly, and reported a subdomain as not blocked while
+  `suspended?/1` reported it suspended, from the same rows.
+
+  Batched because that screen holds a page of domains and one query beats
+  forty.
+  """
+  @spec blocks_for([String.t() | nil]) :: %{String.t() => DomainBlock.t()}
+  def blocks_for([]), do: %{}
+
+  def blocks_for(domains) do
+    stored = stored_blocks(Enum.flat_map(domains, &candidates/1))
+
+    domains
+    |> Enum.flat_map(fn domain ->
+      case most_specific(stored, candidates(domain)) do
+        nil -> []
+        block -> [{domain, block}]
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp stored_blocks([]), do: %{}
+
+  defp stored_blocks(candidates) do
+    DomainBlock
+    |> where([b], b.domain in ^Enum.uniq(candidates))
+    |> Repo.all()
+    |> Map.new(&{&1.domain, &1})
+  end
+
+  # `bad.example` outranks `example`: a moderator who wrote both meant the
+  # narrower one to say what happens to that server.
+  defp most_specific(stored, candidates) do
+    candidates
+    |> Enum.flat_map(&List.wrap(Map.get(stored, &1)))
+    |> Enum.max_by(&String.length(&1.domain), fn -> nil end)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.9",
+      version: "1.0.10",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba_web/admin_instances_test.exs
+++ b/test/abuuba_web/admin_instances_test.exs
@@ -159,6 +159,38 @@ defmodule AbuubaWeb.AdminInstancesTest do
       assert html =~ "Blocked"
       assert %{severity: "silence"} = Domains.block_for("remote.example")
     end
+
+    test "and a block on a parent domain is reported on the subdomain", %{conn: conn} do
+      # The screen read `domain_blocks` itself and matched the column exactly,
+      # so it offered to block a server that already was: `Domains.suspended?/1`
+      # said suspended and this said nothing, from the same row.
+      account_fixture(%{username: "sub", domain: "mail.bad.example"})
+      moderator = account_fixture()
+      {:ok, _} = Domains.block(moderator, %{"domain" => "bad.example", "severity" => "suspend"})
+
+      assert Domains.suspended?("mail.bad.example")
+
+      {:ok, _live, html} = live(conn, ~p"/admin/instances")
+
+      assert html =~ "mail.bad.example"
+
+      assert Map.has_key?(Domains.blocks_for(["mail.bad.example"]), "mail.bad.example"),
+             "the screen asks this, and it answered about a different question"
+    end
+
+    test "and the narrower block is the one that applies", %{conn: _conn} do
+      moderator = account_fixture()
+      {:ok, _} = Domains.block(moderator, %{"domain" => "bad.example", "severity" => "silence"})
+
+      {:ok, _} =
+        Domains.block(moderator, %{"domain" => "mail.bad.example", "severity" => "suspend"})
+
+      assert %{severity: "suspend"} =
+               Domains.blocks_for(["mail.bad.example"])["mail.bad.example"]
+
+      assert %{severity: "silence"} =
+               Domains.blocks_for(["other.bad.example"])["other.bad.example"]
+    end
   end
 
   describe "the audit log" do


### PR DESCRIPTION
`Abuuba.Moderation.Domains.blocks_for/1` is the batch form of `block_for/1` —
it expands each domain to its parents and lets the most specific win, which is
what everything except the instances screen was already doing. `block_for/1`
is now one call into it, so there is one implementation rather than two.

Batched deliberately: the screen holds a page of domains, and asking
`block_for/1` per row would have traded a wrong answer for forty queries.

The normalisation half: `DomainBlock.normalise/1` is the one spelling and the
other three call it. Two of the four keyed `instance_availability`, so a
trailing dot gave one host two rows.

Both halves have a test, and I checked they fail against an exact-match
lookup.

Closes #12

An AI agent wrote this text in my name. I know that is problematic.
