### PR TITLE
Settle which cursor wins when a client sends both, then use the one answer

### DIFF
--- a/lib/abuuba/notifications.ex
+++ b/lib/abuuba/notifications.ex
@@ -854,17 +854,13 @@ defmodule Abuuba.Notifications do
 
   defp paginate(query, page) do
     query
-    |> older_than(Map.get(page, :max_id))
-    |> newer_than(Map.get(page, :min_id) || Map.get(page, :since_id))
-    |> order_by([n], [{^Pagination.direction(page), n.id}])
-    |> limit(^Map.get(page, :limit, 40))
+    |> Pagination.window(Map.put_new(page, :limit, 40))
     |> Repo.all()
     |> Pagination.reading_order(page)
   end
 
-  defp older_than(query, nil), do: query
-  defp older_than(query, id), do: where(query, [n], n.id < ^id)
-
+  # Still here for the unread counts, which bound on an id a caller passed
+  # rather than on a page's cursors.
   defp newer_than(query, nil), do: query
   defp newer_than(query, id), do: where(query, [n], n.id > ^id)
 end

--- a/lib/abuuba/pagination.ex
+++ b/lib/abuuba/pagination.ex
@@ -45,6 +45,18 @@ defmodule Abuuba.Pagination do
   Both bounds are exclusive, matching the reference implementation: a client
   that passes back the id it last saw must not receive it again, or it pages
   forever.
+
+  A client sending `min_id` and `since_id` together gets the `min_id`
+  behaviour and the other is ignored, which is what the reference does --
+  `Paginable.to_a_paginated_by_id` branches on `min_id` being present and
+  never reads `since_id` in that branch. `min_id` names the gap being filled
+  and a second lower bound would cut a hole in it.
+
+  This function used to resolve the pair the other way round while
+  `direction/1` two functions up flipped to `:asc` on `min_id`, so a client
+  sending both got an ascending page from a `since_id` bound -- neither of the
+  two behaviours it could have asked for. Three contexts had grown their own
+  copy with the right order, which is how the disagreement was found.
   """
   @spec window(Ecto.Queryable.t(), map()) :: Ecto.Query.t()
   def window(query, page) do
@@ -58,7 +70,7 @@ defmodule Abuuba.Pagination do
       end
     end)
     |> then(fn q ->
-      case Map.get(page, :since_id) || Map.get(page, :min_id) do
+      case Map.get(page, :min_id) || Map.get(page, :since_id) do
         nil -> q
         after_id -> where(q, [x], x.id > ^after_id)
       end

--- a/lib/abuuba/statuses.ex
+++ b/lib/abuuba/statuses.ex
@@ -1285,6 +1285,7 @@ defmodule Abuuba.Statuses do
     |> maybe_language(Keyword.get(opts, :language))
     |> paginate(opts)
     |> Repo.all()
+    |> reading_order(opts)
   end
 
   @doc """
@@ -1327,27 +1328,30 @@ defmodule Abuuba.Statuses do
   defp maybe_language(query, language), do: from(s in query, where: s.language == ^language)
 
   # Ids sort by creation time, so they are the cursor. See `Abuuba.Snowflake`.
+  # `min_id` runs the query the other way up, so the rows come back oldest
+  # first and have to be turned round before anybody reads them. These two
+  # take a keyword list where `Abuuba.Pagination` takes a map, which is the
+  # only reason this is not a straight call to `reading_order/2`.
+  defp reading_order(rows, opts) do
+    Pagination.reading_order(rows, %{min_id: Keyword.get(opts, :min_id)})
+  end
+
   defp paginate(query, opts) do
     # Clamped at both ends. A negative limit reaches Postgres as LIMIT -1 and
     # errors; a zero one silently returns nothing, which reads as "no posts"
     # rather than as the bad request it is.
     limit = opts |> Keyword.get(:limit, 20) |> max(1) |> min(40)
 
-    query
-    |> then(fn q ->
-      case Keyword.get(opts, :max_id) do
-        nil -> q
-        max_id -> from(s in q, where: s.id < ^max_id)
-      end
-    end)
-    |> then(fn q ->
-      case Keyword.get(opts, :since_id) do
-        nil -> q
-        since_id -> from(s in q, where: s.id > ^since_id)
-      end
-    end)
-    |> order_by([s], desc: s.id)
-    |> limit(^limit)
+    # Through `Pagination.window/2` like every other list, which is also how
+    # this one gets a `min_id` at all: it had a `max_id` and a `since_id` and
+    # no third branch, so a client filling a gap forwards was answered from
+    # the newest end and read the same page over and over.
+    Pagination.window(query, %{
+      max_id: Keyword.get(opts, :max_id),
+      min_id: Keyword.get(opts, :min_id),
+      since_id: Keyword.get(opts, :since_id),
+      limit: limit
+    })
   end
 
   @doc """
@@ -1562,6 +1566,7 @@ defmodule Abuuba.Statuses do
     |> where([_s, st], st.tag_id == ^tag_id)
     |> paginate(opts)
     |> Repo.all()
+    |> reading_order(opts)
   end
 
   ## Favourites and bookmarks
@@ -2789,10 +2794,7 @@ defmodule Abuuba.Statuses do
     |> maybe_exclude_reblogs(Map.get(page, :exclude_reblogs, false))
     |> maybe_only_media(Map.get(page, :only_media, false))
     |> maybe_tagged(Map.get(page, :tagged))
-    |> maybe_before_id(Map.get(page, :max_id))
-    |> maybe_after_id(Map.get(page, :min_id) || Map.get(page, :since_id))
-    |> order_by([s], [{^Pagination.direction(page), s.id}])
-    |> limit(^Map.get(page, :limit, 20))
+    |> Pagination.window(page)
     |> Repo.all()
     |> Pagination.reading_order(page)
   end
@@ -2826,12 +2828,6 @@ defmodule Abuuba.Statuses do
 
     where(query, [s], s.id in subquery(tagged))
   end
-
-  defp maybe_before_id(query, nil), do: query
-  defp maybe_before_id(query, id), do: where(query, [s], s.id < ^id)
-
-  defp maybe_after_id(query, nil), do: query
-  defp maybe_after_id(query, id), do: where(query, [s], s.id > ^id)
 
   @doc """
   What somebody favourited, newest mark first, as `%{mark_id, status}` rows.

--- a/lib/abuuba/timelines.ex
+++ b/lib/abuuba/timelines.ex
@@ -283,30 +283,14 @@ defmodule Abuuba.Timelines do
     end
   end
 
+  # The precedence this used to argue for in a comment now lives in
+  # `Pagination.window/2`, which is where the disagreement was.
   defp paginate(query, page) do
-    # `since_id` yields to `min_id` when a client sends both, matching the
-    # reference implementation: `min_id` names the gap being filled, and a
-    # second lower bound would cut a hole in it.
-    since_id = if Map.get(page, :min_id), do: nil, else: Map.get(page, :since_id)
-
     query
-    |> maybe_before(Map.get(page, :max_id))
-    |> maybe_since(since_id)
-    |> maybe_after(Map.get(page, :min_id))
-    |> order_by([s], [{^Pagination.direction(page), s.id}])
-    |> limit(^Map.get(page, :limit, 20))
+    |> Pagination.window(page)
     |> Repo.all()
     |> Pagination.reading_order(page)
   end
-
-  defp maybe_before(query, nil), do: query
-  defp maybe_before(query, id), do: where(query, [s], s.id < ^id)
-
-  defp maybe_since(query, nil), do: query
-  defp maybe_since(query, id), do: where(query, [s], s.id > ^id)
-
-  defp maybe_after(query, nil), do: query
-  defp maybe_after(query, id), do: where(query, [s], s.id > ^id)
 
   @doc """
   What the people in one list said.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.11",
+      version: "1.0.12",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba/pagination_test.exs
+++ b/test/abuuba/pagination_test.exs
@@ -1,0 +1,75 @@
+defmodule Abuuba.PaginationTest do
+  @moduledoc """
+  What a client gets back when it sends more than one cursor.
+
+  `min_id` and `since_id` are both lower bounds and they mean different
+  things: `since_id` asks for the newest page after an id, `min_id` for the
+  oldest, which is how a client fills a gap forwards. A client that sends both
+  has to get one of the two behaviours rather than a blend of them.
+
+  `Pagination.window/2` resolved the pair one way and three contexts had grown
+  their own copy resolving it the other, one of them with a comment arguing
+  for its order. This is where that is settled, so the next context to want it
+  finds an answer rather than a fourth opinion.
+  """
+  use Abuuba.DataCase, async: true
+
+  import Abuuba.AccountsFixtures
+  import Abuuba.StatusesFixtures
+
+  alias Abuuba.Pagination
+  alias Abuuba.Statuses.Status
+
+  setup do
+    author = account_fixture()
+    posts = for _ <- 1..5, do: status_fixture(%{account_id: author.id})
+
+    %{posts: posts}
+  end
+
+  defp ids(page) do
+    Status
+    |> Pagination.window(page)
+    |> Repo.all()
+    |> Pagination.reading_order(page)
+    |> Enum.map(& &1.id)
+  end
+
+  test "min_id wins over since_id, and since_id is not applied as well", %{posts: posts} do
+    [first, second, _third, _fourth, fifth] = Enum.map(posts, & &1.id)
+
+    # The reference branches on `min_id` being present and never reads
+    # `since_id` in that branch. Applying both would put a second lower bound
+    # on the window and cut a hole in the gap `min_id` named.
+    assert ids(%{min_id: first, since_id: fifth}) == ids(%{min_id: first})
+
+    # And it is genuinely the `min_id` behaviour: the oldest side of the gap,
+    # not the newest.
+    assert ids(%{min_id: first, since_id: fifth, limit: 2}) ==
+             Enum.reverse([second, Enum.at(Enum.map(posts, & &1.id), 2)])
+  end
+
+  test "since_id alone still bounds from the newest end", %{posts: posts} do
+    [first, _second, _third, fourth, fifth] = Enum.map(posts, & &1.id)
+
+    assert ids(%{since_id: first, limit: 2}) == [fifth, fourth]
+  end
+
+  test "the direction agrees with the bound that was honoured", %{posts: posts} do
+    # `direction/1` flips to `:asc` on `min_id`. While `window/2` preferred
+    # `since_id`, a client sending both got an ascending page from a
+    # `since_id` bound -- neither of the two behaviours it could have asked
+    # for, and no test said so.
+    [first, _second, _third, _fourth, fifth] = Enum.map(posts, & &1.id)
+
+    assert Pagination.direction(%{min_id: first, since_id: fifth}) == :asc
+    assert Pagination.direction(%{since_id: fifth}) == :desc
+  end
+
+  test "both bounds are exclusive", %{posts: posts} do
+    [first, _second, _third, _fourth, fifth] = Enum.map(posts, & &1.id)
+
+    refute first in ids(%{min_id: first})
+    refute fifth in ids(%{max_id: fifth})
+  end
+end

--- a/test/abuuba/statuses_test.exs
+++ b/test/abuuba/statuses_test.exs
@@ -489,6 +489,21 @@ defmodule Abuuba.StatusesTest do
   end
 
   describe "the public timeline" do
+    test "min_id fills a gap forwards, newest first like every other page" do
+      author = account_fixture()
+      [first, second, third] = for _ <- 1..3, do: status_fixture(%{account_id: author.id})
+
+      # This query had `max_id` and `since_id` and no third branch, so a
+      # client filling a gap forwards was answered from the newest end and
+      # read the same page over and over. `min_id` takes the oldest side of
+      # the gap; the rows still arrive newest first, which is what a client
+      # renders.
+      assert Enum.map(Statuses.public_timeline(min_id: first.id, limit: 2), & &1.id) ==
+               [third.id, second.id]
+
+      assert Enum.map(Statuses.public_timeline(min_id: second.id), & &1.id) == [third.id]
+    end
+
     test "shows public posts newest first" do
       first = status_fixture()
       second = status_fixture()


### PR DESCRIPTION
**The disagreement, settled toward the three copies rather than the shared
helper.** `Paginable.to_a_paginated_by_id` in the reference branches on
`min_id` being present and never reads `since_id` in that branch, so `min_id`
wins. The internal argument is stronger still: `Pagination.direction/1` already
flipped to `:asc` on `min_id`, so `window/2` preferring `since_id` handed a
client sending both an ascending page from a `since_id` bound — neither of the
two behaviours it could have asked for, and nothing said so.

`window/2` prefers `min_id` now and the three hand-rolled copies are gone.
`paginate_accounts/2` keeps its own: it windows a joined column, which is the
case `window/2` documents itself as not covering.

**One more gap while in here.** The public and hashtag timelines had `max_id`
and `since_id` and no third branch, so a client filling a gap forwards was
answered from the newest end and read the same page repeatedly. They go through
`window/2` too — which meant adding `reading_order`, since `min_id` runs the
query the other way up and those two returned rows straight from `Repo.all`.

`test/abuuba/pagination_test.exs` is new and holds the precedence, both
directions, and the exclusivity of the bounds. I checked the precedence test
fails against the old order.

Closes #14

An AI agent wrote this text in my name. I know that is problematic.
