### PR TITLE
Draw the notifications page once for a burst, not once per arrival

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -76,6 +76,11 @@ config :abuuba, Oban, testing: :manual
 # on the cache being on — that is the cache's contract.
 config :abuuba, cache_enabled: false
 
+# The notifications page coalesces a burst of arrivals into one redraw. Zero
+# here so a test does not wait on a real clock: the flag and the message are
+# the same, only the window is gone.
+config :abuuba, notifications_coalesce_ms: 0
+
 # The delivery breaker's cooling-off period, a minute in production. Asking
 # what it does on both sides of that gate is worth milliseconds, not a minute,
 # and a test that reads the real clock here would be a test nobody runs.

--- a/lib/abuuba_web/live/notifications_live.ex
+++ b/lib/abuuba_web/live/notifications_live.ex
@@ -41,6 +41,12 @@ defmodule AbuubaWeb.NotificationsLive do
 
   @page_size 40
 
+  # Long enough that a burst arrives as one redraw, short enough that a single
+  # notification still feels immediate. Configurable because a test must not
+  # wait on a real clock: the test env sets it to zero, which still goes
+  # through the same flag and the same `:reload_notifications` message.
+  @coalesce_ms 300
+
   # The ones worth offering as a checkbox. The rest are rare enough that a list
   # of fourteen boxes would hide the four somebody actually wanted.
   @offered_types ~w(mention reblog follow follow_request favourite poll update quote status)
@@ -58,6 +64,7 @@ defmodule AbuubaWeb.NotificationsLive do
      |> assign(
        page_title: gettext("Notifications"),
        viewer: account,
+       reload_pending?: false,
        types: stored_types(socket.assigns.current_scope.user)
      )
      |> PostActions.attach(put_back: &put_status_back/2, remove: &drop_status/2)}
@@ -280,14 +287,41 @@ defmodule AbuubaWeb.NotificationsLive do
 
   def handle_event(_event, _params, socket), do: {:noreply, socket}
 
+  # Coalesced rather than reloaded per arrival. `Streaming.publish_notification/1`
+  # broadcasts once per row, and one thing happening is often several rows: the
+  # moduledoc's own example is twelve people boosting one post, which arrived
+  # as twelve reloads of seventeen queries each to end up drawing one group.
+  #
+  # The flag rather than the timer reference, because a second arrival while
+  # one is pending should join it rather than push it later -- a steady trickle
+  # would otherwise never redraw at all.
   @impl Phoenix.LiveView
   def handle_info({:streaming, "notification", _notification}, socket) do
-    {:noreply, load(socket)}
+    if socket.assigns[:reload_pending?] do
+      {:noreply, socket}
+    else
+      schedule_reload(coalesce_ms())
+
+      {:noreply, assign(socket, reload_pending?: true)}
+    end
+  end
+
+  def handle_info(:reload_notifications, socket) do
+    {:noreply, socket |> assign(reload_pending?: false) |> load()}
   end
 
   def handle_info(_message, socket), do: {:noreply, socket}
 
   ## Plumbing
+
+  defp coalesce_ms, do: Application.get_env(:abuuba, :notifications_coalesce_ms, @coalesce_ms)
+
+  # Straight to the mailbox where there is no window to wait for.
+  # `send_after/3` with a zero delay still goes through the timer, so the
+  # message can arrive after a render that was asked for later -- which passes
+  # when the test file runs alone and fails under a full suite.
+  defp schedule_reload(0), do: send(self(), :reload_notifications)
+  defp schedule_reload(ms), do: Process.send_after(self(), :reload_notifications, ms)
 
   defp load(socket) do
     account = socket.assigns.viewer

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.16",
+      version: "1.0.17",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba_web/notifications_live_test.exs
+++ b/test/abuuba_web/notifications_live_test.exs
@@ -171,6 +171,58 @@ defmodule AbuubaWeb.NotificationsLiveTest do
       assert render(live) =~ "followed you"
     end
 
+    test "a burst of them is one redraw, not one each", %{conn: conn, reader: reader} do
+      # `Streaming.publish_notification/1` broadcasts once per row, and one
+      # thing happening is often several rows -- twelve people boosting a post
+      # is the moduledoc's own example. Each arrival used to reload the page:
+      # seventeen queries, twelve times, to end up drawing one group.
+      Application.put_env(:abuuba, :notifications_coalesce_ms, 80)
+      on_exit(fn -> Application.put_env(:abuuba, :notifications_coalesce_ms, 0) end)
+
+      {:ok, live, _html} = live(conn, ~p"/notifications")
+
+      post = status_fixture(%{account_id: reader.id, text: "boosted a lot"})
+
+      counter = count_queries()
+
+      for _ <- 1..12 do
+        sender = account_fixture()
+        {:ok, notification} = Notifications.notify(reader, sender, "reblog", status_id: post.id)
+        Streaming.publish_notification(notification)
+      end
+
+      # Nothing reloaded yet: the window is still open.
+      during = Agent.get(counter, & &1)
+
+      Process.sleep(150)
+      html = render(live)
+
+      after_window = Agent.get(counter, & &1) - during
+
+      assert after_window > 0, "the coalesced reload never happened"
+
+      assert after_window < during / 2,
+             "one redraw should cost less than the twelve writes that triggered it"
+
+      assert html =~ "boosted"
+    end
+
+    defp count_queries do
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+      handler = "notif-#{System.unique_integer([:positive])}"
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      :telemetry.attach(
+        handler,
+        [:abuuba, :repo, :query],
+        fn _event, _measure, _meta, _config -> Agent.update(counter, &(&1 + 1)) end,
+        nil
+      )
+
+      counter
+    end
+
     test "somebody else's does not", %{conn: conn} do
       {:ok, live, _html} = live(conn, ~p"/notifications")
 


### PR DESCRIPTION
Measured before changing anything, since the issue flagged its count as
derived: **17 queries per reload**, so the moduledoc's own example — twelve
people boosting one post — cost 204 to end up drawing one group.

A flag and a `send_after` fold the burst into one redraw. The flag rather than
the timer reference is deliberate: a second arrival while one is pending joins
it instead of pushing it later, or a steady trickle would never redraw at all.

**Two things about the test path, both worth the comments they got.**

The window is configurable and zero in test, because `CLAUDE.md` says a feature
gated on a clock must not read the real one there. And zero sends straight to
the mailbox rather than through `send_after/3` — a zero delay still goes via
the timer, so a render asked for *later* could arrive first. That was green
when the file ran alone and red under the full suite; I only saw it because the
final precommit runs everything.

The burst test overrides the window to 80 ms and counts queries during and
after, so it exercises the real coalescing rather than the zero path. I checked
it fails without the change, with the message it was written for.

Closes #19

An AI agent wrote this text in my name. I know that is problematic.
