### PR TITLE
Delete twelve accessors nothing called, and settle one name

### DIFF
--- a/lib/abuuba/accounts/account.ex
+++ b/lib/abuuba/accounts/account.ex
@@ -566,11 +566,6 @@ defmodule Abuuba.Accounts.Account do
   def username_max, do: @username_max
 
   @doc """
-  The actor types an account may have.
-  """
-  def actor_types, do: Keyword.keys(@actor_types)
-
-  @doc """
   The type behind an ActivityPub `type`, which arrives capitalised.
 
   Anything unrecognised is a Person: an actor whose type this server has never

--- a/lib/abuuba/accounts/registration.ex
+++ b/lib/abuuba/accounts/registration.ex
@@ -17,7 +17,6 @@ defmodule Abuuba.Accounts.Registration do
   import Ecto.Changeset
 
   alias Abuuba.Accounts.Account
-  alias Abuuba.Accounts.User
   alias Abuuba.I18n
   alias Abuuba.Settings
 
@@ -206,14 +205,4 @@ defmodule Abuuba.Accounts.Registration do
   The password from a validated form.
   """
   def password(%Ecto.Changeset{} = changeset), do: get_field(changeset, :password)
-
-  @doc """
-  A changeset suitable for rendering the form, with the given errors applied.
-  """
-  def to_form_changeset(%Ecto.Changeset{} = changeset, action \\ :validate) do
-    Map.put(changeset, :action, action)
-  end
-
-  @doc false
-  def user_module, do: User
 end

--- a/lib/abuuba/accounts/user_token.ex
+++ b/lib/abuuba/accounts/user_token.ex
@@ -168,16 +168,6 @@ defmodule Abuuba.Accounts.UserToken do
   end
 
   @doc """
-  How long a session lasts, in days.
-  """
-  def session_validity_days, do: @session_validity_days
-
-  @doc """
-  How long a confirmation link lasts, in days.
-  """
-  def confirm_validity_days, do: @confirm_validity_days
-
-  @doc """
   How long a password reset link lasts, in hours.
   """
   def reset_validity_hours, do: @reset_validity_hours

--- a/lib/abuuba/federation/http/address.ex
+++ b/lib/abuuba/federation/http/address.ex
@@ -273,9 +273,4 @@ defmodule Abuuba.Federation.HTTP.Address do
   defp pack_v4({a, b, c, d}) do
     Bitwise.bsl(a, 24) + Bitwise.bsl(b, 16) + Bitwise.bsl(c, 8) + d
   end
-
-  @doc """
-  The ports a federation request may reach.
-  """
-  def allowed_ports, do: @allowed_ports
 end

--- a/lib/abuuba/federation/inbox.ex
+++ b/lib/abuuba/federation/inbox.ex
@@ -108,11 +108,6 @@ defmodule Abuuba.Federation.Inbox do
   end
 
   @doc """
-  How long a delete is remembered.
-  """
-  def tombstone_ttl_seconds, do: @tombstone_ttl_seconds
-
-  @doc """
   Whether an activity concerns an actor or object we have never heard of and
   never will.
 

--- a/lib/abuuba/federation/resolve_actor.ex
+++ b/lib/abuuba/federation/resolve_actor.ex
@@ -514,9 +514,4 @@ defmodule Abuuba.Federation.ResolveActor do
 
     key
   end
-
-  @doc """
-  How old a stored actor may be before it is fetched again.
-  """
-  def refresh_after_seconds, do: @refresh_after_seconds
 end

--- a/lib/abuuba/federation/resolve_status.ex
+++ b/lib/abuuba/federation/resolve_status.ex
@@ -668,9 +668,4 @@ defmodule Abuuba.Federation.ResolveStatus do
   How deep a reply chain may be followed.
   """
   def max_thread_depth, do: @max_thread_depth
-
-  @doc """
-  How many new objects one request may cause us to fetch.
-  """
-  def max_discoveries_per_request, do: @max_discoveries_per_request
 end

--- a/lib/abuuba/federation/signature.ex
+++ b/lib/abuuba/federation/signature.ex
@@ -179,11 +179,6 @@ defmodule Abuuba.Federation.Signature do
   @spec actor_uri_from_key_id(String.t()) :: String.t()
   def actor_uri_from_key_id(key_id), do: key_id |> String.split("#") |> List.first()
 
-  @doc """
-  How old a signed request may be before it is refused.
-  """
-  def max_age_seconds, do: @max_age_seconds
-
   ## Signing string
 
   defp build_signing_string(names, request_target, headers) do

--- a/lib/abuuba/imports/run.ex
+++ b/lib/abuuba/imports/run.ex
@@ -82,9 +82,4 @@ defmodule Abuuba.Imports.Run do
   The states a run can be in.
   """
   def states, do: @states
-
-  @doc """
-  What to do with what is already there.
-  """
-  def modes, do: @modes
 end

--- a/lib/abuuba/media/attachment.ex
+++ b/lib/abuuba/media/attachment.ex
@@ -156,14 +156,4 @@ defmodule Abuuba.Media.Attachment do
   The types an attachment may have.
   """
   def types, do: Keyword.keys(@types)
-
-  @doc """
-  The states processing moves through.
-  """
-  def processing_states, do: Keyword.keys(@processing_states)
-
-  @doc """
-  The longest alt text that will be stored.
-  """
-  def description_max, do: @description_max
 end

--- a/lib/abuuba_web/live/compose_component.ex
+++ b/lib/abuuba_web/live/compose_component.ex
@@ -542,7 +542,7 @@ defmodule AbuubaWeb.ComposeComponent do
                     phx-value-media={attachment.id}
                     phx-target={@myself}
                     name="description"
-                    maxlength={Attachment.description_max()}
+                    maxlength={Attachment.max_description()}
                     placeholder={gettext("Describe this for people who cannot see it")}
                     class="textarea textarea-sm w-full"
                   >{attachment.description}</textarea>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.20",
+      version: "1.0.21",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/abuuba/media_test.exs
+++ b/test/abuuba/media_test.exs
@@ -114,14 +114,14 @@ defmodule Abuuba.MediaTest do
     test "is capped, generously" do
       assert {:error, changeset} =
                Media.create_attachment(%{
-                 description: String.duplicate("a", Attachment.description_max() + 1)
+                 description: String.duplicate("a", Attachment.max_description() + 1)
                })
 
       assert errors_on(changeset).description != []
     end
 
     test "accepts a long description, because a good one is long" do
-      long = String.duplicate("a", Attachment.description_max())
+      long = String.duplicate("a", Attachment.max_description())
 
       assert %{description: ^long} = attachment_fixture(%{description: long})
     end


### PR DESCRIPTION
All twelve verified one at a time across `lib`, `test`, `config`, `priv` and
`mix.exs` rather than trusting a count — and the counts were misleading.
`@actor_types` exists in three modules, `max_age_seconds` is also an option key
*and* a second attribute in `rfc9421`, and the matches for `modes` were
`registration_modes` plus prose. Every one turned out to be definition plus its
own attribute and nothing else.

`Attachment.max_description/0` and `description_max/0` were two live names for
one attribute — a reader had to check which a call site meant.
`max_description/0` stays, having the `@spec` and most of the callers; the
other three call sites moved.

Two of those call sites were in `test/`, which my first sweep missed because I
had only grepped `lib/`. The full precommit caught it.

Closes #23

An AI agent wrote this text in my name. I know that is problematic.
