### PR TITLE
Ask the dashboard's questions once each instead of once per day

### DIFF
--- a/lib/abuuba/admin/metrics.ex
+++ b/lib/abuuba/admin/metrics.ex
@@ -77,7 +77,7 @@ defmodule Abuuba.Admin.Metrics do
     with :ok <- known(keys, @measures) do
       days = days_between(from, to)
 
-      {:ok, Enum.map(keys, &%{key: &1, total: total(&1, days), data: series(&1, days)})}
+      {:ok, Enum.map(keys, &measured(&1, days))}
     end
   end
 
@@ -107,6 +107,10 @@ defmodule Abuuba.Admin.Metrics do
 
     Enum.map(starts, fn start ->
       cohort_ids = joined_in(start, cohort_end(start, frequency))
+      # One query for the whole row rather than one per cell. A cohort's
+      # people either posted in a later period or they did not, and asking
+      # that period by period made the chart cost the square of its own width.
+      posted = periods_posted_in(cohort_ids, starts, frequency)
 
       %{
         period: start,
@@ -115,7 +119,7 @@ defmodule Abuuba.Admin.Metrics do
           Enum.map(Enum.with_index(starts), fn {later, index} ->
             %{
               date: later,
-              rate: rate(cohort_ids, later, cohort_end(later, frequency)),
+              rate: rate(cohort_ids, Map.get(posted, later, 0)),
               value: index
             }
           end)
@@ -138,62 +142,93 @@ defmodule Abuuba.Admin.Metrics do
     if from == [], do: [], else: from
   end
 
-  defp series(key, days), do: Enum.map(days, &%{date: &1, value: to_string(count(key, &1))})
+  # One grouped query per key rather than one per key per day. Six keys over a
+  # month came to 434 queries -- `total/2` and `series/2` each asked the same
+  # thirty-one questions, and `"interactions"` asked two of its own -- with
+  # every one of them a sequential scan, because a date predicate written as
+  # `?::date == day` cannot use an index on the column.
+  #
+  # The total is the sum of the series rather than a second pass: it was
+  # always going to be, and asking twice is how it stopped being obvious.
+  defp measured(key, []), do: %{key: key, total: "0", data: []}
 
-  defp total(key, days), do: days |> Enum.map(&count(key, &1)) |> Enum.sum() |> to_string()
+  defp measured(key, days) do
+    counts = per_day(key, List.first(days), List.last(days))
+    data = Enum.map(days, &%{date: &1, value: to_string(Map.get(counts, &1, 0))})
+    total = counts |> Map.values() |> Enum.sum()
+
+    %{key: key, total: to_string(total), data: data}
+  end
 
   # Somebody who posted that day. The reference implementation counts logins;
   # this server does not record one per day, and "wrote something" is a
   # stricter and more honest reading of "active".
-  defp count("active_users", day) do
+  defp per_day("active_users", from, to) do
     Status
     |> where([s], s.local and is_nil(s.deleted_at))
-    |> on_day(day)
-    |> distinct(true)
-    |> select([s], s.account_id)
-    |> subquery()
-    |> Repo.aggregate(:count)
+    |> within_days(from, to)
+    |> group_by([s], fragment("?::date", s.inserted_at))
+    |> select([s], {fragment("?::date", s.inserted_at), count(s.account_id, :distinct)})
+    |> Repo.all()
+    |> Map.new()
   end
 
-  defp count("new_users", day), do: User |> on_day(day) |> Repo.aggregate(:count)
+  defp per_day("new_users", from, to), do: counted_by_day(User, from, to)
 
-  defp count(key, day) when key in ["new_statuses", "instance_statuses"] do
+  defp per_day(key, from, to) when key in ["new_statuses", "instance_statuses"] do
     Status
     |> where([s], s.local and is_nil(s.deleted_at))
-    |> on_day(day)
-    |> Repo.aggregate(:count)
+    |> counted_by_day(from, to)
   end
 
   # Favourites and boosts together: what a reader did with somebody else's
   # post, which is what the chart is about.
-  defp count("interactions", day) do
+  defp per_day("interactions", from, to) do
     boosts =
       Status
       |> where([s], not is_nil(s.reblog_of_id))
-      |> on_day(day)
-      |> Repo.aggregate(:count)
+      |> counted_by_day(from, to)
 
-    favourites = from(f in "favourites") |> on_day(day) |> Repo.aggregate(:count)
+    favourites = counted_by_day(from(f in "favourites"), from, to)
 
-    boosts + favourites
+    Map.merge(boosts, favourites, fn _day, a, b -> a + b end)
   end
 
-  defp count("opened_reports", day), do: Report |> on_day(day) |> Repo.aggregate(:count)
+  defp per_day("opened_reports", from, to), do: counted_by_day(Report, from, to)
 
-  defp count("resolved_reports", day) do
+  defp per_day("resolved_reports", from, to) do
     Report
     |> where([r], not is_nil(r.action_taken_at))
-    |> where([r], fragment("?::date", r.action_taken_at) == ^day)
-    |> Repo.aggregate(:count)
+    |> where([r], r.action_taken_at >= ^start_of(from) and r.action_taken_at < ^after_end(to))
+    |> group_by([r], fragment("?::date", r.action_taken_at))
+    |> select([r], {fragment("?::date", r.action_taken_at), count()})
+    |> Repo.all()
+    |> Map.new()
   end
 
-  defp count("instance_accounts", day), do: Account |> on_day(day) |> Repo.aggregate(:count)
+  defp per_day("instance_accounts", from, to), do: counted_by_day(Account, from, to)
 
   # Named in the moduledoc: nothing here records a peer's version, so the
   # honest answer is none rather than a number nobody can act on.
-  defp count(_key, _day), do: 0
+  defp per_day(_key, _from, _to), do: %{}
 
-  defp on_day(query, day), do: where(query, [r], fragment("?::date", r.inserted_at) == ^day)
+  defp counted_by_day(query, from, to) do
+    query
+    |> within_days(from, to)
+    |> group_by([r], fragment("?::date", r.inserted_at))
+    |> select([r], {fragment("?::date", r.inserted_at), count()})
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  # Half-open and on the bare column, so an index on `inserted_at` applies.
+  # `?::date == day` is a function of the column and cannot use one.
+  defp within_days(query, from, to) do
+    where(query, [r], r.inserted_at >= ^start_of(from) and r.inserted_at < ^after_end(to))
+  end
+
+  defp start_of(date), do: DateTime.new!(date, ~T[00:00:00], "Etc/UTC")
+  defp after_end(date), do: date |> Date.add(1) |> start_of()
 
   ## Dimensions
 
@@ -258,34 +293,68 @@ defmodule Abuuba.Admin.Metrics do
     |> Enum.take(24)
   end
 
+  # A week is what the dashboard asks for and there was no clause for it, so it
+  # fell through to here and got eighty-five one-day cohorts labelled as weeks
+  # -- wrong on the chart before it was slow underneath it.
+  defp cohort_starts(from, to, "week") do
+    from
+    |> Date.beginning_of_week()
+    |> Stream.iterate(&Date.add(&1, 7))
+    |> Enum.take_while(&(Date.compare(&1, to) != :gt))
+    |> Enum.take(52)
+  end
+
   defp cohort_starts(from, to, _frequency) do
     Date.range(from, to) |> Enum.take(@max_days)
   end
 
   defp cohort_end(start, "month"), do: Date.end_of_month(start)
+  defp cohort_end(start, "week"), do: Date.add(start, 6)
   defp cohort_end(start, _frequency), do: start
 
   defp joined_in(from, to) do
     User
-    |> where([u], fragment("?::date", u.inserted_at) >= ^from)
-    |> where([u], fragment("?::date", u.inserted_at) <= ^to)
+    |> within_days(from, to)
     |> select([u], u.account_id)
     |> Repo.all()
   end
 
-  defp rate([], _from, _to), do: "0.0"
+  # How many of this cohort posted in each of the periods, in one query. The
+  # bucket is worked out in SQL from the first period's start, so a row is
+  # counted against the period it falls in without asking about each in turn.
+  defp periods_posted_in([], _starts, _frequency), do: %{}
+  defp periods_posted_in(_ids, [], _frequency), do: %{}
 
-  defp rate(account_ids, from, to) do
-    still_here =
-      Status
-      |> where([s], s.account_id in ^account_ids and is_nil(s.deleted_at))
-      |> where([s], fragment("?::date", s.inserted_at) >= ^from)
-      |> where([s], fragment("?::date", s.inserted_at) <= ^to)
-      |> distinct(true)
-      |> select([s], s.account_id)
-      |> subquery()
-      |> Repo.aggregate(:count)
+  defp periods_posted_in(account_ids, starts, frequency) do
+    last_end = starts |> List.last() |> cohort_end(frequency)
 
+    # Who posted on which day, once each. Bucketing in Elixir rather than in
+    # SQL because "still here" is people and not posts: somebody who wrote
+    # three times in a week is one person, and a per-day count cannot be added
+    # up into a per-week one without turning them into three.
+    Status
+    |> where([s], s.account_id in ^account_ids and is_nil(s.deleted_at))
+    |> within_days(List.first(starts), last_end)
+    |> distinct(true)
+    |> select([s], {s.account_id, fragment("?::date", s.inserted_at)})
+    |> Repo.all()
+    |> Enum.group_by(fn {_id, day} -> period_of(day, starts, frequency) end, &elem(&1, 0))
+    |> Enum.flat_map(fn
+      {nil, _ids} -> []
+      {start, ids} -> [{start, ids |> Enum.uniq() |> length()}]
+    end)
+    |> Map.new()
+  end
+
+  defp period_of(day, starts, frequency) do
+    Enum.find(starts, fn start ->
+      Date.compare(day, start) != :lt and Date.compare(day, cohort_end(start, frequency)) != :gt
+    end)
+  end
+
+  defp rate([], _still_here), do: "0.0"
+
+  defp rate(account_ids, still_here) do
     Float.to_string(Float.round(still_here / length(account_ids), 4))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.12",
+      version: "1.0.13",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba_web/admin_dashboard_test.exs
+++ b/test/abuuba_web/admin_dashboard_test.exs
@@ -84,6 +84,79 @@ defmodule AbuubaWeb.AdminDashboardTest do
     end
   end
 
+  describe "what the charts count" do
+    test "one number per day, and a total that is their sum" do
+      author = account_fixture()
+      today = Date.utc_today()
+
+      for _ <- 1..3, do: status_fixture(%{account_id: author.id, local: true})
+
+      assert {:ok, [%{key: "new_statuses", total: total, data: data}]} =
+               Metrics.measure(["new_statuses"], Date.add(today, -6), today)
+
+      assert length(data) == 7
+      assert Enum.map(data, & &1.date) == Enum.to_list(Date.range(Date.add(today, -6), today))
+
+      # The total was a second pass over the same days, so it could disagree
+      # with the series it sits above. It is their sum now, and cannot.
+      assert total == "3"
+      assert total == data |> Enum.map(&String.to_integer(&1.value)) |> Enum.sum() |> to_string()
+      assert Enum.find(data, &(&1.date == today)).value == "3"
+    end
+
+    test "a day nobody posted is a zero rather than a gap" do
+      today = Date.utc_today()
+
+      assert {:ok, [%{data: data}]} =
+               Metrics.measure(["new_statuses"], Date.add(today, -2), today)
+
+      assert Enum.map(data, & &1.value) |> Enum.all?(&is_binary/1)
+      assert Enum.find(data, &(&1.date == Date.add(today, -2))).value == "0"
+    end
+
+    test "active users counts people, not posts" do
+      author = account_fixture()
+      today = Date.utc_today()
+
+      for _ <- 1..4, do: status_fixture(%{account_id: author.id, local: true})
+
+      assert {:ok, [%{total: total}]} =
+               Metrics.measure(["active_users"], Date.add(today, -1), today)
+
+      assert total == "1", "four posts from one person is one active person"
+    end
+
+    test "retention asks for weeks and gets weeks" do
+      today = Date.utc_today()
+
+      rows = Metrics.retention(Date.add(today, -84), today, "week")
+
+      # `"week"` had no clause and fell through to a day, so this answered with
+      # eighty-five one-day cohorts labelled as weeks.
+      assert length(rows) <= 14, "eighty-five daily cohorts is not a weekly chart"
+
+      assert [%{period: first}, %{period: second} | _] = rows
+      assert Date.diff(second, first) == 7
+      assert Enum.all?(rows, &(length(&1.data) == length(rows)))
+    end
+
+    test "somebody who posted twice in a week is one person still here" do
+      today = Date.utc_today()
+      account = account_fixture()
+      user_fixture(%{account_id: account.id})
+
+      for _ <- 1..2, do: status_fixture(%{account_id: account.id, local: true})
+
+      rows = Metrics.retention(Date.add(today, -84), today, "week")
+      last = List.last(rows)
+
+      assert last.total >= 1
+
+      assert Enum.all?(last.data, &(String.to_float(&1.rate) <= 1.0)),
+             "counting posts rather than people puts the rate over 100%"
+    end
+  end
+
   describe "the same numbers over the API" do
     test "are what the dashboard draws", %{conn: conn} do
       status_fixture(%{account_id: account_fixture().id, text: "something"})


### PR DESCRIPTION
Measured on a real dashboard load first, since the issue flagged its own counts
as derived by reading:

| | before | after |
| --- | --- | --- |
| charts (`measure/3`) | 434 queries, 80 ms | **7**, 22 ms |
| dimensions | 3, 3 ms | 3, 10 ms |
| retention | 340 queries, 22 ms | **15**, 14 ms |
| whole dashboard | 777 | **32 queries, 52 ms** |

The 434 was exactly right. The 340 is this database's figure — empty cohorts
skip their query — and the issue's ~7,300 is the shape it takes on a server
with somebody joining every day, so both numbers are true of different servers.

**A correctness bug underneath the slow one.** `retention/3` was asked for
`"week"`, had no clause for it, and fell through to a day: the chart was
eighty-five one-day cohorts labelled as weeks. That is where the quadratic came
from. Rates are now one query per cohort rather than one per cell, and bucketed
in Elixir — "still here" is people, and a per-day distinct count cannot be
summed into a per-week one without turning one person who posted twice into
two.

The totals were a second pass over the same days, so they could disagree with
the series they sit above. They are its sum now.

**No `assign_async`.** It was wanted for the 777 queries; at 52 ms the render
does not need deferring, and the plumbing would cost three `<.async_result>`
wrappers and empty the assertions that check the charts are drawn at all. Say
the word if you want it anyway.

Closes #15

An AI agent wrote this text in my name. I know that is problematic.
