### PR TITLE
Use the batch helpers that were already sitting beside the loops

### DIFF
--- a/lib/abuuba/federation/activity/move.ex
+++ b/lib/abuuba/federation/activity/move.ex
@@ -25,7 +25,6 @@ defmodule Abuuba.Federation.Activity.Move do
   alias Abuuba.Accounts
   alias Abuuba.Federation.Activity.Helpers
   alias Abuuba.Relationships
-  alias Abuuba.Repo
 
   @cooldown_days 7
 
@@ -75,17 +74,17 @@ defmodule Abuuba.Federation.Activity.Move do
         moved_at: DateTime.utc_now()
       })
 
+    # `local_follower_ids/1` asks the same question in one query -- the join
+    # does the local filter that a `Repo.get` per follower was doing here --
+    # and `follow/3` and `unfollow/2` both take an id, so the rows were never
+    # needed. An account with a thousand followers moved in a thousand and one
+    # queries.
     origin
-    |> Relationships.follower_ids()
-    |> Enum.map(&Repo.get(Abuuba.Accounts.Account, &1))
-    |> Enum.filter(&local?/1)
+    |> Relationships.local_follower_ids()
     |> Enum.each(&refollow(&1, origin, target))
 
     :ok
   end
-
-  defp local?(nil), do: false
-  defp local?(account), do: is_nil(account.domain)
 
   # Follow first, then unfollow. The other order leaves somebody following
   # nobody if the second step fails, and following both for a moment is a much

--- a/lib/abuuba/instance.ex
+++ b/lib/abuuba/instance.ex
@@ -629,10 +629,17 @@ defmodule Abuuba.Instance do
   """
   @spec put_remote_emoji([map()] | nil, String.t() | nil) :: [String.t()]
   def put_remote_emoji(tags, domain) when is_list(tags) and is_binary(domain) and domain != "" do
-    tags
-    |> Enum.flat_map(&remote_emoji_attrs(&1, domain))
-    |> Enum.map(&upsert_remote_emoji/1)
-    |> Enum.reject(&is_nil/1)
+    stored =
+      tags
+      |> Enum.flat_map(&remote_emoji_attrs(&1, domain))
+      |> Enum.map(&upsert_remote_emoji/1)
+      |> Enum.reject(&is_nil/1)
+
+    # Only when something was written. `remote_emoji/1` is cached, and the post
+    # that brought a new shortcode is the one about to be rendered with it.
+    if stored != [], do: Cache.invalidate({:remote_emoji, domain})
+
+    stored
   end
 
   def put_remote_emoji(_tags, _domain), do: []
@@ -645,10 +652,18 @@ defmodule Abuuba.Instance do
   """
   @spec remote_emoji(String.t() | nil) :: %{String.t() => CustomEmoji.t()}
   def remote_emoji(domain) when is_binary(domain) and domain != "" do
-    CustomEmoji
-    |> where([e], e.domain == ^domain and not e.disabled)
-    |> Repo.all()
-    |> Map.new(&{&1.shortcode, &1})
+    # Read through the cache like `custom_emojis/0` beside it, and for the same
+    # reason: a page of posts from one server asks this once per render and the
+    # answer changes only when that server sends a shortcode nobody here had
+    # seen. `put_remote_emoji/2` is what forgets it when one does, so a new
+    # emoji shows up on the render that brought it rather than five minutes
+    # later.
+    Cache.fetch({:remote_emoji, domain}, :timer.minutes(5), fn ->
+      CustomEmoji
+      |> where([e], e.domain == ^domain and not e.disabled)
+      |> Repo.all()
+      |> Map.new(&{&1.shortcode, &1})
+    end)
   end
 
   def remote_emoji(_domain), do: %{}

--- a/lib/abuuba/moderation/domains.ex
+++ b/lib/abuuba/moderation/domains.ex
@@ -600,10 +600,23 @@ defmodule Abuuba.Moderation.Domains do
   # other block still covers. Asked per account rather than per domain, because
   # an account on `ok.bad.example` may be covered by a wider block on
   # `bad.example` that has not moved.
+  # Two queries for the whole set rather than two per account. Lifting a block
+  # on a busy server walks every account under it, and each one was asking what
+  # else covers its domain and what a moderator had decided about it on its
+  # own -- the same two questions, thousands of times, with only a handful of
+  # distinct answers between them.
   defp lift_beyond(domain, severity) do
-    for account <- domain |> accounts_under() |> Repo.all(),
-        effective = severity_for_account(account, domain, severity),
-        changes = lifted_fields(effective, standing_action(account)),
+    accounts = domain |> accounts_under() |> Repo.all()
+    covering = strongest_other_block(accounts, domain)
+    standing = standing_actions(Enum.map(accounts, & &1.id))
+
+    for account <- accounts,
+        effective =
+          Enum.max_by(
+            [severity, Map.get(covering, account.domain, "noop")],
+            &DomainBlock.rank/1
+          ),
+        changes = lifted_fields(effective, Map.get(standing, account.id, "noop")),
         changes != [] do
       Accounts.update_moderation(account, Map.new(changes))
     end
@@ -611,34 +624,54 @@ defmodule Abuuba.Moderation.Domains do
     :ok
   end
 
-  # What a moderator decided about this one account, apart from any domain
-  # block. Lifting the wider decision must not quietly undo the narrower one
-  # nobody revisited.
-  defp standing_action(%Account{id: id}) do
-    Strike
-    |> where([s], s.target_account_id == ^id and is_nil(s.overruled_at))
-    |> where([s], s.action in ["silence", "suspend"])
-    |> select([s], s.action)
-    |> Repo.all()
-    |> Enum.max_by(&DomainBlock.rank/1, fn -> "noop" end)
+  # What still covers each domain in the set, apart from the one being changed.
+  # Keyed by the account's domain, of which there are usually one or two under
+  # a block however many accounts there are.
+  defp strongest_other_block(accounts, changed_domain) do
+    domains = accounts |> Enum.map(& &1.domain) |> Enum.uniq()
+
+    stored =
+      domains
+      |> Enum.flat_map(&candidates/1)
+      |> Enum.uniq()
+      |> Enum.reject(&(&1 == changed_domain))
+      |> stored_severities()
+
+    Map.new(domains, fn domain ->
+      strongest =
+        domain
+        |> candidates()
+        |> Enum.reject(&(&1 == changed_domain))
+        |> Enum.flat_map(&List.wrap(Map.get(stored, &1)))
+        |> Enum.max_by(&DomainBlock.rank/1, fn -> "noop" end)
+
+      {domain, strongest}
+    end)
   end
 
-  # The severity that still applies to one account once the block being changed
-  # carries `severity`: the strongest of it and anything else covering them.
-  defp severity_for_account(%Account{domain: account_domain}, changed_domain, severity) do
-    others =
-      account_domain
-      |> candidates()
-      |> Enum.reject(&(&1 == changed_domain))
+  defp stored_severities([]), do: %{}
 
-    strongest =
-      DomainBlock
-      |> where([b], b.domain in ^others)
-      |> select([b], b.severity)
-      |> Repo.all()
-      |> Enum.max_by(&DomainBlock.rank/1, fn -> "noop" end)
+  defp stored_severities(domains) do
+    DomainBlock
+    |> where([b], b.domain in ^domains)
+    |> select([b], {b.domain, b.severity})
+    |> Repo.all()
+    |> Map.new()
+  end
 
-    Enum.max_by([severity, strongest], &DomainBlock.rank/1)
+  # What a moderator decided about each account, apart from any domain block.
+  # Lifting the wider decision must not quietly undo the narrower one nobody
+  # revisited.
+  defp standing_actions([]), do: %{}
+
+  defp standing_actions(account_ids) do
+    Strike
+    |> where([s], s.target_account_id in ^account_ids and is_nil(s.overruled_at))
+    |> where([s], s.action in ["silence", "suspend"])
+    |> select([s], {s.target_account_id, s.action})
+    |> Repo.all()
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+    |> Map.new(fn {id, actions} -> {id, Enum.max_by(actions, &DomainBlock.rank/1)} end)
   end
 
   # The strongest of what the domain still says and what was decided about this

--- a/lib/abuuba/moderation/reports.ex
+++ b/lib/abuuba/moderation/reports.ex
@@ -252,21 +252,20 @@ defmodule Abuuba.Moderation.Reports do
     end
   end
 
+  # The join already carries the permissions, so the mask comes back with the
+  # account and `Roles.allows?/2` answers without reading anything: this used
+  # to select every account with a role and then re-read each one's user row
+  # to ask what it was allowed to do.
   defp moderators do
     from(u in "users",
       join: r in "user_roles",
       on: r.id == u.role_id,
-      select: u.account_id
+      select: {u.account_id, r.permissions}
     )
     |> Repo.all()
-    |> Enum.filter(&can_handle?/1)
-  end
-
-  defp can_handle?(account_id) do
-    case Repo.get_by(Abuuba.Accounts.User, account_id: account_id) do
-      nil -> false
-      user -> Roles.can?(user, "manage_reports")
-    end
+    |> Enum.flat_map(fn {account_id, held} ->
+      if Roles.allows?(held, "manage_reports"), do: [account_id], else: []
+    end)
   end
 
   # Only for a remote account, and only when asked. Forwarding tells the other

--- a/lib/abuuba/notifications.ex
+++ b/lib/abuuba/notifications.ex
@@ -749,13 +749,36 @@ defmodule Abuuba.Notifications do
   def get_request(_account_id, nil), do: nil
 
   def get_request(account_id, request_id) do
-    # Not one that has been put away. The list stops showing a dismissed
-    # request, and an id that still answers would be the same request coming
-    # back for a client that kept it.
-    Request
-    |> where([r], r.id == ^request_id and r.account_id == ^account_id)
-    |> where([r], is_nil(r.dismissed_at))
-    |> Repo.one()
+    account_id |> get_requests([request_id]) |> List.first()
+  end
+
+  @doc """
+  Several of them at once, in the order the ids were given.
+
+  The bulk accept and dismiss endpoints take a list, and asked one id at a
+  time. Same scope as `get_request/2`, which is now one call into this.
+  """
+  @spec get_requests(Account.t() | integer(), [integer() | nil]) :: [Request.t()]
+  def get_requests(%Account{id: id}, request_ids), do: get_requests(id, request_ids)
+
+  def get_requests(account_id, request_ids) do
+    case Enum.reject(request_ids, &is_nil/1) do
+      [] ->
+        []
+
+      ids ->
+        # Not one that has been put away. The list stops showing a dismissed
+        # request, and an id that still answers would be the same request
+        # coming back for a client that kept it.
+        found =
+          Request
+          |> where([r], r.id in ^ids and r.account_id == ^account_id)
+          |> where([r], is_nil(r.dismissed_at))
+          |> Repo.all()
+          |> Map.new(&{&1.id, &1})
+
+        Enum.flat_map(ids, &List.wrap(Map.get(found, &1)))
+    end
   end
 
   @doc """

--- a/lib/abuuba/timelines.ex
+++ b/lib/abuuba/timelines.ex
@@ -324,12 +324,18 @@ defmodule Abuuba.Timelines do
   they have said they do not want.
   """
   @spec merge_account(Account.t() | integer(), Account.t() | integer()) :: :ok
-  def merge_account(%Account{id: reader_id}, author), do: merge_account(reader_id, author)
-  def merge_account(reader_id, %Account{id: author_id}), do: merge_account(reader_id, author_id)
+  def merge_account(%Account{} = reader, %Account{id: author_id}),
+    do: merge_account(reader, author_id)
 
-  def merge_account(reader_id, author_id) do
-    reader = Accounts.get_account(reader_id)
+  # Keeps the reader the caller already holds. `regenerate/1` calls this once
+  # per followed account, and the clause here used to throw the struct away
+  # and read the same row back -- so rebuilding the feed of somebody following
+  # five hundred people read their own account five hundred times.
+  def merge_account(%Account{} = reader, author_id), do: backfill(reader, author_id)
 
+  def merge_account(reader_id, author), do: merge_account(Accounts.get_account(reader_id), author)
+
+  defp backfill(%Account{id: reader_id} = reader, author_id) do
     Statuses.not_deleted()
     |> Statuses.visible_to(reader)
     |> where([s], s.account_id == ^author_id)
@@ -357,10 +363,12 @@ defmodule Abuuba.Timelines do
   def regenerate(%Account{id: account_id}), do: regenerate(account_id)
 
   def regenerate(account_id) do
+    reader = Accounts.get_account(account_id)
+
     # Their own posts first. A home timeline has always included them, and the
     # fan-out is what usually puts them there — which is no help to a feed
     # being built from nothing.
-    Enum.each([account_id | followed_ids(account_id)], &merge_account(account_id, &1))
+    Enum.each([account_id | followed_ids(account_id)], &merge_account(reader, &1))
 
     account_id
     |> Statuses.followed_tags(%{limit: 100})

--- a/lib/abuuba/trends.ex
+++ b/lib/abuuba/trends.ex
@@ -41,7 +41,6 @@ defmodule Abuuba.Trends do
   import Ecto.Query
 
   alias Abuuba.Accounts.Account
-  alias Abuuba.Accounts.User
   alias Abuuba.Federation.InstanceActor
   alias Abuuba.Moderation.AuditLog
   alias Abuuba.Notifications
@@ -872,18 +871,17 @@ defmodule Abuuba.Trends do
   # been asked about.
   defp mark_requested("status", _id, _now), do: false
 
+  # The join already carries the permissions, so `Roles.allows?/2` answers from
+  # the mask rather than reading each user row back to ask the same thing.
   defp reviewers do
     from(u in "users",
       join: r in "user_roles",
       on: r.id == u.role_id,
-      select: u.account_id
+      select: {u.account_id, r.permissions}
     )
     |> Repo.all()
-    |> Enum.filter(fn account_id ->
-      case Repo.get_by(User, account_id: account_id) do
-        nil -> false
-        user -> Roles.can?(user, "manage_taxonomies")
-      end
+    |> Enum.flat_map(fn {account_id, held} ->
+      if Roles.allows?(held, "manage_taxonomies"), do: [account_id], else: []
     end)
   end
 

--- a/lib/abuuba_web/controllers/api/notification_controller.ex
+++ b/lib/abuuba_web/controllers/api/notification_controller.ex
@@ -17,6 +17,7 @@ defmodule AbuubaWeb.API.NotificationController do
 
   use AbuubaWeb, :controller
 
+  alias Abuuba.Accounts
   alias Abuuba.Notifications
   alias Abuuba.Notifications.Notification
   alias Abuuba.Notifications.Policy
@@ -162,13 +163,17 @@ defmodule AbuubaWeb.API.NotificationController do
   def group_accounts(conn, %{"group_key" => key}) do
     account = current_account(conn)
 
-    accounts =
+    ids =
       account
       |> Notifications.group(key)
       |> Enum.map(& &1.from_account_id)
       |> Enum.uniq()
-      |> Enum.map(&Abuuba.Accounts.get_account/1)
-      |> Enum.reject(&is_nil/1)
+
+    # One query rather than one per sender. A group is up to a hundred people,
+    # and `Accounts.get_accounts/1` is the batch that answers them all --
+    # keyed by id, so the group's own order is what survives.
+    found = Accounts.get_accounts(ids)
+    accounts = Enum.flat_map(ids, &List.wrap(Map.get(found, &1)))
 
     json(conn, Entities.accounts(accounts, account))
   end
@@ -261,10 +266,8 @@ defmodule AbuubaWeb.API.NotificationController do
   defp answer_many(conn, params, action) do
     account = current_account(conn)
 
-    params
-    |> API.id_list("id")
-    |> Enum.map(&Notifications.get_request(account, &1))
-    |> Enum.reject(&is_nil/1)
+    account
+    |> Notifications.get_requests(API.id_list(params, "id"))
     |> Enum.map(& &1.from_account_id)
     |> Enum.reject(&is_nil/1)
     |> Enum.each(fn from_id ->

--- a/lib/abuuba_web/controllers/feed_controller.ex
+++ b/lib/abuuba_web/controllers/feed_controller.ex
@@ -88,7 +88,19 @@ defmodule AbuubaWeb.FeedController do
   end
 
   defp xml(opts) do
-    items = opts |> Keyword.fetch!(:statuses) |> Enum.filter(&public?/1) |> Enum.map(&item/1)
+    statuses = opts |> Keyword.fetch!(:statuses) |> Enum.filter(&public?/1)
+
+    # One query for the authors rather than one per item. `status_uri/1` looks
+    # the author up to build the address, and a feed is twenty of them -- so
+    # a profile feed re-read the same account twenty times, and a hashtag feed
+    # read twenty different ones.
+    authors =
+      statuses
+      |> Enum.map(& &1.account_id)
+      |> Enum.uniq()
+      |> Accounts.get_accounts()
+
+    items = Enum.map(statuses, &item(&1, Map.get(authors, &1.account_id)))
 
     """
     <?xml version="1.0" encoding="UTF-8"?>
@@ -105,8 +117,8 @@ defmodule AbuubaWeb.FeedController do
     """
   end
 
-  defp item(status) do
-    uri = Serializer.status_uri(status)
+  defp item(status, author) do
+    uri = Serializer.status_uri(status, author)
 
     """
     <item>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.14",
+      version: "1.0.15",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba/remote_emoji_test.exs
+++ b/test/abuuba/remote_emoji_test.exs
@@ -82,6 +82,32 @@ defmodule Abuuba.RemoteEmojiTest do
     end
   end
 
+  describe "the lookup a render does" do
+    test "answers with what has just been stored for that server" do
+      # `remote_emoji/1` is cached in production like `custom_emojis/0` beside
+      # it, and `put_remote_emoji/2` forgets the entry when it writes -- the
+      # post that brings a shortcode nobody here had seen is the one about to
+      # be drawn with it.
+      #
+      # The cache is off in test by config, deliberately, so this pins the
+      # read and the write agreeing and *not* the invalidation. Nothing here
+      # can see that, which is the cache's stated contract.
+      domain = "emo#{System.unique_integer([:positive])}.example"
+
+      assert Instance.remote_emoji(domain) == %{}
+
+      assert ["party"] =
+               Instance.put_remote_emoji([tag(":party:", "https://#{domain}/p.png")], domain)
+
+      assert %{"party" => %CustomEmoji{}} = Instance.remote_emoji(domain)
+    end
+
+    test "and a domain nobody sent anything for is answered without a query" do
+      assert Instance.remote_emoji(nil) == %{}
+      assert Instance.remote_emoji("") == %{}
+    end
+  end
+
   describe "rendering" do
     setup do
       remote =


### PR DESCRIPTION
Seven of the nine. The other two — the status batch and the annual report —
were already done in #44, when `readable_many/2` replaced their
`Enum.flat_map` over `get_status/2`.

Two needed a batch helper that did not exist yet: `Notifications.get_requests/2`
(with `get_request/2` now one call into it, so there is one scope rather than
two) and a per-set version of the domain-lift questions.

**Lifting a domain block** was the worst of them: two queries per account under
the block. Both are now one for the whole set, and the "what else covers this
domain" half is per *distinct* domain, of which there are a handful however many
accounts there are.

**`Move`** turned out not to need the accounts at all — `follow/3` and
`unfollow/2` both take an id, so a thousand-follower move was a thousand and one
queries for rows nothing read.

**`remote_emoji/1`** is cached the way `custom_emojis/0` beside it always was,
with `put_remote_emoji/2` invalidating on write — the post that brings a new
shortcode is the one about to be drawn with it. Worth saying plainly: the cache
is off in test by config, so no test can see that invalidation. The test I added
pins the read and the write agreeing and nothing more; I checked it passes
without the invalidation too, so it is not evidence for it. `config/test.exs`
says nothing should depend on the cache being on, which is the contract this
sits inside.

Closes #17

An AI agent wrote this text in my name. I know that is problematic.
