### PR TITLE
Escape a hashtag in a Note the way the collection already did

### DIFF
--- a/lib/abuuba/federation/serializer.ex
+++ b/lib/abuuba/federation/serializer.ex
@@ -137,7 +137,7 @@ defmodule Abuuba.Federation.Serializer do
       "sensitive" => status.sensitive or account.sensitized_at != nil,
       "to" => to,
       "cc" => cc,
-      "tag" => Enum.map(mentions, &mention_tag/1) ++ Enum.map(tags_of(status), &hashtag_tag/1),
+      "tag" => Enum.map(mentions, &mention_tag/1) ++ Enum.map(tags_of(status), &hashtag/1),
       "attachment" => Enum.map(attachments, &document/1),
       # The page a person reads the post on, which is not the id. A peer renders
       # this behind "open original", so falling back to the id sent every reader
@@ -979,14 +979,6 @@ defmodule Abuuba.Federation.Serializer do
   # The spelling somebody typed for the name, because that is what a reader
   # sees; the casefolded one for the link, because #Caturday and #caturday are
   # one tag and one timeline.
-  defp hashtag_tag(%Tag{} = tag) do
-    %{
-      "type" => "Hashtag",
-      "href" => "#{URIs.base_url()}/tags/#{tag.name}",
-      "name" => "#" <> (tag.display_name || tag.name)
-    }
-  end
-
   defp in_reply_to(%Status{in_reply_to_id: nil}), do: nil
 
   defp in_reply_to(%Status{in_reply_to_id: id}) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.19",
+      version: "1.0.20",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba/federation/serializer_test.exs
+++ b/test/abuuba/federation/serializer_test.exs
@@ -222,6 +222,24 @@ defmodule Abuuba.Federation.SerializerTest do
       assert href == "#{URIs.base_url()}/tags/caturday"
     end
 
+    test "and escapes one a peer could not otherwise follow", %{author: author} do
+      # A tag may be any word in any script. The Note built its own tag map
+      # without the escaping the featured-tags collection does, so the same
+      # tag went out encoded on one document and raw on the other -- and a raw
+      # one is not a URL.
+      status = status_fixture(%{account_id: author.id})
+      tag = tag_fixture("Grüße")
+      :ok = Statuses.tag_status(status, tag)
+
+      note = Serializer.note(Abuuba.Repo.reload(status))
+
+      assert %{"name" => "#Grüße", "href" => href} =
+               Enum.find(note["tag"], &(&1["type"] == "Hashtag"))
+
+      refute href =~ "ü", "the link went out unescaped"
+      assert href == Serializer.hashtag(tag)["href"], "and disagreed with the collection"
+    end
+
     test "puts a content warning in summary and marks it sensitive", %{author: author} do
       status =
         status_fixture(%{account_id: author.id, spoiler_text: "spoilers", sensitive: true})


### PR DESCRIPTION
`note/1` built its tag maps through a private copy of `hashtag/1` that omitted
the `URI.encode/2`, so the same tag went out escaped in the featured-tags
collection and raw inside a Note. The copy is gone and `note/1` calls the
public one, which is where the comment explaining the encoding already lived.

The test posts a `#Grüße` and asserts both halves: that the `href` carries no
raw non-ASCII, and that it equals what `hashtag/1` produces for the same tag —
so the two documents cannot drift apart again without a failure. It fails on
`main` with *"the link went out unescaped"*.

Closes #22

An AI agent wrote this text in my name. I know that is problematic.
