### PR TITLE
One answer to whether a flag means yes, and the reference's answer

### DIFF
--- a/lib/abuuba_web/api.ex
+++ b/lib/abuuba_web/api.ex
@@ -60,15 +60,33 @@ defmodule AbuubaWeb.API do
   @spec id_param(map(), String.t()) :: integer() | nil
   def id_param(params, key), do: params |> Map.get(key) |> parse_id()
 
+  # What the reference calls false, which is Rails' `ActiveModel::Type::Boolean`
+  # cast: everything else a client sends is yes. Written out rather than
+  # narrowed to `"false"` and `"0"`, because `"off"` and `"f"` are what a
+  # checkbox and a shell client send and both mean no.
+  @falsey ["false", "0", "f", "off", false, 0]
+
   @doc """
   Whether a query parameter means yes.
 
   A flag arrives as a string from a query string and as a boolean from a JSON
-  body, and clients send `1` for both. Anything else is no, including the
-  absent one.
+  body, and clients send `1` for both. The absent one is no.
+
+  A denylist and not an allowlist, matching `truthy_param?` in the reference:
+  `"on"` and `"yes"` are what some clients send for a checkbox, and answering
+  no to them is the kind of difference that shows up as a setting which will
+  not turn on. This module and `AbuubaWeb.API.AccountController` used to
+  disagree about exactly that, one each way.
+
+  `AbuubaWeb.API.boolean/2` and `Abuuba.Moderation.Domains.truthy/1` are
+  deliberately stricter and say so; they are not this question.
   """
   @spec truthy?(term()) :: boolean()
-  def truthy?(value), do: value in [true, "true", "1", 1]
+  def truthy?(nil), do: false
+
+  def truthy?(value) when is_binary(value), do: String.downcase(value) not in @falsey
+
+  def truthy?(value), do: value not in @falsey
 
   @doc """
   An id a caller already holds, or `nil` where it is not one.

--- a/lib/abuuba_web/controllers/activity_pub_controller.ex
+++ b/lib/abuuba_web/controllers/activity_pub_controller.ex
@@ -36,6 +36,7 @@ defmodule AbuubaWeb.ActivityPubController do
   alias Abuuba.Stats
   alias Abuuba.Statuses
   alias Abuuba.Statuses.Status
+  alias AbuubaWeb.API
   alias AbuubaWeb.SignedRequest
 
   @content_type "application/activity+json"
@@ -352,7 +353,7 @@ defmodule AbuubaWeb.ActivityPubController do
   # peer walks from one to the other.
   defp render_replies(conn, %Status{} = status, account, params) do
     collection_id = Serializer.replies_uri(status, account)
-    others? = truthy?(params["only_other_accounts"])
+    others? = API.truthy?(params["only_other_accounts"])
     # Bounded like any other id off the wire. A min_id no column could hold
     # raises inside the query rather than simply matching nothing.
     min_id =
@@ -385,7 +386,7 @@ defmodule AbuubaWeb.ActivityPubController do
     # same page nested inside the collection does not, because the collection
     # around it already did.
     document =
-      if truthy?(params["page"]) do
+      if API.truthy?(params["page"]) do
         Actor.with_activitystreams_context(page)
       else
         Actor.inline_collection(collection_id, page, context: true)
@@ -393,8 +394,6 @@ defmodule AbuubaWeb.ActivityPubController do
 
     conn |> put_resp_content_type(@content_type) |> json(document)
   end
-
-  defp truthy?(value), do: value in ["true", "1", true]
 
   # A full page means there may be more of the same kind. A short one means the
   # author is done talking, so the walk carries on into everybody else's

--- a/lib/abuuba_web/controllers/api/account_controller.ex
+++ b/lib/abuuba_web/controllers/api/account_controller.ex
@@ -718,7 +718,7 @@ defmodule AbuubaWeb.API.AccountController do
 
   defp put_if(attrs, params, key, field) do
     case Map.fetch(params, key) do
-      {:ok, value} -> Map.put(attrs, field, truthy?(value))
+      {:ok, value} -> Map.put(attrs, field, API.truthy?(value))
       :error -> attrs
     end
   end
@@ -744,8 +744,6 @@ defmodule AbuubaWeb.API.AccountController do
   defp expiry(attrs, seconds) do
     Map.put(attrs, :expires_at, DateTime.add(DateTime.utc_now(), seconds, :second))
   end
-
-  defp truthy?(value), do: value not in [false, "false", "0", 0, nil]
 
   defp put_role(payload, user) do
     case Entities.role(Roles.of(user)) do

--- a/lib/abuuba_web/controllers/api/push_subscription_controller.ex
+++ b/lib/abuuba_web/controllers/api/push_subscription_controller.ex
@@ -97,13 +97,11 @@ defmodule AbuubaWeb.API.PushSubscriptionController do
   end
 
   defp put_alerts(attrs, alerts) when is_map(alerts) do
-    Map.put(attrs, "alerts", Map.new(alerts, fn {key, value} -> {key, truthy?(value)} end))
+    Map.put(attrs, "alerts", Map.new(alerts, fn {key, value} -> {key, API.truthy?(value)} end))
   end
 
   defp put_alerts(attrs, _alerts), do: attrs
 
   defp put_policy(attrs, policy) when is_binary(policy), do: Map.put(attrs, "policy", policy)
   defp put_policy(attrs, _policy), do: attrs
-
-  defp truthy?(value), do: value in [true, "true", "1", 1]
 end

--- a/lib/abuuba_web/controllers/api/search_controller.ex
+++ b/lib/abuuba_web/controllers/api/search_controller.ex
@@ -55,8 +55,8 @@ defmodule AbuubaWeb.API.SearchController do
       # when the caller asked to resolve: without that it is an ordinary search
       # over what this server already holds, which is what `resolve=false`
       # means.
-      url?(query) or (truthy?(params["resolve"]) and ResolveActor.resolvable?(query)) ->
-        json(conn, resolve(query, viewer, truthy?(params["resolve"])))
+      url?(query) or (API.truthy?(params["resolve"]) and ResolveActor.resolvable?(query)) ->
+        json(conn, resolve(query, viewer, API.truthy?(params["resolve"])))
 
       true ->
         json(conn, run(query, viewer, params))
@@ -72,8 +72,8 @@ defmodule AbuubaWeb.API.SearchController do
     # answer, which is worse than a refusal: somebody searching within one
     # profile was given everybody's posts and no reason to doubt them.
     account_id = API.id_param(params, "account_id")
-    followed_by = if truthy?(params["following"]) and viewer, do: viewer.id
-    exclude_unreviewed = truthy?(params["exclude_unreviewed"])
+    followed_by = if API.truthy?(params["following"]) and viewer, do: viewer.id
+    exclude_unreviewed = API.truthy?(params["exclude_unreviewed"])
 
     %{
       "accounts" =>
@@ -145,7 +145,7 @@ defmodule AbuubaWeb.API.SearchController do
   defp empty, do: %{"accounts" => [], "statuses" => [], "hashtags" => []}
 
   defp needs_account?(params) do
-    truthy?(params["resolve"]) or offset(params) > 0
+    API.truthy?(params["resolve"]) or offset(params) > 0
   end
 
   defp url?(query),
@@ -157,6 +157,4 @@ defmodule AbuubaWeb.API.SearchController do
       _ -> 0
     end
   end
-
-  defp truthy?(value), do: value in [true, "true", "1", 1]
 end

--- a/lib/abuuba_web/controllers/api/timeline_controller.ex
+++ b/lib/abuuba_web/controllers/api/timeline_controller.ex
@@ -234,14 +234,12 @@ defmodule AbuubaWeb.API.TimelineController do
     params
     |> Pagination.params(default: 20, max: 40)
     |> Map.merge(%{
-      local: truthy?(params["local"]),
-      remote: truthy?(params["remote"]),
-      only_media: truthy?(params["only_media"]),
+      local: API.truthy?(params["local"]),
+      remote: API.truthy?(params["remote"]),
+      only_media: API.truthy?(params["only_media"]),
       any: NestedParams.list(params["any"]),
       all: NestedParams.list(params["all"]),
       none: NestedParams.list(params["none"])
     })
   end
-
-  defp truthy?(value), do: value in [true, "true", "1", 1]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.17",
+      version: "1.0.18",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba_web/api_test.exs
+++ b/test/abuuba_web/api_test.exs
@@ -43,6 +43,29 @@ defmodule AbuubaWeb.APITest do
     end
   end
 
+  describe "whether a flag means yes" do
+    test "the values the reference calls no, and nothing else" do
+      # `ActiveModel::Type::Boolean` is what `truthy_param?` casts with, and
+      # its false set is these plus their capitalisations. Everything else a
+      # client sends is yes.
+      for no <- [false, 0, "0", "f", "F", "false", "FALSE", "off", "OFF", nil] do
+        refute API.truthy?(no), "#{inspect(no)} should be no"
+      end
+
+      for yes <- [true, 1, "1", "true", "TRUE", "on", "yes", "banana"] do
+        assert API.truthy?(yes), "#{inspect(yes)} should be yes"
+      end
+    end
+
+    test "which is a denylist, and used to be two functions disagreeing" do
+      # `AbuubaWeb.API.AccountController` carried its own, the other way round:
+      # an allowlist here said `"on"` was no while its denylist said `"f"` was
+      # yes, so the same word meant opposite things on two endpoints.
+      assert API.truthy?("on")
+      refute API.truthy?("f")
+    end
+  end
+
   describe "how many records a request asked for" do
     test "the default when it did not ask" do
       assert API.limit(%{}, 20) == 20


### PR DESCRIPTION
**On the polarity, which the issue asked me to decide.** Neither version was
what the reference does. `truthy_param?` casts with
`ActiveModel::Type::Boolean`, whose false set is:

```
false, 0, "0", "f", "false", "off"   (plus capitalisations)
```

Everything else is yes. So the allowlist answered no to `"on"` and `"yes"`, and
`AccountController`'s denylist answered yes to `"f"` and `"off"` — one mistake
each way. `API.truthy?/1` now matches the cast, which is why the answer is the
denylist rather than the version that had more copies.

That is a behaviour change on the eighteen call sites for inputs like `"on"`
and `"f"`. It is the compatible direction, and compat here is bug-for-bug.

All five private copies are gone. `API.boolean/2` and `Domains.truthy/1` are
stricter on purpose and documented as such; untouched.

Closes #20

An AI agent wrote this text in my name. I know that is problematic.
