### PR TITLE
Call the shared helper where there really was a copy of it

### DIFF
--- a/lib/abuuba/federation/http.ex
+++ b/lib/abuuba/federation/http.ex
@@ -52,6 +52,23 @@ defmodule Abuuba.Federation.HTTP do
   @as2_profile ~s(profile="https://www.w3.org/ns/activitystreams")
 
   @doc """
+  Fetches an ActivityPub document, or lets a caller substitute the fetching.
+
+  `get_json/2` with the `:fetch` option honoured: a test hands in a function
+  and everything else goes over the wire. Three resolvers each carried a
+  byte-identical copy of this, which is three places to remember when the
+  option grows a second shape.
+  """
+  @spec fetch_json(String.t(), keyword()) ::
+          {:ok, map()} | {:error, atom() | {:status, integer()}}
+  def fetch_json(url, opts \\ []) do
+    case Keyword.get(opts, :fetch) do
+      nil -> get_json(url, opts)
+      fetcher -> fetcher.(url)
+    end
+  end
+
+  @doc """
   Fetches an ActivityPub document.
 
   Signed as the instance actor by default, because a growing number of servers

--- a/lib/abuuba/federation/quotes.ex
+++ b/lib/abuuba/federation/quotes.ex
@@ -33,6 +33,7 @@ defmodule Abuuba.Federation.Quotes do
   alias Abuuba.Accounts.Account
   alias Abuuba.Federation.HTTP
   alias Abuuba.Federation.Serializer
+  alias Abuuba.Federation.URIs
   alias Abuuba.Relationships
   alias Abuuba.Repo
   alias Abuuba.Stats
@@ -95,7 +96,7 @@ defmodule Abuuba.Federation.Quotes do
   end
 
   defp check(status, row, opts) do
-    with {:ok, document} <- fetch(row.approval_uri, opts),
+    with {:ok, document} <- HTTP.fetch_json(row.approval_uri, opts),
          :ok <- check_type(document),
          :ok <- check_host(row, document, opts),
          :ok <- check_interacting_object(document, status),
@@ -118,7 +119,7 @@ defmodule Abuuba.Federation.Quotes do
 
     cond do
       is_nil(quoted_author) -> {:error, :unknown_quoted_author}
-      same_host?(document["id"], quoted_author) -> :ok
+      URIs.same_host?(document["id"], quoted_author) -> :ok
       true -> {:error, :approval_from_wrong_host}
     end
   end
@@ -416,22 +417,6 @@ defmodule Abuuba.Federation.Quotes do
       }
     )
     |> Repo.one()
-  end
-
-  defp fetch(uri, opts) do
-    case Keyword.get(opts, :fetch) do
-      nil -> HTTP.get_json(uri, opts)
-      fetcher -> fetcher.(uri)
-    end
-  end
-
-  defp same_host?(a, b) do
-    with %URI{host: host_a} when is_binary(host_a) <- URI.parse(a || ""),
-         %URI{host: host_b} when is_binary(host_b) <- URI.parse(b || "") do
-      String.downcase(host_a) == String.downcase(host_b)
-    else
-      _ -> false
-    end
   end
 
   defp same_uri?(a, b) when is_binary(a) and is_binary(b) do

--- a/lib/abuuba/federation/resolve_actor.ex
+++ b/lib/abuuba/federation/resolve_actor.ex
@@ -96,7 +96,7 @@ defmodule Abuuba.Federation.ResolveActor do
   # re-read below turns the loser into an update instead of a second insert.
   defp fetch_and_store(uri, existing_account, opts) do
     with :ok <- check_uri(uri),
-         {:ok, document} <- fetch(uri, opts),
+         {:ok, document} <- HTTP.fetch_json(uri, opts),
          :ok <- check_document(document, uri),
          {:ok, handle} <- handle_from(document, uri),
          :ok <- check_loopback(handle, document["id"], opts),
@@ -116,13 +116,6 @@ defmodule Abuuba.Federation.ResolveActor do
         {:ok, account}
       end
     end)
-  end
-
-  defp fetch(uri, opts) do
-    case Keyword.get(opts, :fetch) do
-      nil -> HTTP.get_json(uri, opts)
-      fetcher -> fetcher.(uri)
-    end
   end
 
   @doc """
@@ -148,7 +141,7 @@ defmodule Abuuba.Federation.ResolveActor do
   end
 
   defp resolve_owner_of(key_id, opts) do
-    with {:ok, document} <- fetch(key_id, opts),
+    with {:ok, document} <- HTTP.fetch_json(key_id, opts),
          owner when is_binary(owner) <- owner_uri(document),
          true <- URIs.same_host?(owner, key_id) do
       resolve(owner, opts)
@@ -179,7 +172,7 @@ defmodule Abuuba.Federation.ResolveActor do
       not is_map(document) -> {:error, :malformed_actor}
       document["type"] not in @actor_types -> {:error, :not_an_actor}
       not is_binary(document["id"]) -> {:error, :malformed_actor}
-      not same_host?(document["id"], requested_uri) -> {:error, :actor_host_mismatch}
+      not URIs.same_host?(document["id"], requested_uri) -> {:error, :actor_host_mismatch}
       is_nil(inbox(document)) -> {:error, :actor_without_inbox}
       true -> :ok
     end
@@ -188,14 +181,6 @@ defmodule Abuuba.Federation.ResolveActor do
   # A document may only describe an actor on the host that served it.
   # Otherwise a hostile server hands back a document claiming to be somebody
   # on another host and we file it under their name.
-  defp same_host?(id, requested) do
-    with %URI{host: a} when is_binary(a) <- URI.parse(id),
-         %URI{host: b} when is_binary(b) <- URI.parse(requested) do
-      String.downcase(a) == String.downcase(b)
-    else
-      _ -> false
-    end
-  end
 
   @doc """
   Resolves whatever somebody typed: an address, or a handle.

--- a/lib/abuuba/federation/resolve_status.ex
+++ b/lib/abuuba/federation/resolve_status.ex
@@ -40,6 +40,7 @@ defmodule Abuuba.Federation.ResolveStatus do
   alias Abuuba.Federation.Limits
   alias Abuuba.Federation.Quotes
   alias Abuuba.Federation.ResolveActor
+  alias Abuuba.Federation.URIs
   alias Abuuba.Instance
   alias Abuuba.Media
   alias Abuuba.Moderation.Domains
@@ -70,12 +71,9 @@ defmodule Abuuba.Federation.ResolveStatus do
   """
   @spec trustworthy_attribution?(String.t() | nil, term()) :: boolean()
   def trustworthy_attribution?(object_id, attributed_to) do
-    with author when is_binary(author) <- attribution_uri(attributed_to),
-         %URI{host: object_host} when is_binary(object_host) <- URI.parse(object_id || ""),
-         %URI{host: author_host} when is_binary(author_host) <- URI.parse(author) do
-      String.downcase(object_host) == String.downcase(author_host)
-    else
-      _ -> false
+    case attribution_uri(attributed_to) do
+      author when is_binary(author) -> URIs.same_host?(object_id, author)
+      _not_a_uri -> false
     end
   end
 
@@ -142,7 +140,7 @@ defmodule Abuuba.Federation.ResolveStatus do
   ## Fetching
 
   defp fetch_and_store(uri, opts) do
-    with {:ok, document} <- fetch(uri, opts),
+    with {:ok, document} <- HTTP.fetch_json(uri, opts),
          {:ok, object} <- unwrap(document),
          {:ok, object} <- refetch_by_id(object, uri, opts),
          :ok <- check_object(object),
@@ -158,13 +156,6 @@ defmodule Abuuba.Federation.ResolveStatus do
 
       other ->
         other
-    end
-  end
-
-  defp fetch(uri, opts) do
-    case Keyword.get(opts, :fetch) do
-      nil -> HTTP.get_json(uri, opts)
-      fetcher -> fetcher.(uri)
     end
   end
 
@@ -192,7 +183,7 @@ defmodule Abuuba.Federation.ResolveStatus do
   end
 
   defp refetch(id, opts) do
-    with {:ok, document} <- fetch(id, Keyword.put(opts, :refetched, true)),
+    with {:ok, document} <- HTTP.fetch_json(id, Keyword.put(opts, :refetched, true)),
          {:ok, object} <- unwrap(document) do
       if same_uri?(object["id"], id), do: {:ok, object}, else: {:error, :id_mismatch}
     end
@@ -620,7 +611,7 @@ defmodule Abuuba.Federation.ResolveStatus do
   defp walk(_uri, _opts, _depth, 0), do: {:error, :discovery_budget_exhausted}
 
   defp walk(uri, opts, depth, budget) do
-    with {:ok, document} <- fetch(uri, opts),
+    with {:ok, document} <- HTTP.fetch_json(uri, opts),
          {:ok, object} <- unwrap(document) do
       parent_id = resolve_parent(object, opts, depth, budget)
 

--- a/lib/abuuba/federation/signature.ex
+++ b/lib/abuuba/federation/signature.ex
@@ -418,7 +418,7 @@ defmodule Abuuba.Federation.Signature do
   ## Crypto
 
   defp rsa_sign(signing_string, pem) do
-    with {:ok, key} <- decode_private_key(pem) do
+    with {:ok, key} <- decode_key(pem) do
       {:ok,
        signing_string
        |> :public_key.sign(:sha256, key)
@@ -428,23 +428,17 @@ defmodule Abuuba.Federation.Signature do
 
   defp rsa_verify(signing_string, signature, pem) do
     with {:ok, decoded} <- Base.decode64(signature),
-         {:ok, key} <- decode_public_key(pem) do
+         {:ok, key} <- decode_key(pem) do
       :public_key.verify(signing_string, :sha256, decoded, key)
     else
       _ -> false
     end
   end
 
-  defp decode_private_key(pem) do
-    case :public_key.pem_decode(pem) do
-      [entry | _] -> {:ok, :public_key.pem_entry_decode(entry)}
-      [] -> {:error, :bad_key}
-    end
-  rescue
-    _ -> {:error, :bad_key}
-  end
-
-  defp decode_public_key(pem) do
+  # One function for both halves of the pair: `pem_decode/1` reads whichever
+  # kind of key the PEM holds, so signing and verifying were asking the same
+  # question through two byte-identical private functions.
+  defp decode_key(pem) do
     case :public_key.pem_decode(pem) do
       [entry | _] -> {:ok, :public_key.pem_entry_decode(entry)}
       [] -> {:error, :bad_key}

--- a/lib/abuuba_web/controllers/api/account_controller.ex
+++ b/lib/abuuba_web/controllers/api/account_controller.ex
@@ -628,7 +628,7 @@ defmodule AbuubaWeb.API.AccountController do
   defp with_account(conn, id, fun) do
     viewer = current_account(conn)
 
-    case Accounts.get_account(API.id_param(%{"id" => id}, "id") || 0) do
+    case Accounts.get_account(API.parse_id(id) || 0) do
       %Account{suspended_at: nil} = account -> fun.(account, viewer)
       _ -> API.error(conn, 404, "Record not found")
     end

--- a/lib/abuuba_web/controllers/api/instance_info_controller.ex
+++ b/lib/abuuba_web/controllers/api/instance_info_controller.ex
@@ -370,7 +370,7 @@ defmodule AbuubaWeb.API.InstanceInfoController do
   end
 
   defp with_announcement(conn, id, fun) do
-    case Instance.get_announcement(API.id_param(%{"id" => id}, "id")) do
+    case Instance.get_announcement(API.parse_id(id)) do
       nil -> API.error(conn, 404, "Record not found")
       announcement -> fun.(announcement)
     end

--- a/lib/abuuba_web/controllers/api/list_controller.ex
+++ b/lib/abuuba_web/controllers/api/list_controller.ex
@@ -12,7 +12,6 @@ defmodule AbuubaWeb.API.ListController do
   alias Abuuba.Lists
   alias AbuubaWeb.API
   alias AbuubaWeb.API.Entities
-  alias AbuubaWeb.API.NestedParams
   alias AbuubaWeb.API.Pagination
 
   plug AbuubaWeb.Plugs.RequireUser
@@ -90,19 +89,15 @@ defmodule AbuubaWeb.API.ListController do
   end
 
   defp with_list(conn, id, fun) do
-    case Lists.get(current_account(conn), API.id_param(%{"id" => id}, "id")) do
+    case Lists.get(current_account(conn), API.parse_id(id)) do
       nil -> API.error(conn, 404, "Record not found")
       list -> fun.(list)
     end
   end
 
-  defp account_ids(params) do
-    params
-    |> Map.get("account_ids", [])
-    |> NestedParams.list()
-    |> Enum.map(&API.id_param(%{"id" => &1}, "id"))
-    |> Enum.reject(&is_nil/1)
-  end
+  # `API.id_list/2` is this, plus the `Enum.uniq/1` this one was missing --
+  # adding an account to a list twice in one request is adding it once.
+  defp account_ids(params), do: API.id_list(params, "account_ids")
 
   defp invalid(conn, changeset) do
     API.error(conn, 422, "Validation failed", Entities.field_errors(changeset))

--- a/lib/abuuba_web/controllers/api/media_controller.ex
+++ b/lib/abuuba_web/controllers/api/media_controller.ex
@@ -153,7 +153,7 @@ defmodule AbuubaWeb.API.MediaController do
   defp with_own(conn, id, fun) do
     account = current_account(conn)
 
-    case Media.get_own_unattached(account, API.id_param(%{"id" => id}, "id") || 0) do
+    case Media.get_own_unattached(account, API.parse_id(id) || 0) do
       nil -> API.error(conn, 404, "Record not found")
       attachment -> fun.(attachment)
     end

--- a/lib/abuuba_web/controllers/api/notification_controller.ex
+++ b/lib/abuuba_web/controllers/api/notification_controller.ex
@@ -69,7 +69,7 @@ defmodule AbuubaWeb.API.NotificationController do
   def show(conn, %{"id" => id}) do
     account = current_account(conn)
 
-    case Notifications.get(account, API.id_param(%{"id" => id}, "id")) do
+    case Notifications.get(account, API.parse_id(id)) do
       nil -> API.error(conn, 404, "Record not found")
       notification -> json(conn, Entities.notification(notification, account))
     end
@@ -78,7 +78,7 @@ defmodule AbuubaWeb.API.NotificationController do
   def dismiss(conn, %{"id" => id}) do
     account = current_account(conn)
 
-    case API.id_param(%{"id" => id}, "id") do
+    case API.parse_id(id) do
       nil -> API.error(conn, 404, "Record not found")
       notification_id -> Notifications.dismiss(account, notification_id) && json(conn, %{})
     end

--- a/lib/abuuba_web/controllers/api/poll_controller.ex
+++ b/lib/abuuba_web/controllers/api/poll_controller.ex
@@ -45,7 +45,7 @@ defmodule AbuubaWeb.API.PollController do
   # rules to keep in step with the first.
   defp with_poll(conn, id, fun) do
     viewer = current_account(conn)
-    poll = Abuuba.Repo.get(Poll, API.id_param(%{"id" => id}, "id") || 0)
+    poll = Abuuba.Repo.get(Poll, API.parse_id(id) || 0)
 
     case poll && Statuses.readable(poll.status_id, viewer) do
       nil -> API.error(conn, 404, "Record not found")

--- a/lib/abuuba_web/controllers/api/relationship_controller.ex
+++ b/lib/abuuba_web/controllers/api/relationship_controller.ex
@@ -108,7 +108,7 @@ defmodule AbuubaWeb.API.RelationshipController do
   # so `/follow_requests/:id/authorize` names the person, not the request.
   defp answer_request(conn, id, fun) do
     account = current_account(conn)
-    follower_id = API.id_param(%{"id" => id}, "id")
+    follower_id = API.parse_id(id)
 
     case follower_id && Relationships.get_follow_request(follower_id, account) do
       nil ->

--- a/lib/abuuba_web/controllers/api/report_controller.ex
+++ b/lib/abuuba_web/controllers/api/report_controller.ex
@@ -40,7 +40,7 @@ defmodule AbuubaWeb.API.ReportController do
   end
 
   defp target(params) do
-    params |> Map.get("account_id") |> then(&API.id_param(%{"id" => &1}, "id")) |> account()
+    params |> Map.get("account_id") |> API.parse_id() |> account()
   end
 
   defp account(nil), do: nil

--- a/lib/abuuba_web/controllers/api/scheduled_status_controller.ex
+++ b/lib/abuuba_web/controllers/api/scheduled_status_controller.ex
@@ -63,7 +63,7 @@ defmodule AbuubaWeb.API.ScheduledStatusController do
   defp with_own(conn, id, fun) do
     account = current_account(conn)
 
-    case Statuses.get_scheduled(account, API.id_param(%{"id" => id}, "id") || 0) do
+    case Statuses.get_scheduled(account, API.parse_id(id) || 0) do
       nil -> API.error(conn, 404, "Record not found")
       scheduled -> fun.(scheduled)
     end

--- a/lib/abuuba_web/controllers/api/status_controller.ex
+++ b/lib/abuuba_web/controllers/api/status_controller.ex
@@ -384,7 +384,7 @@ defmodule AbuubaWeb.API.StatusController do
   """
   def revoke_quote(conn, %{"status_id" => status_id, "id" => quoting_id}) do
     with_own_status(conn, status_id, fn status, viewer ->
-      case Quotes.revoke_for(status, API.id_param(%{"id" => quoting_id}, "id")) do
+      case Quotes.revoke_for(status, API.parse_id(quoting_id)) do
         :ok -> json(conn, Entities.status(status, viewer))
         :error -> API.error(conn, 404, "Record not found")
       end
@@ -687,7 +687,7 @@ defmodule AbuubaWeb.API.StatusController do
   defp fetch(conn, id, read, fun) do
     viewer = current_account(conn)
 
-    case read.(API.id_param(%{"id" => id}, "id"), viewer) do
+    case read.(API.parse_id(id), viewer) do
       nil -> API.error(conn, 404, "Record not found")
       status -> fun.(status, viewer)
     end

--- a/lib/abuuba_web/controllers/api/timeline_controller.ex
+++ b/lib/abuuba_web/controllers/api/timeline_controller.ex
@@ -108,7 +108,7 @@ defmodule AbuubaWeb.API.TimelineController do
   def list(conn, %{"id" => id} = params) do
     account = current_account(conn)
 
-    case Lists.get(account, API.id_param(%{"id" => id}, "id")) do
+    case Lists.get(account, API.parse_id(id)) do
       # An empty list and a list that does not exist are different things, and
       # a client shows them differently.
       nil -> API.error(conn, 404, "Record not found")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.18",
+      version: "1.0.19",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
**Done — four that really were copies:**

- `Signature.decode_private_key/1` and `decode_public_key/1`, byte-identical, are one `decode_key/1`.
- The injectable `fetch/2` that `Quotes`, `ResolveActor` and `ResolveStatus` each carried is `HTTP.fetch_json/2`.
- Two hand-rolled `same_host?/2` and one inline comparison ask `URIs.same_host?/2` — which is also safer: `ResolveActor`'s raised on a non-binary where `host_of/1` answers `nil`.
- Fourteen `API.id_param(%{"id" => x}, "id")` call `API.parse_id/1`, and `ListController.account_ids/1` is `API.id_list/2` — what it wrote out, minus the `Enum.uniq/1` it was missing.

**Not done, and why — several of the listed ones are not duplication:**

- **`presence/1` is three functions, not six copies.** Two pass a non-string through; three narrow it to `nil`; `actor.ex` answers about `[]`. The narrowing ones are not stylistic: `account_controller` reads `params["tagged"]` and `preview_cards` reads a parsed remote document, so a client sending `tagged[]=x` gets a list, and narrowing it to `nil` is what keeps a list out of a string column. Merging them onto the loose version would remove that.
- **`trends.ex:581` has no host helper.** That line is `write_counter/4`.
- **`to_integer/1`** is three different signatures — one takes a default, one handles `Decimal`.
- **`maybe_put/3`** is two identical lines either side of the web/lib boundary. A shared module for it costs more than the copy.
- `acct/1`, `account_of/1` and `timestamp/1` are genuinely identical between `entities.ex` and `serializer.ex`, but the same boundary applies and `account_of/1` does a `Repo.get`, so a shared home for it is a context decision rather than a dedup.

Closes #21

An AI agent wrote this text in my name. I know that is problematic.
