### PR TITLE
Let the composer write a post and what it carries in one go

### DIFF
--- a/lib/abuuba_web/live/compose_component.ex
+++ b/lib/abuuba_web/live/compose_component.ex
@@ -1176,10 +1176,19 @@ defmodule AbuubaWeb.ComposeComponent do
   defp write(socket) do
     account = socket.assigns.account
 
+    # One write, with the pictures and the poll in it. Three writes meant
+    # `create_status/2` announced the post on commit and the other two ran
+    # afterwards, so the streaming API, the live timeline and the outbox were
+    # each handed a photo post with no photographs -- and a poll the changeset
+    # refused left a published post behind that its author had been told was
+    # refused. `Abuuba.Statuses.create_status/2` grew these two options for
+    # exactly this, and the API has been calling it that way.
     with :ok <- ActionLimits.take(account, :statuses),
-         {:ok, status} <- Statuses.create_status(post_attrs(socket.assigns)),
-         :ok <- attach_poll(socket.assigns, status),
-         :ok <- attach_media(socket.assigns, status) do
+         {:ok, status} <-
+           Statuses.create_status(post_attrs(socket.assigns),
+             media_ids: socket.assigns.attachment_ids,
+             poll: poll_attrs(socket.assigns)
+           ) do
       send(self(), {:composed, status})
 
       socket |> forget_draft() |> reset() |> refresh_lists()
@@ -1220,32 +1229,18 @@ defmodule AbuubaWeb.ComposeComponent do
     }
   end
 
-  defp attach_media(%{attachment_ids: []}, _status), do: :ok
+  defp poll_attrs(%{poll?: false}), do: nil
 
-  defp attach_media(%{attachment_ids: ids}, status) do
-    case Media.attach(status, ids) do
-      {:ok, _status} -> :ok
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp attach_poll(%{poll?: false}, _status), do: :ok
-
-  defp attach_poll(%{poll?: true, draft: draft}, status) do
+  defp poll_attrs(%{poll?: true, draft: draft}) do
     options = usable_options(draft)
 
-    attrs = %{
+    %{
       options: options,
       tallies: List.duplicate(0, length(options)),
       multiple: draft["poll_multiple"] == true,
       expires_at:
         DateTime.add(DateTime.utc_now(), Params.to_integer(draft["poll_expires_in"]), :second)
     }
-
-    case Statuses.create_poll(status, attrs) do
-      {:ok, _poll} -> :ok
-      {:error, changeset} -> {:error, changeset}
-    end
   end
 
   defp reset(socket) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.10",
+      version: "1.0.11",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba_web/compose_test.exs
+++ b/test/abuuba_web/compose_test.exs
@@ -856,6 +856,28 @@ defmodule AbuubaWeb.ComposeTest do
       assert render(live) =~ "media-attachment"
     end
 
+    test "and the post is announced with them already on it", %{conn: conn, account: account} do
+      # The composer wrote three times: `create_status/2` announces on commit,
+      # so the streaming API, the live timeline and the outbox were each handed
+      # a photo post with no photographs. `ordered_media_attachment_ids` is on
+      # the row that goes out, so what the broadcast carried says whether the
+      # pictures were on it yet.
+      Abuuba.Streaming.subscribe(Abuuba.Streaming.public_topic())
+
+      {:ok, live, _html} = live(conn, ~p"/home")
+
+      pick(live, [png("cat.png")])
+      submit(live, %{"text" => "a photograph"})
+
+      assert [status] = posted(account)
+
+      assert_receive {:streaming, "update", announced}, 2_000
+      assert announced.id == status.id
+
+      refute announced.ordered_media_attachment_ids == [],
+             "the post went out before its pictures were on it"
+    end
+
     test "hangs them on the post, in order", %{conn: conn, account: account} do
       {:ok, live, _html} = live(conn, ~p"/home")
 


### PR DESCRIPTION
The composer now calls `Statuses.create_status(attrs, media_ids: …, poll: …)`
— the options the context grew for this, and what the API controller has been
calling since.

**On the test.** My first attempt asserted the poll existed on the announced
post and passed against the old three-write code, because reading `get_poll/1`
after the fact finds the row whenever it was written. Reading the row back
cannot see announce ordering at all, which is how this stayed invisible.

`ordered_media_attachment_ids` is a column on the status that goes out, so the
test subscribes to the public topic and asserts on what the broadcast carried.
I checked it fails against the old order, with the message it was written for:
*"the post went out before its pictures were on it"*.

Closes #13

An AI agent wrote this text in my name. I know that is problematic.
