### PR TITLE
Recompute the compose preview only when what it is made of changed

### DIFF
--- a/lib/abuuba/accounts.ex
+++ b/lib/abuuba/accounts.ex
@@ -363,6 +363,76 @@ defmodule Abuuba.Accounts do
 
   def lookup(_handle), do: nil
 
+  @doc """
+  The same for several handles at once, keyed by the handle as it was given.
+
+  One query rather than one per handle. The compose box renders a preview of
+  what is being written on every keystroke, and resolving each `@mention`
+  separately made a post naming four people four round trips per render.
+
+  Handles that name nobody are simply absent, the way `lookup/1` answers `nil`.
+  """
+  @spec lookup_many([String.t()]) :: %{String.t() => Account.t()}
+  def lookup_many([]), do: %{}
+
+  def lookup_many(handles) do
+    wanted =
+      handles
+      |> Enum.uniq()
+      |> Enum.flat_map(fn handle ->
+        case split_handle(handle) do
+          nil -> []
+          pair -> [{handle, pair}]
+        end
+      end)
+
+    found = accounts_by_handle(wanted |> Enum.map(&elem(&1, 1)) |> Enum.uniq())
+
+    wanted
+    |> Enum.flat_map(fn {handle, pair} ->
+      case Map.get(found, pair) do
+        nil -> []
+        account -> [{handle, account}]
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp accounts_by_handle([]), do: %{}
+
+  defp accounts_by_handle(pairs) do
+    pairs
+    |> Enum.reduce(Account, fn {username, domain}, query ->
+      or_where(
+        query,
+        [a],
+        fragment("lower(?)", a.username) == ^username and
+          fragment("coalesce(lower(?), '')", a.domain) == ^domain
+      )
+    end)
+    |> Repo.all()
+    |> Map.new(&{{String.downcase(&1.username), String.downcase(&1.domain || "")}, &1})
+  end
+
+  # The three shapes `lookup/1` accepts, as the pair the column comparison
+  # wants: a handle naming this server's own domain is the local account.
+  defp split_handle(handle) when is_binary(handle) do
+    case handle |> String.trim() |> String.trim_leading("@") |> String.split("@") do
+      [username] ->
+        {String.downcase(username), ""}
+
+      [username, domain] ->
+        if URIs.local_domain?(domain),
+          do: {String.downcase(username), ""},
+          else: {String.downcase(username), String.downcase(domain)}
+
+      _ ->
+        nil
+    end
+  end
+
+  defp split_handle(_handle), do: nil
+
   defp lookup_with_domain(username, domain) do
     if URIs.local_domain?(domain) do
       get_account_by_handle(username, nil)

--- a/lib/abuuba_web/live/compose_component.ex
+++ b/lib/abuuba_web/live/compose_component.ex
@@ -49,6 +49,7 @@ defmodule AbuubaWeb.ComposeComponent do
   alias Abuuba.Accounts.PostingDefaults
   alias Abuuba.Accounts.Preferences
   alias Abuuba.ActionLimits
+  alias Abuuba.Federation.URIs
   alias Abuuba.Instance
   alias Abuuba.Media
   alias Abuuba.Media.Attachment
@@ -1431,20 +1432,67 @@ defmodule AbuubaWeb.ComposeComponent do
 
   # Everything the box shows about itself is computed from the draft rather
   # than tracked alongside it, so there is no second copy to fall behind.
+  # Split by what each part actually depends on, because these do not all
+  # change together. `assets/js/compose.js` pushes `caret` on input, keyup and
+  # click, undebounced -- and every one of those used to re-resolve each
+  # `@mention` against the database, ask for the parent author again, and run a
+  # search if the caret happened to sit in a word. A reply opens with an
+  # `@alice @bob ` prefix already in it, so moving the cursor with an arrow key
+  # cost three queries and rendering the whole preview.
   defp derive(socket) do
     draft = socket.assigns.draft
-    {token, suggestions} = suggest(draft)
 
     socket
-    |> assign(
-      form: to_form(draft, as: :draft),
-      preview: Formatter.to_html(draft["text"]),
-      remaining: Instance.max_characters() - length_of(draft),
-      mentions: reply_chips(socket.assigns),
-      token: token,
-      suggestions: suggestions
-    )
+    |> assign(form: to_form(draft, as: :draft))
+    |> derive_from_text(draft)
+    |> derive_suggestions(draft)
   end
+
+  # The preview, the counter and the reply chips: all of the text, none of the
+  # caret. The warning counts towards the length and the parent decides the
+  # chips, so both are part of what says this is unchanged.
+  defp derive_from_text(socket, draft) do
+    key = {draft["text"], warning(draft), reply_to_id(socket.assigns)}
+
+    if socket.assigns[:derived_from] == key do
+      socket
+    else
+      assign(socket,
+        derived_from: key,
+        preview: Formatter.to_html(draft["text"], accounts: mention_links(draft["text"])),
+        remaining: Instance.max_characters() - length_of(draft),
+        mentions: reply_chips(socket.assigns)
+      )
+    end
+  end
+
+  # One query for every handle in the text rather than one each. `to_html/2`
+  # resolves them itself when it is not told, which is a lookup per mention on
+  # every render of a post being written.
+  defp mention_links(text) do
+    text
+    |> Formatter.mentions()
+    |> Accounts.lookup_many()
+    |> Map.new(fn {handle, account} -> {handle, URIs.profile_url(account)} end)
+  end
+
+  # These do move with the caret, which is the one thing that changes on its
+  # own -- but only into a different word, so the same word twice is the same
+  # offer.
+  defp derive_suggestions(socket, draft) do
+    key = {draft["text"], caret(draft)}
+
+    if socket.assigns[:suggested_for] == key do
+      socket
+    else
+      {token, suggestions} = suggest(draft)
+
+      assign(socket, suggested_for: key, token: token, suggestions: suggestions)
+    end
+  end
+
+  defp reply_to_id(%{reply_to: %Status{id: id}}), do: id
+  defp reply_to_id(_assigns), do: nil
 
   # In the author's order, which lives in the component rather than in the
   # table: the table has no column for an order that only matters until the

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.15",
+      version: "1.0.16",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba/broadcast_test.exs
+++ b/test/abuuba/broadcast_test.exs
@@ -150,9 +150,14 @@ defmodule Abuuba.BroadcastTest do
       {:ok, _} = Statuses.boost(other, status)
 
       {:ok, counter} = Agent.start_link(fn -> 0 end)
+      handler = "reader-state-#{System.unique_integer([:positive])}"
+
+      # Detached when the test ends, or it keeps firing for the rest of the
+      # suite and dies against an agent that is gone.
+      on_exit(fn -> :telemetry.detach(handler) end)
 
       :telemetry.attach(
-        "reader-state-#{System.unique_integer([:positive])}",
+        handler,
         [:abuuba, :repo, :query],
         fn _event, _measure, _meta, _config -> Agent.update(counter, &(&1 + 1)) end,
         nil

--- a/test/abuuba_web/compose_test.exs
+++ b/test/abuuba_web/compose_test.exs
@@ -153,6 +153,60 @@ defmodule AbuubaWeb.ComposeTest do
     end
   end
 
+  describe "what a caret move costs" do
+    test "nothing, once the text has not changed", %{conn: conn, account: account} do
+      # `assets/js/compose.js` pushes `caret` on input, keyup and click,
+      # undebounced. Every one of those used to re-resolve each `@mention`
+      # against the database, ask for the parent author again, and search if
+      # the caret sat in a word -- so an arrow key through a reply cost three
+      # queries and a whole preview render.
+      other = account_fixture(%{username: "bobby"})
+      {:ok, _parent} = Abuuba.Statuses.create_status(%{account_id: other.id, text: "hello"})
+
+      {:ok, live, _html} = live(conn, ~p"/home")
+
+      draft(live, %{"text" => "@bobby and @#{account.username} "})
+
+      # Settle whatever the first render owes, then count only the caret.
+      _ = caret(live, 3)
+
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+      handler = "caret-#{System.unique_integer([:positive])}"
+
+      # Detached when the test ends. A handler that outlives the agent it
+      # updates keeps firing for every query the rest of the suite makes, dies
+      # against a dead process, and logs its own detaching -- which is enough
+      # to abort the run under `--warnings-as-errors`.
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      :telemetry.attach(
+        handler,
+        [:abuuba, :repo, :query],
+        fn _event, _measure, _meta, _config -> Agent.update(counter, &(&1 + 1)) end,
+        nil
+      )
+
+      # Back into the same word: same text, same token, nothing to ask.
+      _ = caret(live, 3)
+
+      assert Agent.get(counter, & &1) == 0
+    end
+
+    test "and the preview still follows the text when it does change", %{conn: conn} do
+      # The control. Caching the derived state on a key is one typo away from
+      # a preview that never updates, and every assertion above is that
+      # something did not happen.
+      {:ok, live, _html} = live(conn, ~p"/home")
+
+      assert draft(live, %{"text" => "first words"}) =~ "first words"
+
+      html = draft(live, %{"text" => "second words"})
+
+      assert html =~ "second words"
+      refute html =~ "first words"
+    end
+  end
+
   describe "the preview" do
     test "shows a mention as the link it will become", %{conn: conn} do
       account_fixture(%{username: "bob"})


### PR DESCRIPTION
`derive/1` is split by what each part is made of: the preview, counter and
reply chips from the text, the warning and the parent; the suggestions from the
text and the caret. A caret that moved inside the same word now recomputes
nothing, which is what `caret` being pushed on input, keyup and click makes
worth doing.

`Accounts.lookup_many/1` is new, and `to_html/2` is handed the answer, so the
renders that *do* happen resolve every handle in one query rather than one
each.

The test counts queries on a second caret move and asserts zero; I checked it
fails when the split is removed. There is a control beside it, because caching
derived state on a key is one typo away from a preview that never updates.

**Two things this also fixes, both mine.** The telemetry handler I used for
counting outlived its test, kept firing for the rest of the suite and died
against a dead agent — including the one shipped in #57, fixed here too. And
`refute parent == nil` compared a struct to `nil`, which is a type warning, so
`mix precommit` printed `4527 passed` and then aborted under
`--warnings-as-errors`. Exactly the trap CLAUDE.md documents: I read the exit
code rather than the summary, which is the only reason it did not reach CI.

Closes #18

An AI agent wrote this text in my name. I know that is problematic.
