### PR TITLE
Write "may a stranger be shown this account" once

### DIFF
--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -263,7 +263,8 @@ rather than a default.
 ### Follow suggestions
 
 **Administration → Suggestions** lists who this server puts in front of a
-newcomer, ranked the way the suggestions themselves are. Taking somebody out is
+newcomer, drawn from the same pool as the suggestions and ranked the same way,
+so what you see here is what a newcomer could be shown. Taking somebody out is
 not a block and not a silence: their account carries on exactly as before and
 nobody is told. It is for the account you would rather not lead with — a bot
 with a thousand followers, somebody who asked not to be suggested — where a

--- a/docs/admin/trends.md
+++ b/docs/admin/trends.md
@@ -60,7 +60,10 @@ working day. One half-life for all three would be wrong twice.
 ## What is eligible
 
 A post contributes only if it is public, not a reply, not marked sensitive, and
-its author asked to be discoverable and is neither silenced nor suspended.
+its author asked to be discoverable and is neither silenced, suspended, nor
+migrated to another account. That last list is the same one the public
+directory and the follow suggestions use, so an account you take out of one is
+out of all three.
 Replies are left out deliberately: a conversation is not a trend, and counting
 replies makes the loudest argument on the server the thing everybody is shown.
 

--- a/lib/abuuba/accounts.ex
+++ b/lib/abuuba/accounts.ex
@@ -492,25 +492,55 @@ defmodule Abuuba.Accounts do
   end
 
   @doc """
+  Narrows a query to the accounts this server will put in front of somebody who
+  did not ask for them by name.
+
+  Four surfaces need that: the public directory below, follow suggestions, the
+  admin's list of who is most likely to be suggested, and whether a post may
+  feed the trends. Each used to spell the answer itself and no two agreed --
+  the admin list and the trends check both still offered an account that had
+  migrated away, and the admin's docstring claimed it matched the suggestions
+  it did not match.
+
+  Composed rather than complete: a surface with a rule of its own adds it on
+  top. The directory is local-only, because nobody on another server agreed to
+  appear in ours, and the trends honour `trendable`, which is a smaller thing
+  than limiting somebody.
+
+  Searching for an account is the fifth door and is deliberately not this one:
+  `Abuuba.Search.Postgres.accounts/3` drops the suspended and the moved-away and
+  keeps the rest, because somebody typing a name has asked for that account by
+  name. Being limited, or not discoverable, is about not being offered unasked.
+
+  Expects the account binding to be named `:account`, so it works on a query
+  rooted at `Account` and on one that reached it through a join.
+  """
+  @spec listable(Ecto.Queryable.t()) :: Ecto.Query.t()
+  def listable(query) do
+    where(
+      query,
+      [account: a],
+      # Limiting an account says it should not be put in front of people who
+      # did not ask for it, and each of the four is exactly that. Somebody who
+      # has moved is left out for a different reason: the listing should send
+      # people to the account that will answer, not to the one they left.
+      a.discoverable and is_nil(a.suspended_at) and is_nil(a.silenced_at) and
+        is_nil(a.moved_to_account_id)
+    )
+  end
+
+  @doc """
   Accounts a server is willing to list publicly.
 
-  Only accounts that asked to be discoverable, and only local ones: a directory
-  of everybody a server has ever heard of is a directory of the fediverse, not
-  of this instance, and nobody on another server agreed to appear in it.
+  `listable/1`, and only local ones: a directory of everybody a server has ever
+  heard of is a directory of the fediverse, not of this instance, and nobody on
+  another server agreed to appear in it.
   """
   @spec directory(keyword()) :: [Account.t()]
   def directory(opts \\ []) do
-    Account
-    |> where([a], is_nil(a.suspended_at) and a.discoverable)
-    # Limiting an account says it should not be put in front of people who did
-    # not ask for it, which is what a directory does. Suggestions, trends and
-    # the admin's popular list all left them out already; this was the one
-    # place that still offered them.
-    |> where([a], is_nil(a.silenced_at))
-    # And somebody who has moved: the listing should send people to the account
-    # that will answer, not to the one they left.
-    |> where([a], is_nil(a.moved_to_account_id))
-    |> where([a], is_nil(a.domain))
+    from(a in Account, as: :account)
+    |> listable()
+    |> where([account: a], is_nil(a.domain))
     |> directory_order(Keyword.get(opts, :order, "active"))
     |> offset(^Keyword.get(opts, :offset, 0))
     |> limit(^Keyword.get(opts, :limit, 40))

--- a/lib/abuuba/accounts/suggestions.ex
+++ b/lib/abuuba/accounts/suggestions.ex
@@ -14,9 +14,11 @@ defmodule Abuuba.Accounts.Suggestions do
 
   ## Nobody appears who has not asked to be found
 
-  Only accounts marked discoverable, and never one that is suspended, blocked,
-  muted, already followed, or the reader themselves. A suggestion that names
-  somebody the reader has blocked is the server arguing with them.
+  `Abuuba.Accounts.listable/1` decides the first half -- discoverable, not
+  suspended, not limited, not migrated away -- and this list adds the reader's
+  own answers: never somebody blocked, muted, already followed, or the reader
+  themselves. A suggestion that names somebody the reader has blocked is the
+  server arguing with them.
 
   Blocks count in both directions, which they did not at first: an account that
   had blocked the reader was still being offered to them, and a block exists to
@@ -37,6 +39,7 @@ defmodule Abuuba.Accounts.Suggestions do
   # and a table for it would be four files to say "these few, not those".
   @suppressed_setting "suppressed_suggestions"
 
+  alias Abuuba.Accounts
   alias Abuuba.Accounts.Account
   alias Abuuba.Accounts.SuggestionDismissal
   alias Abuuba.Relationships.Block
@@ -62,14 +65,11 @@ defmodule Abuuba.Accounts.Suggestions do
 
     from(f in Follow,
       join: a in Account,
+      as: :account,
       on: a.id == f.target_account_id,
       where: f.account_id in subquery(mine),
       where: f.target_account_id != ^account_id,
       where: f.target_account_id not in subquery(mine),
-      where: a.discoverable and is_nil(a.suspended_at) and is_nil(a.silenced_at),
-      # Nobody who has migrated away: suggesting an account somebody left is
-      # suggesting one that will never post again.
-      where: is_nil(a.moved_to_account_id),
       where: f.target_account_id not in ^suppressed(),
       where: f.target_account_id not in subquery(dismissed(account_id)),
       where: f.target_account_id not in subquery(hidden(Block, account_id)),
@@ -85,6 +85,7 @@ defmodule Abuuba.Accounts.Suggestions do
       offset: ^offset,
       select: a
     )
+    |> Accounts.listable()
     |> Repo.all()
   end
 

--- a/lib/abuuba/admin.ex
+++ b/lib/abuuba/admin.ex
@@ -697,7 +697,10 @@ defmodule Abuuba.Admin do
 
   Ranked the way the suggestions themselves are — by how many people here
   already follow them — because a screen for tuning suggestions that showed a
-  different order from the suggestions would be tuning something else.
+  different order from the suggestions would be tuning something else. Who is
+  eligible at all comes from the same `Abuuba.Accounts.listable/1` they do,
+  which this claimed and did not do: it went on offering an account that had
+  migrated away long after the suggestions stopped.
   """
   @spec suggestion_candidates(pos_integer()) :: [Account.t()]
   def suggestion_candidates(limit \\ 50) do
@@ -706,13 +709,14 @@ defmodule Abuuba.Admin do
     popular =
       from(f in Follow,
         join: a in Account,
+        as: :account,
         on: a.id == f.target_account_id,
-        where: a.discoverable and is_nil(a.suspended_at) and is_nil(a.silenced_at),
         group_by: a.id,
         order_by: [desc: count(f.account_id), desc: a.id],
         limit: ^limit,
         select: a
       )
+      |> Accounts.listable()
       |> Repo.all()
 
     # The suppressed ones are shown too, and first: an admin looking at this

--- a/lib/abuuba/trends.ex
+++ b/lib/abuuba/trends.ex
@@ -40,6 +40,7 @@ defmodule Abuuba.Trends do
 
   import Ecto.Query
 
+  alias Abuuba.Accounts
   alias Abuuba.Accounts.Account
   alias Abuuba.Federation.InstanceActor
   alias Abuuba.Moderation.AuditLog
@@ -499,9 +500,10 @@ defmodule Abuuba.Trends do
   @doc """
   Whether a post may contribute to trends at all.
 
-  Public, from somebody who asked to be findable, not sensitive, and not a
-  reply. A conversation is not a trend, and counting replies makes the loudest
-  argument on the server the thing everybody is shown.
+  Public, not sensitive, not a reply, and from an author
+  `Abuuba.Accounts.listable/1` will offer unasked. A conversation is not a
+  trend, and counting replies makes the loudest argument on the server the
+  thing everybody is shown.
   """
   @spec eligible?(Status.t()) :: boolean()
   def eligible?(%Status{} = status) do
@@ -515,14 +517,14 @@ defmodule Abuuba.Trends do
   def eligible?(_status), do: false
 
   defp author_eligible?(account_id) do
-    case Repo.get(Account, account_id) do
-      nil ->
-        false
-
-      account ->
-        account.discoverable and is_nil(account.silenced_at) and is_nil(account.suspended_at) and
-          account.trendable != false
-    end
+    from(a in Account, as: :account, where: a.id == ^account_id)
+    |> Accounts.listable()
+    # `trendable` is the moderator's separate, smaller "not in the trends" --
+    # and it is nullable, so the column being unset has to be spelled out. A
+    # bare `!= false` is NULL for every account nobody has ever touched, which
+    # in SQL is not true and would empty the trends.
+    |> where([account: a], is_nil(a.trendable) or a.trendable)
+    |> Repo.exists?()
   end
 
   ## Counting, inside

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Abuuba.MixProject do
   def project do
     [
       app: :abuuba,
-      version: "1.0.21",
+      version: "1.0.22",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -51,7 +51,7 @@ msgid "Change"
 msgstr "Ändern"
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:714
+#: lib/abuuba_web/live/compose_component.ex:715
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr "Sprache"
@@ -126,7 +126,7 @@ msgstr "Bestätige zuerst deine E-Mail-Adresse. Sieh in deinem Postfach nach."
 msgid "Create account"
 msgstr "Konto erstellen"
 
-#: lib/abuuba_web/live/landing_live.ex:81
+#: lib/abuuba_web/live/landing_live.ex:78
 #: lib/abuuba_web/live/registration_live.ex:37
 #: lib/abuuba_web/live/registration_live.ex:207
 #, elixir-autogen, elixir-format
@@ -468,8 +468,8 @@ msgstr "%{app} autorisieren"
 
 #: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:388
-#: lib/abuuba_web/live/compose_component.ex:401
+#: lib/abuuba_web/live/compose_component.ex:389
+#: lib/abuuba_web/live/compose_component.ex:402
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -626,14 +626,14 @@ msgstr "Diese Anwendung hat Berechtigungen angefragt, die dieser Server nicht ke
 msgid "Upload files as you"
 msgstr "Als du Dateien hochladen"
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:667
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:673
 #: lib/abuuba_web/controllers/well_known_controller.ex:42
 #: lib/abuuba_web/controllers/well_known_controller.ex:48
 #, elixir-autogen, elixir-format
 msgid "No such account here."
 msgstr "So ein Konto gibt es hier nicht."
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:587
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:593
 #: lib/abuuba_web/controllers/well_known_controller.ex:64
 #, elixir-autogen, elixir-format
 msgid "That account is gone."
@@ -644,12 +644,12 @@ msgstr "Dieses Konto gibt es nicht mehr."
 msgid "That is not a resource we understand."
 msgstr "Diese Ressource verstehen wir nicht."
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:685
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:691
 #, elixir-autogen, elixir-format
 msgid "A server may only ask about its own followers."
 msgstr "Ein Server darf nur nach seinen eigenen Followern fragen."
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:679
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:685
 #, elixir-autogen, elixir-format
 msgid "That request has to be signed."
 msgstr "Diese Anfrage muss signiert sein."
@@ -664,7 +664,7 @@ msgstr "Entdecken"
 #: lib/abuuba_web/components/layouts.ex:258
 #: lib/abuuba_web/components/layouts.ex:279
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2328
+#: lib/abuuba_web/live/settings_live.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
@@ -677,7 +677,7 @@ msgid "Keyboard shortcuts"
 msgstr "Tastaturkürzel"
 
 #: lib/abuuba_web/components/layouts.ex:282
-#: lib/abuuba_web/live/landing_live.ex:83
+#: lib/abuuba_web/live/landing_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr "Anmelden"
@@ -690,15 +690,15 @@ msgstr "Hauptnavigation"
 
 #: lib/abuuba_web/components/layouts.ex:261
 #: lib/abuuba_web/live/notification_settings_live.ex:31
-#: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2329
+#: lib/abuuba_web/live/notifications_live.ex:65
+#: lib/abuuba_web/live/settings_live.ex:2335
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr "Mitteilungen"
 
 #: lib/abuuba_web/components/layouts.ex:273
 #: lib/abuuba_web/live/settings_live.ex:121
-#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr "Einstellungen"
@@ -763,7 +763,7 @@ msgid "Follow some people and their posts will appear here."
 msgstr "Folge ein paar Menschen, dann erscheinen ihre Beiträge hier."
 
 #: lib/abuuba_web/components/status_component.ex:283
-#: lib/abuuba_web/live/compose_component.ex:594
+#: lib/abuuba_web/live/compose_component.ex:595
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr "Umfrage"
@@ -773,7 +773,7 @@ msgstr "Umfrage"
 msgid "Reply"
 msgstr "Antworten"
 
-#: lib/abuuba_web/live/home_live.ex:305
+#: lib/abuuba_web/live/home_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "That vote could not be counted."
 msgstr "Diese Stimme konnte nicht gezählt werden."
@@ -793,96 +793,96 @@ msgstr "Du bist am Ende angekommen."
 msgid "Your choice"
 msgstr "Deine Wahl"
 
-#: lib/abuuba_web/live/compose_component.ex:1658
+#: lib/abuuba_web/live/compose_component.ex:1701
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr "1 Tag"
 
-#: lib/abuuba_web/live/compose_component.ex:1656
+#: lib/abuuba_web/live/compose_component.ex:1699
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr "1 Stunde"
 
-#: lib/abuuba_web/live/compose_component.ex:1659
+#: lib/abuuba_web/live/compose_component.ex:1702
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr "3 Tage"
 
-#: lib/abuuba_web/live/compose_component.ex:1655
+#: lib/abuuba_web/live/compose_component.ex:1698
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr "30 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1654
+#: lib/abuuba_web/live/compose_component.ex:1697
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr "5 Minuten"
 
-#: lib/abuuba_web/live/compose_component.ex:1657
+#: lib/abuuba_web/live/compose_component.ex:1700
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr "6 Stunden"
 
-#: lib/abuuba_web/live/compose_component.ex:1660
+#: lib/abuuba_web/live/compose_component.ex:1703
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr "7 Tage"
 
-#: lib/abuuba_web/live/compose_component.ex:1132
+#: lib/abuuba_web/live/compose_component.ex:1133
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr "Eine Umfrage braucht mindestens zwei Antworten."
 
-#: lib/abuuba_web/live/compose_component.ex:629
+#: lib/abuuba_web/live/compose_component.ex:630
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr "Antwort hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:700
+#: lib/abuuba_web/live/compose_component.ex:701
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr "Umfrage hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:641
+#: lib/abuuba_web/live/compose_component.ex:642
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr "Mehrfachauswahl erlauben"
 
-#: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2323
+#: lib/abuuba_web/live/compose_component.ex:1718
+#: lib/abuuba_web/live/settings_live.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr "Alle"
 
-#: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2318
+#: lib/abuuba_web/live/compose_component.ex:1709
+#: lib/abuuba_web/live/settings_live.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr "Alle, und überall gelistet"
 
-#: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2319
+#: lib/abuuba_web/live/compose_component.ex:1710
+#: lib/abuuba_web/live/settings_live.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr "Alle, aber nicht in öffentlichen Timelines"
 
-#: lib/abuuba_web/live/compose_component.ex:605
+#: lib/abuuba_web/live/compose_component.ex:606
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr "Antwort %{number}"
 
-#: lib/abuuba_web/live/compose_component.ex:429
-#: lib/abuuba_web/live/compose_component.ex:690
+#: lib/abuuba_web/live/compose_component.ex:430
+#: lib/abuuba_web/live/compose_component.ex:691
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr "Inhaltswarnung"
 
-#: lib/abuuba_web/live/compose_component.ex:791
+#: lib/abuuba_web/live/compose_component.ex:792
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr "Strg + Enter veröffentlicht"
 
-#: lib/abuuba_web/live/compose_component.ex:424
+#: lib/abuuba_web/live/compose_component.ex:425
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr "Diese Person nicht mit anschreiben"
@@ -893,203 +893,203 @@ msgstr "Diese Person nicht mit anschreiben"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: lib/abuuba_web/live/compose_component.ex:394
+#: lib/abuuba_web/live/compose_component.ex:395
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr "Beitrag bearbeiten"
 
-#: lib/abuuba_web/live/compose_component.ex:645
+#: lib/abuuba_web/live/compose_component.ex:646
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr "Endet nach"
 
-#: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/profile_live.ex:798
+#: lib/abuuba_web/live/compose_component.ex:1711
+#: lib/abuuba_web/live/profile_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr "Follower"
 
-#: lib/abuuba_web/live/compose_component.ex:1669
+#: lib/abuuba_web/live/compose_component.ex:1712
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr "Erwähnte Personen"
 
 #: lib/abuuba_web/live/admin_live.ex:3427
-#: lib/abuuba_web/live/compose_component.ex:1677
-#: lib/abuuba_web/live/settings_live.ex:2325
+#: lib/abuuba_web/live/compose_component.ex:1720
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr "Niemand"
 
-#: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/settings_live.ex:2320
+#: lib/abuuba_web/live/compose_component.ex:1711
+#: lib/abuuba_web/live/settings_live.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr "Nur die Leute, die dir folgen"
 
-#: lib/abuuba_web/live/compose_component.ex:1669
+#: lib/abuuba_web/live/compose_component.ex:1712
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr "Nur die Leute, die du nennst"
 
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2324
+#: lib/abuuba_web/live/compose_component.ex:1719
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr "Leute, die dir folgen"
 
-#: lib/abuuba_web/live/compose_component.ex:1433
+#: lib/abuuba_web/live/compose_component.ex:1429
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/compose_component.ex:674
+#: lib/abuuba_web/live/compose_component.ex:675
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Vorschau"
 
-#: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/compose_component.ex:1684
+#: lib/abuuba_web/live/compose_component.ex:1709
+#: lib/abuuba_web/live/compose_component.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr "Öffentlich"
 
-#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/compose_component.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr "Still öffentlich"
 
-#: lib/abuuba_web/live/compose_component.ex:710
+#: lib/abuuba_web/live/compose_component.ex:711
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr "Umfrage entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:617
+#: lib/abuuba_web/live/compose_component.ex:618
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr "Diese Antwort entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:381
+#: lib/abuuba_web/live/compose_component.ex:382
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr "Antwort an %{name}"
 
-#: lib/abuuba_web/live/compose_component.ex:1431
+#: lib/abuuba_web/live/compose_component.ex:1427
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr "Änderungen speichern"
 
 #: lib/abuuba_web/live/admin_live.ex:3388
-#: lib/abuuba_web/live/compose_component.ex:456
+#: lib/abuuba_web/live/compose_component.ex:457
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr "Vorschläge"
 
-#: lib/abuuba_web/live/compose_component.ex:1094
+#: lib/abuuba_web/live/compose_component.ex:1095
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr "Das ist %{count} Zeichen zu lang."
 
-#: lib/abuuba_web/live/compose_component.ex:1156
-#: lib/abuuba_web/live/compose_component.ex:1191
-#: lib/abuuba_web/live/compose_component.ex:1387
+#: lib/abuuba_web/live/compose_component.ex:1157
+#: lib/abuuba_web/live/compose_component.ex:1201
+#: lib/abuuba_web/live/compose_component.ex:1383
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr "Der Beitrag konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/compose_component.ex:440
-#: lib/abuuba_web/live/compose_component.ex:446
+#: lib/abuuba_web/live/compose_component.ex:441
+#: lib/abuuba_web/live/compose_component.ex:447
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr "Was beschäftigt dich?"
 
-#: lib/abuuba_web/live/compose_component.ex:434
+#: lib/abuuba_web/live/compose_component.ex:435
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr "Wovor sollen die Leute gewarnt werden?"
 
-#: lib/abuuba_web/live/compose_component.ex:750
+#: lib/abuuba_web/live/compose_component.ex:751
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr "Wer das zitieren darf"
 
-#: lib/abuuba_web/live/compose_component.ex:730
+#: lib/abuuba_web/live/compose_component.ex:731
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr "Wer das sehen darf"
 
-#: lib/abuuba_web/live/compose_component.ex:1090
+#: lib/abuuba_web/live/compose_component.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr "Schreib erst mal etwas."
 
-#: lib/abuuba_web/live/compose_component.ex:1188
+#: lib/abuuba_web/live/compose_component.ex:1198
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr "Du hast gerade viel veröffentlicht. Versuch es später noch einmal."
 
-#: lib/abuuba_web/live/compose_component.ex:1627
+#: lib/abuuba_web/live/compose_component.ex:1670
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr "jemanden"
 
-#: lib/abuuba_web/live/compose_component.ex:797
+#: lib/abuuba_web/live/compose_component.ex:798
 #, elixir-autogen, elixir-format
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] "%{count} Entwurf"
 msgstr[1] "%{count} Entwürfe"
 
-#: lib/abuuba_web/live/compose_component.ex:829
+#: lib/abuuba_web/live/compose_component.ex:830
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] "%{count} Beitrag wartet auf den Versand"
 msgstr[1] "%{count} Beiträge warten auf den Versand"
 
-#: lib/abuuba_web/live/compose_component.ex:1136
+#: lib/abuuba_web/live/compose_component.ex:1137
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr "Eine Antwort ist zu lang. Halte jede unter %{count} Zeichen."
 
-#: lib/abuuba_web/live/compose_component.ex:860
+#: lib/abuuba_web/live/compose_component.ex:861
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr "Absagen"
 
-#: lib/abuuba_web/live/compose_component.ex:821
+#: lib/abuuba_web/live/compose_component.ex:822
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: lib/abuuba_web/live/compose_component.ex:660
+#: lib/abuuba_web/live/compose_component.ex:661
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr "Geht raus am"
 
-#: lib/abuuba_web/live/compose_component.ex:811
-#: lib/abuuba_web/live/compose_component.ex:850
+#: lib/abuuba_web/live/compose_component.ex:812
+#: lib/abuuba_web/live/compose_component.ex:851
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr "Öffnen"
 
-#: lib/abuuba_web/live/compose_component.ex:1107
-#: lib/abuuba_web/live/compose_component.ex:1378
+#: lib/abuuba_web/live/compose_component.ex:1108
+#: lib/abuuba_web/live/compose_component.ex:1374
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr "Sag, wann der Beitrag rausgehen soll."
 
-#: lib/abuuba_web/live/compose_component.ex:782
+#: lib/abuuba_web/live/compose_component.ex:783
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr "Planen"
 
-#: lib/abuuba_web/live/compose_component.ex:1432
+#: lib/abuuba_web/live/compose_component.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr "Einplanen"
 
-#: lib/abuuba_web/live/compose_component.ex:306
+#: lib/abuuba_web/live/compose_component.ex:307
 #, elixir-autogen, elixir-format
 msgid "That draft could not be saved."
 msgstr "Der Entwurf konnte nicht gespeichert werden."
@@ -1099,109 +1099,109 @@ msgstr "Der Entwurf konnte nicht gespeichert werden."
 msgid "That post is scheduled."
 msgstr "Der Beitrag ist eingeplant."
 
-#: lib/abuuba_web/live/compose_component.ex:1141
+#: lib/abuuba_web/live/compose_component.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr "Zwei Antworten sind gleich. Mach sie unterschiedlich."
 
-#: lib/abuuba_web/live/compose_component.ex:302
+#: lib/abuuba_web/live/compose_component.ex:303
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr "Du hast zu viele Entwürfe für einen weiteren. Verwirf erst einen."
 
-#: lib/abuuba_web/live/compose_component.ex:1426
+#: lib/abuuba_web/live/compose_component.ex:1422
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr "ein leerer Beitrag"
 
-#: lib/abuuba_web/live/compose_component.ex:667
+#: lib/abuuba_web/live/compose_component.ex:668
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr "deine eigene Zeit, mindestens %{count} Minuten ab jetzt"
 
-#: lib/abuuba_web/live/compose_component.ex:1104
+#: lib/abuuba_web/live/compose_component.ex:1105
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr "Ein Bild geht ohne Beschreibung raus. Schick noch einmal ab, um es trotzdem zu veröffentlichen."
 
-#: lib/abuuba_web/live/compose_component.ex:475
+#: lib/abuuba_web/live/compose_component.ex:476
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr "Bild, Video oder Ton hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:570
+#: lib/abuuba_web/live/compose_component.ex:571
 #, elixir-autogen, elixir-format
 msgid "Add a still"
 msgstr "Standbild hinzufügen"
 
-#: lib/abuuba_web/live/compose_component.ex:520
+#: lib/abuuba_web/live/compose_component.ex:521
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr "Klick auf den wichtigsten Teil"
 
-#: lib/abuuba_web/live/compose_component.ex:537
-#: lib/abuuba_web/live/compose_component.ex:545
+#: lib/abuuba_web/live/compose_component.ex:538
+#: lib/abuuba_web/live/compose_component.ex:546
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr "Beschreibe das für Leute, die es nicht sehen können"
 
-#: lib/abuuba_web/live/compose_component.ex:559
+#: lib/abuuba_web/live/compose_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr "Nach vorne"
 
-#: lib/abuuba_web/live/compose_component.ex:574
+#: lib/abuuba_web/live/compose_component.ex:575
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr "Standbild auswählen"
 
-#: lib/abuuba_web/live/compose_component.ex:532
+#: lib/abuuba_web/live/compose_component.ex:533
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr "Bildmittelpunkt festlegen"
 
-#: lib/abuuba_web/live/compose_component.ex:500
+#: lib/abuuba_web/live/compose_component.ex:501
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr "Abbrechen"
 
-#: lib/abuuba_web/live/compose_component.ex:585
+#: lib/abuuba_web/live/compose_component.ex:586
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/compose_component.ex:241
-#: lib/abuuba_web/live/compose_component.ex:1422
+#: lib/abuuba_web/live/compose_component.ex:242
+#: lib/abuuba_web/live/compose_component.ex:1418
 #, elixir-autogen, elixir-format
 msgid "That file could not be uploaded."
 msgstr "Die Datei konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/compose_component.ex:1419
+#: lib/abuuba_web/live/compose_component.ex:1415
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/compose_component.ex:228
+#: lib/abuuba_web/live/compose_component.ex:229
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr "Mehr als %{count} Bilder trägt ein Beitrag nicht."
 
-#: lib/abuuba_web/live/compose_component.ex:1420
+#: lib/abuuba_web/live/compose_component.ex:1416
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr "Das sind mehr Dateien, als ein Beitrag tragen kann."
 
-#: lib/abuuba_web/live/compose_component.ex:1421
+#: lib/abuuba_web/live/compose_component.ex:1417
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr "Dieser Server nimmt keine Dateien dieser Art."
 
-#: lib/abuuba_web/live/compose_component.ex:479
+#: lib/abuuba_web/live/compose_component.ex:480
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr "oder zieh eine ins Feld oder füg sie ein"
 
-#: lib/abuuba_web/live/status_live.ex:316
+#: lib/abuuba_web/live/status_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr "%{name} auf %{server}"
@@ -1220,7 +1220,7 @@ msgstr "Blockieren"
 
 #: lib/abuuba_web/live/explore_live.ex:114
 #: lib/abuuba_web/live/profile_live.ex:144
-#: lib/abuuba_web/live/tag_live.ex:63
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr "Folgen"
@@ -1230,12 +1230,12 @@ msgstr "Folgen"
 msgid "Go to the new account"
 msgstr "Zum neuen Konto"
 
-#: lib/abuuba_web/live/status_live.ex:121
+#: lib/abuuba_web/live/status_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Look for more replies on the other server"
 msgstr "Auf dem anderen Server nach weiteren Antworten suchen"
 
-#: lib/abuuba_web/live/profile_live.ex:797
+#: lib/abuuba_web/live/profile_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr "Medien"
@@ -1258,8 +1258,8 @@ msgstr "Hier ist noch nichts."
 msgid "Pinned"
 msgstr "Angeheftet"
 
-#: lib/abuuba_web/live/explore_live.ex:256
-#: lib/abuuba_web/live/profile_live.ex:795
+#: lib/abuuba_web/live/explore_live.ex:247
+#: lib/abuuba_web/live/profile_live.ex:772
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:208
@@ -1267,7 +1267,7 @@ msgstr "Angeheftet"
 msgid "Posts"
 msgstr "Beiträge"
 
-#: lib/abuuba_web/live/profile_live.ex:796
+#: lib/abuuba_web/live/profile_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr "Beiträge und Antworten"
@@ -1297,7 +1297,7 @@ msgstr "Blockierung aufheben"
 #: lib/abuuba_web/live/profile_live.ex:162
 #: lib/abuuba_web/live/report_live.ex:263
 #: lib/abuuba_web/live/report_live.ex:268
-#: lib/abuuba_web/live/tag_live.ex:63
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr "Entfolgen"
@@ -1318,103 +1318,103 @@ msgstr "Bestätigt"
 msgid "What to show"
 msgstr "Was gezeigt wird"
 
-#: lib/abuuba_web/live/notifications_live.ex:112
+#: lib/abuuba_web/live/notifications_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] "%{count} neu"
 msgstr[1] "%{count} neu"
 
-#: lib/abuuba_web/live/notifications_live.ex:162
+#: lib/abuuba_web/live/notifications_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] "%{count} Mitteilung"
 msgstr[1] "%{count} Mitteilungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:409
+#: lib/abuuba_web/live/notifications_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] "%{count} Person hat deinen Beitrag geteilt"
 msgstr[1] "%{count} Leute haben deinen Beitrag geteilt"
 
-#: lib/abuuba_web/live/notifications_live.ex:413
+#: lib/abuuba_web/live/notifications_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] "%{count} Person hat deinen Beitrag favorisiert"
 msgstr[1] "%{count} Leute haben deinen Beitrag favorisiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:420
+#: lib/abuuba_web/live/notifications_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] "%{count} Person folgt dir jetzt"
 msgstr[1] "%{count} Leute folgen dir jetzt"
 
-#: lib/abuuba_web/live/notifications_live.ex:423
+#: lib/abuuba_web/live/notifications_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] "%{count} Person hat dich erwähnt"
 msgstr[1] "%{count} Leute haben dich erwähnt"
 
-#: lib/abuuba_web/live/notifications_live.ex:147
+#: lib/abuuba_web/live/notifications_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] "%{count} Person wartet darauf, dich zu erreichen"
 msgstr[1] "%{count} Leute warten darauf, dich zu erreichen"
 
-#: lib/abuuba_web/live/notifications_live.ex:427
+#: lib/abuuba_web/live/notifications_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] "%{name} und %{count} weitere Person"
 msgstr[1] "%{name} und %{count} weitere Leute"
 
-#: lib/abuuba_web/live/notifications_live.ex:376
+#: lib/abuuba_web/live/notifications_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr "%{name} möchte dir folgen"
 
-#: lib/abuuba_web/live/notifications_live.ex:374
+#: lib/abuuba_web/live/notifications_live.ex:408
 #, elixir-autogen, elixir-format
 msgid "%{name} boosted your post"
 msgstr "%{name} hat deinen Beitrag geteilt"
 
-#: lib/abuuba_web/live/notifications_live.ex:379
+#: lib/abuuba_web/live/notifications_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr "%{name} hat einen Beitrag bearbeitet, den du geteilt hast"
 
-#: lib/abuuba_web/live/notifications_live.ex:377
+#: lib/abuuba_web/live/notifications_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr "%{name} hat deinen Beitrag favorisiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:375
+#: lib/abuuba_web/live/notifications_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr "%{name} folgt dir jetzt"
 
-#: lib/abuuba_web/live/notifications_live.ex:373
+#: lib/abuuba_web/live/notifications_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr "%{name} hat dich erwähnt"
 
-#: lib/abuuba_web/live/notifications_live.ex:380
+#: lib/abuuba_web/live/notifications_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "%{name} posted"
 msgstr "%{name} hat etwas veröffentlicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:381
+#: lib/abuuba_web/live/notifications_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr "%{name} hat deinen Beitrag zitiert"
 
-#: lib/abuuba_web/live/notifications_live.ex:378
+#: lib/abuuba_web/live/notifications_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr "Eine Umfrage von %{name} ist beendet"
@@ -1439,7 +1439,7 @@ msgstr "Konten, die eine Moderation eingeschränkt hat"
 msgid "Accounts made very recently"
 msgstr "Ganz neu angelegte Konten"
 
-#: lib/abuuba_web/live/notifications_live.ex:459
+#: lib/abuuba_web/live/notifications_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr "Alle"
@@ -1469,17 +1469,17 @@ msgstr "Alle, denen du nicht folgst."
 msgid "Automated accounts"
 msgstr "Automatische Konten"
 
-#: lib/abuuba_web/live/notifications_live.ex:468
+#: lib/abuuba_web/live/notifications_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Boosts"
 msgstr "Geteilte Beiträge"
 
-#: lib/abuuba_web/live/notifications_live.ex:140
+#: lib/abuuba_web/live/notifications_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr "Alle löschen"
 
-#: lib/abuuba_web/live/notifications_live.ex:207
+#: lib/abuuba_web/live/notifications_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr "Ausblenden"
@@ -1489,13 +1489,13 @@ msgstr "Ausblenden"
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr "Jede Zeile beschreibt eine Art von Absender. Annehmen lässt sie durch, Filtern legt sie in die Warteliste auf deiner Mitteilungsseite, und Ignorieren verwirft sie."
 
-#: lib/abuuba_web/live/notifications_live.ex:473
+#: lib/abuuba_web/live/notifications_live.ex:507
 #, elixir-autogen, elixir-format
 msgid "Edits"
 msgstr "Bearbeitungen"
 
 #: lib/abuuba_web/components/layouts.ex:151
-#: lib/abuuba_web/live/notifications_live.ex:471
+#: lib/abuuba_web/live/notifications_live.ex:505
 #: lib/abuuba_web/live/saved_live.ex:88
 #: lib/abuuba_web/live/saved_live.ex:95
 #: lib/abuuba_web/live/settings_live.ex:220
@@ -1511,15 +1511,15 @@ msgstr "Filtern"
 #: lib/abuuba_web/components/layouts.ex:292
 #: lib/abuuba_web/live/follow_requests_live.ex:37
 #: lib/abuuba_web/live/follow_requests_live.ex:44
-#: lib/abuuba_web/live/notifications_live.ex:470
+#: lib/abuuba_web/live/notifications_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr "Folgeanfragen"
 
-#: lib/abuuba_web/live/notifications_live.ex:469
-#: lib/abuuba_web/live/profile_live.ex:799
-#: lib/abuuba_web/live/settings_live.ex:2121
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/notifications_live.ex:503
+#: lib/abuuba_web/live/profile_live.ex:776
+#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr "Folge ich"
@@ -1534,28 +1534,28 @@ msgstr "Ignorieren"
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr "Bei Ignorieren ist Vorsicht geboten: nichts wird irgendwo abgelegt und es lässt sich nicht wiederherstellen. Filtern ist die umkehrbare Wahl."
 
-#: lib/abuuba_web/live/notifications_live.ex:176
+#: lib/abuuba_web/live/notifications_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr "Durchlassen"
 
-#: lib/abuuba_web/live/notifications_live.ex:136
+#: lib/abuuba_web/live/notifications_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
-#: lib/abuuba_web/live/notifications_live.ex:459
-#: lib/abuuba_web/live/notifications_live.ex:467
+#: lib/abuuba_web/live/notifications_live.ex:493
+#: lib/abuuba_web/live/notifications_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr "Erwähnungen"
 
-#: lib/abuuba_web/live/notifications_live.ex:185
+#: lib/abuuba_web/live/notifications_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr "Jetzt nicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:221
+#: lib/abuuba_web/live/notifications_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr "Es ist noch nichts passiert."
@@ -1570,7 +1570,7 @@ msgstr "Leute, die dir nicht folgen"
 msgid "People you do not follow"
 msgstr "Leute, denen du nicht folgst"
 
-#: lib/abuuba_web/live/notifications_live.ex:472
+#: lib/abuuba_web/live/notifications_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "Polls"
 msgstr "Umfragen"
@@ -1606,8 +1606,8 @@ msgstr "Speichern"
 msgid "Saved."
 msgstr "Gespeichert."
 
-#: lib/abuuba_web/live/notifications_live.ex:371
-#: lib/abuuba_web/live/notifications_live.ex:436
+#: lib/abuuba_web/live/notifications_live.ex:405
+#: lib/abuuba_web/live/notifications_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr "Jemand"
@@ -1617,7 +1617,7 @@ msgstr "Jemand"
 msgid "Somebody a moderator here has already restricted."
 msgstr "Jemand, den eine Moderation hier bereits eingeschränkt hat."
 
-#: lib/abuuba_web/live/notifications_live.ex:406
+#: lib/abuuba_web/live/notifications_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr "Etwas ist passiert, das %{name} betrifft"
@@ -1627,7 +1627,7 @@ msgstr "Etwas ist passiert, das %{name} betrifft"
 msgid "That could not be saved. Try again."
 msgstr "Das konnte nicht gespeichert werden. Versuch es noch einmal."
 
-#: lib/abuuba_web/live/notifications_live.ex:101
+#: lib/abuuba_web/live/notifications_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr "Welche Mitteilungen"
@@ -1637,7 +1637,7 @@ msgstr "Welche Mitteilungen"
 msgid "Who can reach you"
 msgstr "Wer dich erreichen kann"
 
-#: lib/abuuba_web/live/notifications_live.ex:154
+#: lib/abuuba_web/live/notifications_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr "Deine Einstellungen haben diese abgelegt, statt sie zu zeigen."
@@ -1660,7 +1660,7 @@ msgstr "Ein Name, ein #Tag oder ein paar Wörter"
 msgid "Everything"
 msgstr "Alles"
 
-#: lib/abuuba_web/live/explore_live.ex:257
+#: lib/abuuba_web/live/explore_live.ex:248
 #: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:207
@@ -1668,12 +1668,12 @@ msgstr "Alles"
 msgid "Hashtags"
 msgstr "Hashtags"
 
-#: lib/abuuba_web/live/landing_live.ex:70
+#: lib/abuuba_web/live/landing_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "It runs %{software}, which is free software anybody may run."
 msgstr "Er läuft mit %{software}, freier Software, die jeder betreiben darf."
 
-#: lib/abuuba_web/live/landing_live.ex:84
+#: lib/abuuba_web/live/landing_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Look around first"
 msgstr "Erst mal umsehen"
@@ -1683,17 +1683,17 @@ msgstr "Erst mal umsehen"
 msgid "Narrowing a search"
 msgstr "Eine Suche eingrenzen"
 
-#: lib/abuuba_web/live/landing_live.ex:100
+#: lib/abuuba_web/live/landing_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted publicly here yet."
 msgstr "Hier hat noch niemand öffentlich etwas veröffentlicht."
 
-#: lib/abuuba_web/live/tag_live.ex:78
+#: lib/abuuba_web/live/tag_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted under this tag yet."
 msgstr "Unter diesem Tag hat noch niemand etwas veröffentlicht."
 
-#: lib/abuuba_web/live/explore_live.ex:124
+#: lib/abuuba_web/live/explore_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht haben."
@@ -1703,7 +1703,7 @@ msgstr "Hier ist noch nichts. Komm wieder, wenn Leute etwas veröffentlicht habe
 msgid "Nothing matched that."
 msgstr "Dazu gab es keine Treffer."
 
-#: lib/abuuba_web/live/explore_live.ex:258
+#: lib/abuuba_web/live/explore_live.ex:249
 #: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:206
@@ -1711,7 +1711,7 @@ msgstr "Dazu gab es keine Treffer."
 msgid "People"
 msgstr "Leute"
 
-#: lib/abuuba_web/live/landing_live.ex:89
+#: lib/abuuba_web/live/landing_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Recently, from people here"
 msgstr "Neulich, von Leuten hier"
@@ -1740,7 +1740,7 @@ msgstr "Die Registrierung braucht eine Freigabe: du meldest dich an und eine Adm
 msgid "Search"
 msgstr "Suche"
 
-#: lib/abuuba_web/live/landing_live.ex:64
+#: lib/abuuba_web/live/landing_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr "Dies ist ein Server im Fediverse: ein Netzwerk unabhängiger Server, deren Leute einander folgen und miteinander reden können, egal auf welchem sie sind. Ein Konto hier kann allen überall darin folgen."
@@ -1781,7 +1781,7 @@ msgid "About you"
 msgstr "Über dich"
 
 #: lib/abuuba_web/live/admin_live.ex:3378
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr "Konto"
@@ -1796,22 +1796,22 @@ msgstr "Feld hinzufügen"
 msgid "Add a filter"
 msgstr "Filter hinzufügen"
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2123
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr "Darstellung"
 
-#: lib/abuuba_web/live/settings_live.ex:2295
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr "Gilt nur für deine öffentlichen Beiträge."
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr "Apps"
 
-#: lib/abuuba_web/live/settings_live.ex:2148
+#: lib/abuuba_web/live/settings_live.ex:2154
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr "Apps, die in dein Konto gelassen wurden."
@@ -1821,7 +1821,7 @@ msgstr "Apps, die in dein Konto gelassen wurden."
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr "Apps, bei denen du angemeldet bist. Eine wieder hinauszunehmen meldet sie sofort ab."
 
-#: lib/abuuba_web/live/settings_live.ex:2290
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr "Vor jedem Follow fragen"
@@ -1843,7 +1843,7 @@ msgstr "Löschen"
 msgid "Display name"
 msgstr "Anzeigename"
 
-#: lib/abuuba_web/live/settings_live.ex:2306
+#: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr "Medien nicht von selbst abspielen"
@@ -1853,12 +1853,12 @@ msgstr "Medien nicht von selbst abspielen"
 msgid "Each line has to be a web address, one per line."
 msgstr "Jede Zeile muss eine Webadresse sein, eine pro Zeile."
 
-#: lib/abuuba_web/live/settings_live.ex:2291
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr "Jeder Follow wird zu einer Anfrage, die du beantwortest."
 
-#: lib/abuuba_web/live/settings_live.ex:2146
+#: lib/abuuba_web/live/settings_live.ex:2152
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr "Allen, denen du folgst, und ein Weg, damit aufzuhören."
@@ -1873,33 +1873,33 @@ msgstr "Alles zu deinem Konto ist hier. Wähl einen Bereich."
 msgid "Fields"
 msgstr "Felder"
 
-#: lib/abuuba_web/live/settings_live.ex:2120
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2271
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr "Filter"
 
-#: lib/abuuba_web/live/settings_live.ex:2347
+#: lib/abuuba_web/live/settings_live.ex:2353
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr "Hinter einer Warnung zusammenklappen"
 
-#: lib/abuuba_web/live/settings_live.ex:2348
+#: lib/abuuba_web/live/settings_live.ex:2354
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr "Ganz ausblenden"
 
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr "Verbergen, wem ich folge und wer mir folgt"
 
-#: lib/abuuba_web/live/settings_live.ex:2304
+#: lib/abuuba_web/live/settings_live.ex:2310
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr "Mehr Kontrast"
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2148
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr "Wie sich die Oberfläche verhält und liest."
@@ -1909,17 +1909,17 @@ msgstr "Wie sich die Oberfläche verhält und liest."
 msgid "Label"
 msgstr "Bezeichnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr "Suchmaschinen meine Beiträge indexieren lassen"
 
-#: lib/abuuba_web/live/settings_live.ex:2292
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr "Mich im Verzeichnis listen"
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr "Markiert das Konto als Bot, worauf manche Leute filtern."
@@ -1944,47 +1944,47 @@ msgstr "Eine Webadresse pro Zeile. Ein Konto hier zu nennen erlaubt dir später 
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr "Nur die genannten Leute fehlt mit Absicht: als Voreinstellung wird jeder Beitrag, den du zu ändern vergisst, zu einer Nachricht an niemanden."
 
-#: lib/abuuba_web/live/settings_live.ex:2149
+#: lib/abuuba_web/live/settings_live.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr "Deine anderen Konten und der Umzug zwischen ihnen."
 
-#: lib/abuuba_web/live/settings_live.ex:2311
+#: lib/abuuba_web/live/settings_live.ex:2317
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr "Überschreibt deine Systemeinstellung, wenn sie für dich falsch ist."
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2121
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr "Überblick"
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr "Veröffentlichen"
 
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr "Profil"
 
-#: lib/abuuba_web/live/settings_live.ex:2332
+#: lib/abuuba_web/live/settings_live.ex:2338
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr "Profile"
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2336
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr "Öffentliche Timelines"
 
-#: lib/abuuba_web/live/settings_live.ex:2303
+#: lib/abuuba_web/live/settings_live.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr "Bewegung reduzieren"
@@ -2001,7 +2001,7 @@ msgstr "Bewegung reduzieren"
 msgid "Remove"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr "Sicherheit"
@@ -2016,7 +2016,7 @@ msgstr "Überall abmelden"
 msgid "Signing out everywhere ends every session, including this one."
 msgstr "Überall abmelden beendet jede Sitzung, auch diese."
 
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr "Hält das erste Absenden an, wenn ein Bild keine Beschreibung hat."
@@ -2027,7 +2027,7 @@ msgid "Take it back out"
 msgstr "Wieder hinausnehmen"
 
 #: lib/abuuba_web/live/admin_live.ex:3746
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr "Das konnte nicht gespeichert werden. Prüf, was du eingegeben hast."
@@ -2042,17 +2042,17 @@ msgstr "Das aktuelle Passwort stimmt nicht."
 msgid "The language you usually write in"
 msgstr "Die Sprache, in der du meistens schreibst"
 
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2303
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr "Die Listen sind nicht mehr öffentlich; die Follows selbst funktionieren weiter."
 
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2304
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr "Dieses Konto veröffentlicht automatisch"
 
-#: lib/abuuba_web/live/settings_live.ex:2331
+#: lib/abuuba_web/live/settings_live.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr "Threads"
@@ -2072,7 +2072,7 @@ msgstr "Den angehakten entfolgen"
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr "Bis zu vier Zeilen auf deinem Profil. Die Reihenfolge hier ist die Reihenfolge dort."
 
-#: lib/abuuba_web/live/settings_live.ex:2305
+#: lib/abuuba_web/live/settings_live.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr "Die Schrift meines Systems verwenden"
@@ -2082,7 +2082,7 @@ msgstr "Die Schrift meines Systems verwenden"
 msgid "Value"
 msgstr "Wert"
 
-#: lib/abuuba_web/live/settings_live.ex:2307
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr "Mich auf fehlende Beschreibungen hinweisen"
@@ -2092,7 +2092,7 @@ msgstr "Mich auf fehlende Beschreibungen hinweisen"
 msgid "What it does"
 msgstr "Was er tut"
 
-#: lib/abuuba_web/live/settings_live.ex:2143
+#: lib/abuuba_web/live/settings_live.ex:2149
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr "Womit das Schreibfeld beginnt."
@@ -2108,7 +2108,7 @@ msgstr "Wie er heißen soll"
 msgid "Where it applies"
 msgstr "Wo er gilt"
 
-#: lib/abuuba_web/live/settings_live.ex:2144
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr "Wer dich finden kann und wer fragen muss, um zu folgen."
@@ -2123,7 +2123,7 @@ msgstr "Wer neue Beiträge zitieren darf"
 msgid "Who new posts go to"
 msgstr "An wen neue Beiträge gehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2145
+#: lib/abuuba_web/live/settings_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr "Wörter und Wendungen, die du lieber nicht siehst."
@@ -2133,7 +2133,7 @@ msgstr "Wörter und Wendungen, die du lieber nicht siehst."
 msgid "You are not following anybody yet."
 msgstr "Du folgst noch niemandem."
 
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr "Dein Konto erscheint auf der öffentlichen Verzeichnisseite dieses Servers."
@@ -2143,7 +2143,7 @@ msgstr "Dein Konto erscheint auf der öffentlichen Verzeichnisseite dieses Serve
 msgid "Your current password"
 msgstr "Dein aktuelles Passwort"
 
-#: lib/abuuba_web/live/settings_live.ex:2141
+#: lib/abuuba_web/live/settings_live.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr "Dein Name, was du über dich sagst, deine Felder."
@@ -2153,7 +2153,7 @@ msgstr "Dein Name, was du über dich sagst, deine Felder."
 msgid "Your other accounts"
 msgstr "Deine anderen Konten"
 
-#: lib/abuuba_web/live/settings_live.ex:2147
+#: lib/abuuba_web/live/settings_live.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr "Dein Passwort, Zwei-Faktor und das Abmelden."
@@ -2309,12 +2309,12 @@ msgstr "Beiträge"
 msgid "servers known"
 msgstr "bekannte Server"
 
-#: lib/abuuba_web/live/settings_live.ex:1876
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr "Eine Verwarnung"
 
-#: lib/abuuba_web/live/settings_live.ex:2152
+#: lib/abuuba_web/live/settings_live.ex:2158
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr "Alles, was eine Moderatorin oder ein Moderator hier über dein Konto entschieden hat."
@@ -2324,7 +2324,7 @@ msgstr "Alles, was eine Moderatorin oder ein Moderator hier über dein Konto ent
 msgid "Appeal this"
 msgstr "Einspruch einlegen"
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr "Moderation"
@@ -2334,7 +2334,7 @@ msgstr "Moderation"
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr "Hier ist nichts. Niemand aus der Moderation hat etwas gegen dein Konto unternommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr "Schreib bitte etwas dazu, warum du das für falsch hältst."
@@ -2344,13 +2344,13 @@ msgstr "Schreib bitte etwas dazu, warum du das für falsch hältst."
 msgid "Say why you think this was wrong"
 msgstr "Warum hältst du das für falsch?"
 
-#: lib/abuuba_web/live/settings_live.ex:1879
+#: lib/abuuba_web/live/settings_live.ex:1885
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr "Einige deiner Beiträge wurden gelöscht"
 
 #: lib/abuuba_web/live/settings_live.ex:1218
-#: lib/abuuba_web/live/settings_live.ex:1856
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr "Die Frist für einen Einspruch ist abgelaufen."
@@ -2360,37 +2360,37 @@ msgstr "Die Frist für einen Einspruch ist abgelaufen."
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr "Was die Moderation hier über dein Konto entschieden hat und was dir dazu gesagt wurde."
 
-#: lib/abuuba_web/live/settings_live.ex:1871
+#: lib/abuuba_web/live/settings_live.ex:1877
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr "Du hast Einspruch eingelegt, er wurde abgelehnt."
 
-#: lib/abuuba_web/live/settings_live.ex:1870
+#: lib/abuuba_web/live/settings_live.ex:1876
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr "Du hast Einspruch eingelegt, ihm wurde stattgegeben."
 
-#: lib/abuuba_web/live/settings_live.ex:1872
+#: lib/abuuba_web/live/settings_live.ex:1878
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr "Du hast Einspruch eingelegt. Entschieden ist noch nichts."
 
-#: lib/abuuba_web/live/settings_live.ex:1877
+#: lib/abuuba_web/live/settings_live.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr "Dein Konto wurde deaktiviert"
 
-#: lib/abuuba_web/live/settings_live.ex:1880
+#: lib/abuuba_web/live/settings_live.ex:1886
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr "Dein Konto wurde eingeschränkt"
 
-#: lib/abuuba_web/live/settings_live.ex:1881
+#: lib/abuuba_web/live/settings_live.ex:1887
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr "Dein Konto wurde gesperrt"
 
-#: lib/abuuba_web/live/settings_live.ex:1878
+#: lib/abuuba_web/live/settings_live.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr "Deine Beiträge wurden als sensibel markiert"
@@ -2847,7 +2847,7 @@ msgstr "Was gerade im Trend liegt"
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr "Worüber gerade mehr Leute als sonst schreiben, danach alles Übrige, das Neueste zuerst."
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2115
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr "%{uses} von %{max} genutzt"
@@ -2867,7 +2867,7 @@ msgstr "Eine Ankündigung braucht einen Text."
 msgid "Announcements"
 msgstr "Ankündigungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2154
+#: lib/abuuba_web/live/settings_live.ex:2160
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr "Codes, mit denen sich Bekannte von dir anmelden können."
@@ -2907,7 +2907,7 @@ msgstr "Gültig ab"
 msgid "In effect from %{date}"
 msgstr "Gültig ab %{date}"
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr "Einladungen"
@@ -3003,7 +3003,7 @@ msgstr "Du hast noch keine erstellt."
 msgid "everybody was told"
 msgstr "alle wurden informiert"
 
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2112
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3117,9 +3117,9 @@ msgstr "nur mit Freigabe"
 msgid "by %{name}"
 msgstr "von %{name}"
 
-#: lib/abuuba_web/live/home_live.ex:357
-#: lib/abuuba_web/live/post_actions.ex:395
-#: lib/abuuba_web/live/status_live.ex:226
+#: lib/abuuba_web/live/home_live.ex:351
+#: lib/abuuba_web/live/post_actions.ex:402
+#: lib/abuuba_web/live/status_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "That could not be translated just now."
 msgstr "Das ließ sich gerade nicht übersetzen."
@@ -3139,133 +3139,133 @@ msgstr "Übersetzt von %{provider}. Lade die Seite neu für das Original."
 msgid "This account has been disabled. Contact the moderators."
 msgstr "Dieses Konto wurde deaktiviert. Wende dich an die Moderation."
 
-#: lib/abuuba_web/live/settings_live.ex:2005
+#: lib/abuuba_web/live/settings_live.ex:2011
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr "%{count} konnten nicht übernommen werden"
 
-#: lib/abuuba_web/live/settings_live.ex:1996
+#: lib/abuuba_web/live/settings_live.ex:2002
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr "%{done} von %{total} gelesen, %{imported} übernommen."
 
-#: lib/abuuba_web/live/settings_live.ex:1912
+#: lib/abuuba_web/live/settings_live.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr "Boosts und Umfragen. Ein Boost verweist auf den Beitrag einer anderen Person, den das Archiv nicht enthält, und die Stimmen einer Umfrage wären hier nicht mehr richtig."
 
-#: lib/abuuba_web/live/settings_live.ex:2069
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr "Wähle zuerst ein Archiv aus."
 
-#: lib/abuuba_web/live/settings_live.ex:1893
+#: lib/abuuba_web/live/settings_live.ex:1899
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr "Jeder Fediverse-Server gibt dir ein ZIP mit allem, was du geschrieben hast. Lade es hier hoch, und deine Beiträge kommen zurück, mit ihren Bildern und ihrem ursprünglichen Datum."
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr "Fertig."
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr "Import"
 
-#: lib/abuuba_web/live/settings_live.ex:1918
+#: lib/abuuba_web/live/settings_live.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr "Importierte Beiträge tauchen in keiner Timeline auf und gehen nicht ins Netzwerk. Sie stehen in deinem Profil, in der Reihenfolge, in der du sie geschrieben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2090
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr "Ein Archiv auf einmal."
 
-#: lib/abuuba_web/live/settings_live.ex:2157
+#: lib/abuuba_web/live/settings_live.ex:2163
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr "Ein Archiv deiner Beiträge von einem anderen Server wieder einlesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2097
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr "Dein Archiv wird gelesen."
 
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr "Das Archiv konnte nicht gelesen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr "Das konnte nicht gelesen werden. Lade das Archiv hoch, das dir dein alter Server gegeben hat."
 
-#: lib/abuuba_web/live/settings_live.ex:2080
-#: lib/abuuba_web/live/settings_live.ex:2085
+#: lib/abuuba_web/live/settings_live.ex:2086
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr "Das konnte nicht hochgeladen werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2088
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr "Die Datei ist zu groß."
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2089
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr "Das ist keine Archivdatei."
 
-#: lib/abuuba_web/live/settings_live.ex:1902
+#: lib/abuuba_web/live/settings_live.ex:1908
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr "Die alten Adressen. Deine Beiträge lagen auf einer anderen Domain und können dort nicht wieder liegen, also bleibt jeder Link darauf tot."
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr "Wartet auf den Start."
 
-#: lib/abuuba_web/live/settings_live.ex:1899
+#: lib/abuuba_web/live/settings_live.ex:1905
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr "Was nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:1907
+#: lib/abuuba_web/live/settings_live.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr "Deine Follower. Ein Follow ist eine Abmachung zwischen zwei Servern, und einer davon ist weg; sie müssen diesem Konto neu folgen."
 
-#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr "ein Boost, der nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2104
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr "eine Umfrage, die nicht mitkommen kann"
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr "kein Datum, also kein Platz dafür"
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr "die Datei ist kein Archiv"
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr "der Beitrag wurde nicht gefunden"
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr "dieser Server hat ihn nicht angenommen"
@@ -3275,7 +3275,7 @@ msgstr "dieser Server hat ihn nicht angenommen"
 msgid "Accept all"
 msgstr "Alle annehmen"
 
-#: lib/abuuba_web/live/settings_live.ex:1951
+#: lib/abuuba_web/live/settings_live.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr "Dazu hinzufügen"
@@ -3285,7 +3285,7 @@ msgstr "Dazu hinzufügen"
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr "Nach einem Umzug kommen alle, die dir gefolgt sind, auf einmal an. Das nimmt sie alle an, was dieselbe Antwort ist, die du ihnen schon gegeben hast."
 
-#: lib/abuuba_web/live/settings_live.ex:1969
+#: lib/abuuba_web/live/settings_live.ex:1975
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr "Ein Archiv deiner Beiträge"
@@ -3305,19 +3305,19 @@ msgstr "Wartende Folgeanfragen"
 msgid "I came back"
 msgstr "Ich bin zurück"
 
-#: lib/abuuba_web/live/settings_live.ex:1982
+#: lib/abuuba_web/live/settings_live.ex:1988
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr "Archiv importieren"
 
-#: lib/abuuba_web/live/settings_live.ex:1959
+#: lib/abuuba_web/live/settings_live.ex:1965
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr "Liste importieren"
 
 #: lib/abuuba_web/live/settings_live.ex:1082
-#: lib/abuuba_web/live/settings_live.ex:1931
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:1937
+#: lib/abuuba_web/live/settings_live.ex:2268
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr "Listen"
@@ -3332,7 +3332,7 @@ msgstr "Umziehen"
 msgid "Move to another account"
 msgstr "Zu einem anderen Konto umziehen"
 
-#: lib/abuuba_web/live/settings_live.ex:2055
+#: lib/abuuba_web/live/settings_live.ex:2061
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr "Unter dieser Adresse war niemand zu finden."
@@ -3342,22 +3342,22 @@ msgstr "Unter dieser Adresse war niemand zu finden."
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr "Anderen Servern wird gesagt, dass sie stattdessen dem neuen Konto folgen sollen. Wer dir von diesem Server aus folgt, ist bereits umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1955
+#: lib/abuuba_web/live/settings_live.ex:1961
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr "Durch die Datei ersetzen"
 
-#: lib/abuuba_web/live/settings_live.ex:2045
+#: lib/abuuba_web/live/settings_live.ex:2051
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr "Dieses Konto nennt dieses hier nicht als eines von deinen. Trage die Adresse dieses Kontos zuerst dort bei den Aliassen ein."
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:2062
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr "Das ist dieses Konto."
 
-#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:1939
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr "Die CSV-Dateien, die dir dein alter Server gibt: Follows, Blocks, Stummschaltungen, Domain-Blocks, Listen, Lesezeichen, Filter. Lade sie einzeln hoch, unter dem Namen, unter dem sie kamen."
@@ -3372,17 +3372,17 @@ msgstr "Das andere Konto muss dieses hier zuerst in seinen eigenen Aliassen nenn
 msgid "This account has moved."
 msgstr "Dieses Konto ist zu %{handle} umgezogen."
 
-#: lib/abuuba_web/live/settings_live.ex:1948
+#: lib/abuuba_web/live/settings_live.ex:1954
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr "Was mit dem passieren soll, was schon da ist"
 
-#: lib/abuuba_web/live/settings_live.ex:2051
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr "Du bist vor Kurzem umgezogen. Ein Konto kann nur alle %{days} Tage umziehen."
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:673
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:679
 #, elixir-autogen, elixir-format
 msgid "No such post here."
 msgstr "So einen Beitrag gibt es hier nicht."
@@ -3843,20 +3843,20 @@ msgstr "das Passwort deines Kontos auf %{site} wurde gerade geändert, und über
 msgid "A copy of everything"
 msgstr "Eine Kopie von allem"
 
-#: lib/abuuba_web/live/settings_live.ex:2269
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr "Wird gebaut"
 
 #: lib/abuuba_web/live/settings_live.ex:822
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr "Blockierte Server"
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr "Blockierte"
@@ -3865,7 +3865,7 @@ msgstr "Blockierte"
 #: lib/abuuba_web/live/saved_live.ex:88
 #: lib/abuuba_web/live/saved_live.ex:94
 #: lib/abuuba_web/live/settings_live.ex:218
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2270
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr "Lesezeichen"
@@ -3875,7 +3875,7 @@ msgstr "Lesezeichen"
 msgid "Build me a copy"
 msgstr "Bau mir eine Kopie"
 
-#: lib/abuuba_web/live/settings_live.ex:2271
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr "Hat nicht geklappt"
@@ -3885,12 +3885,12 @@ msgstr "Hat nicht geklappt"
 msgid "Download"
 msgstr "Herunterladen"
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr "Exportieren"
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr "Stummgeschaltete"
@@ -3910,7 +3910,7 @@ msgstr "Eine wird gerade schon gebaut."
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr "Bilder und Videos sind nicht in der Datei. Sie enthält ihre Adressen, die funktionieren, solange dieser Server läuft."
 
-#: lib/abuuba_web/live/settings_live.ex:2270
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr "Fertig"
@@ -3930,7 +3930,7 @@ msgstr "Die Datei wird nach %{days} Tagen gelöscht, weil sie dein ganzes Konto 
 msgid "There is nothing of that kind to export."
 msgstr "So etwas gibt es hier nicht zu exportieren."
 
-#: lib/abuuba_web/live/settings_live.ex:2268
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr "Wartet auf den Start"
@@ -3976,7 +3976,7 @@ msgstr "Dieses Konto schließen"
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr "Alles hier gehört dir, und das Konto zu schließen ist deine Entscheidung."
 
-#: lib/abuuba_web/live/settings_live.ex:2160
+#: lib/abuuba_web/live/settings_live.ex:2166
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr "Eine Kopie von allem mitnehmen, oder das Konto endgültig schließen."
@@ -4021,7 +4021,7 @@ msgstr "Deine Beiträge, Folge-Beziehungen, Listen, Filter, Lesezeichen und Eins
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr "Dein Benutzername bleibt und niemand kann ihn je bekommen, damit alte Links und Erwähnungen von dir nie auf jemand anderen zeigen."
 
-#: lib/abuuba_web/controllers/feed_controller.ex:132
+#: lib/abuuba_web/controllers/feed_controller.ex:141
 #, elixir-autogen, elixir-format
 msgid "A post"
 msgstr "Ein Beitrag"
@@ -4031,7 +4031,7 @@ msgstr "Ein Beitrag"
 msgid "Nobody yet."
 msgstr "Noch niemand."
 
-#: lib/abuuba_web/controllers/feed_controller.ex:77
+#: lib/abuuba_web/controllers/feed_controller.ex:74
 #, elixir-autogen, elixir-format
 msgid "Public posts tagged #%{tag}"
 msgstr "Öffentliche Beiträge mit #%{tag}"
@@ -4967,12 +4967,12 @@ msgid_plural "%{count} signed up"
 msgstr[0] "eine Anmeldung"
 msgstr[1] "%{count} Anmeldungen"
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2244
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr "Profilbild"
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr "Titelbild"
@@ -4988,7 +4988,7 @@ msgstr "JPEG, PNG, GIF oder WebP, bis %{size}. Größere werden schon vor dem Ho
 msgid "None yet."
 msgstr "Noch keins."
 
-#: lib/abuuba_web/live/settings_live.ex:2079
+#: lib/abuuba_web/live/settings_live.ex:2085
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr "Ein Bild auf einmal."
@@ -5003,19 +5003,19 @@ msgstr "Bilder"
 msgid "Take it off"
 msgstr "Entfernen"
 
-#: lib/abuuba_web/live/settings_live.ex:2077
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr "Damit kann dieser Server nichts anfangen. Versuch es mit JPEG, PNG, GIF oder WebP."
 
-#: lib/abuuba_web/live/settings_live.ex:2227
-#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr "Dieses Bild konnte nicht gespeichert werden."
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2080
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr "Dieses Bild ist zu groß. Die Grenze steht eine Zeile weiter oben."
@@ -5074,7 +5074,7 @@ msgstr[0] "Am %{date} an eine Adresse geschickt."
 msgstr[1] "Am %{date} an %{count} Adressen geschickt."
 
 #: lib/abuuba_web/live/settings_live.ex:703
-#: lib/abuuba_web/live/settings_live.ex:1806
+#: lib/abuuba_web/live/settings_live.ex:1812
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Betreff"
@@ -5124,7 +5124,7 @@ msgstr "Du hast heute schon so viele Nachrichten geschickt, wie du kannst."
 msgid "you@example.com"
 msgstr "du@example.com"
 
-#: lib/abuuba_web/live/settings_live.ex:1807
+#: lib/abuuba_web/live/settings_live.ex:1813
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr "Nachricht"
@@ -5605,7 +5605,7 @@ msgstr "Beendet die Benachrichtigungen und nimmt sie aus deiner Timeline. Nieman
 msgid "Unmute this conversation"
 msgstr "Stummschaltung dieser Unterhaltung aufheben"
 
-#: lib/abuuba_web/live/notifications_live.ex:479
+#: lib/abuuba_web/live/notifications_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr "Beiträge von Leuten, die du beobachtest"
@@ -5615,37 +5615,37 @@ msgstr "Beiträge von Leuten, die du beobachtest"
 msgid "Tell me when they post"
 msgstr "Sag mir Bescheid, wenn sie etwas posten"
 
-#: lib/abuuba_web/live/notifications_live.ex:398
+#: lib/abuuba_web/live/notifications_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr "%{name} hat deinen Beitrag zu einer Sammlung hinzugefügt"
 
-#: lib/abuuba_web/live/notifications_live.ex:402
+#: lib/abuuba_web/live/notifications_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr "%{name} hat eine Meldung eingereicht"
 
-#: lib/abuuba_web/live/notifications_live.ex:400
+#: lib/abuuba_web/live/notifications_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "%{name} signed up"
 msgstr "%{name} hat sich registriert"
 
-#: lib/abuuba_web/live/notifications_live.ex:391
+#: lib/abuuba_web/live/notifications_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr "Einige deiner Follows wurden entfernt, als dieser Server die Föderation mit einem anderen beendet hat"
 
-#: lib/abuuba_web/live/notifications_live.ex:387
+#: lib/abuuba_web/live/notifications_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr "Dein Konto hat eine Verwarnung der Moderation erhalten"
 
-#: lib/abuuba_web/live/notifications_live.ex:395
+#: lib/abuuba_web/live/notifications_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr "Dein Jahr auf diesem Server ist fertig zum Lesen"
 
-#: lib/abuuba_web/live/notifications_live.ex:474
+#: lib/abuuba_web/live/notifications_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "Quotes"
 msgstr "Zitate"
@@ -5794,7 +5794,7 @@ msgstr "Alle auf einem blockierten Server auf einmal: Nichts von dort erreicht d
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr "Zu viele Anmeldungen von hier im Moment. Bitte versuche es später noch einmal."
 
-#: lib/abuuba_web/live/explore_live.ex:149
+#: lib/abuuba_web/live/explore_live.ex:153
 #: lib/abuuba_web/live/profile_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
@@ -5860,8 +5860,8 @@ msgstr "Stattgeben und rückgängig machen"
 msgid "Warned"
 msgstr "Verwarnt"
 
-#: lib/abuuba_web/live/settings_live.ex:2252
-#: lib/abuuba_web/live/settings_live.ex:2255
+#: lib/abuuba_web/live/settings_live.ex:2258
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr "%{size} MB"
@@ -5892,7 +5892,7 @@ msgstr "Diesen Beitrag löschen? Andere Server werden aufgefordert, ihre Kopie e
 msgid "Sign out"
 msgstr "Abmelden"
 
-#: lib/abuuba_web/live/post_actions.ex:428
+#: lib/abuuba_web/live/post_actions.ex:435
 #, elixir-autogen, elixir-format
 msgid "That post is gone."
 msgstr "Der Beitrag ist gelöscht."
@@ -6112,3 +6112,8 @@ msgstr "und"
 #, elixir-autogen, elixir-format
 msgid "%{time} UTC"
 msgstr "%{time} UTC"
+
+#: lib/abuuba_web/live/explore_live.ex:127
+#, elixir-autogen, elixir-format
+msgid "This server shows what people are posting to those with an account here."
+msgstr "Dieser Server zeigt nur Leuten mit einem Konto hier, was hier gepostet wird."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -49,7 +49,7 @@ msgid "Change"
 msgstr ""
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:714
+#: lib/abuuba_web/live/compose_component.ex:715
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -124,7 +124,7 @@ msgstr ""
 msgid "Create account"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:81
+#: lib/abuuba_web/live/landing_live.ex:78
 #: lib/abuuba_web/live/registration_live.ex:37
 #: lib/abuuba_web/live/registration_live.ex:207
 #, elixir-autogen, elixir-format
@@ -466,8 +466,8 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:388
-#: lib/abuuba_web/live/compose_component.ex:401
+#: lib/abuuba_web/live/compose_component.ex:389
+#: lib/abuuba_web/live/compose_component.ex:402
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -624,14 +624,14 @@ msgstr ""
 msgid "Upload files as you"
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:667
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:673
 #: lib/abuuba_web/controllers/well_known_controller.ex:42
 #: lib/abuuba_web/controllers/well_known_controller.ex:48
 #, elixir-autogen, elixir-format
 msgid "No such account here."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:587
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:593
 #: lib/abuuba_web/controllers/well_known_controller.ex:64
 #, elixir-autogen, elixir-format
 msgid "That account is gone."
@@ -642,12 +642,12 @@ msgstr ""
 msgid "That is not a resource we understand."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:685
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:691
 #, elixir-autogen, elixir-format
 msgid "A server may only ask about its own followers."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:679
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:685
 #, elixir-autogen, elixir-format
 msgid "That request has to be signed."
 msgstr ""
@@ -662,7 +662,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:258
 #: lib/abuuba_web/components/layouts.ex:279
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2328
+#: lib/abuuba_web/live/settings_live.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -675,7 +675,7 @@ msgid "Keyboard shortcuts"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:282
-#: lib/abuuba_web/live/landing_live.ex:83
+#: lib/abuuba_web/live/landing_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
@@ -688,15 +688,15 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:261
 #: lib/abuuba_web/live/notification_settings_live.ex:31
-#: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2329
+#: lib/abuuba_web/live/notifications_live.ex:65
+#: lib/abuuba_web/live/settings_live.ex:2335
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:273
 #: lib/abuuba_web/live/settings_live.ex:121
-#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -761,7 +761,7 @@ msgid "Follow some people and their posts will appear here."
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:283
-#: lib/abuuba_web/live/compose_component.ex:594
+#: lib/abuuba_web/live/compose_component.ex:595
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:305
+#: lib/abuuba_web/live/home_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "That vote could not be counted."
 msgstr ""
@@ -791,96 +791,96 @@ msgstr ""
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1658
+#: lib/abuuba_web/live/compose_component.ex:1701
 #, elixir-autogen, elixir-format
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1656
+#: lib/abuuba_web/live/compose_component.ex:1699
 #, elixir-autogen, elixir-format
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1659
+#: lib/abuuba_web/live/compose_component.ex:1702
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1655
+#: lib/abuuba_web/live/compose_component.ex:1698
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1654
+#: lib/abuuba_web/live/compose_component.ex:1697
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1657
+#: lib/abuuba_web/live/compose_component.ex:1700
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1660
+#: lib/abuuba_web/live/compose_component.ex:1703
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1132
+#: lib/abuuba_web/live/compose_component.ex:1133
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:629
+#: lib/abuuba_web/live/compose_component.ex:630
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:700
+#: lib/abuuba_web/live/compose_component.ex:701
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:641
+#: lib/abuuba_web/live/compose_component.ex:642
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2323
+#: lib/abuuba_web/live/compose_component.ex:1718
+#: lib/abuuba_web/live/settings_live.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2318
+#: lib/abuuba_web/live/compose_component.ex:1709
+#: lib/abuuba_web/live/settings_live.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2319
+#: lib/abuuba_web/live/compose_component.ex:1710
+#: lib/abuuba_web/live/settings_live.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:605
+#: lib/abuuba_web/live/compose_component.ex:606
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:429
-#: lib/abuuba_web/live/compose_component.ex:690
+#: lib/abuuba_web/live/compose_component.ex:430
+#: lib/abuuba_web/live/compose_component.ex:691
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:791
+#: lib/abuuba_web/live/compose_component.ex:792
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:424
+#: lib/abuuba_web/live/compose_component.ex:425
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr ""
@@ -891,203 +891,203 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:394
+#: lib/abuuba_web/live/compose_component.ex:395
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:645
+#: lib/abuuba_web/live/compose_component.ex:646
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/profile_live.ex:798
+#: lib/abuuba_web/live/compose_component.ex:1711
+#: lib/abuuba_web/live/profile_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1669
+#: lib/abuuba_web/live/compose_component.ex:1712
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3427
-#: lib/abuuba_web/live/compose_component.ex:1677
-#: lib/abuuba_web/live/settings_live.ex:2325
+#: lib/abuuba_web/live/compose_component.ex:1720
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/settings_live.ex:2320
+#: lib/abuuba_web/live/compose_component.ex:1711
+#: lib/abuuba_web/live/settings_live.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1669
+#: lib/abuuba_web/live/compose_component.ex:1712
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2324
+#: lib/abuuba_web/live/compose_component.ex:1719
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1433
+#: lib/abuuba_web/live/compose_component.ex:1429
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:674
+#: lib/abuuba_web/live/compose_component.ex:675
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/compose_component.ex:1684
+#: lib/abuuba_web/live/compose_component.ex:1709
+#: lib/abuuba_web/live/compose_component.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/compose_component.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:710
+#: lib/abuuba_web/live/compose_component.ex:711
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:617
+#: lib/abuuba_web/live/compose_component.ex:618
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:381
+#: lib/abuuba_web/live/compose_component.ex:382
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1431
+#: lib/abuuba_web/live/compose_component.ex:1427
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3388
-#: lib/abuuba_web/live/compose_component.ex:456
+#: lib/abuuba_web/live/compose_component.ex:457
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1094
+#: lib/abuuba_web/live/compose_component.ex:1095
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1156
-#: lib/abuuba_web/live/compose_component.ex:1191
-#: lib/abuuba_web/live/compose_component.ex:1387
+#: lib/abuuba_web/live/compose_component.ex:1157
+#: lib/abuuba_web/live/compose_component.ex:1201
+#: lib/abuuba_web/live/compose_component.ex:1383
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:440
-#: lib/abuuba_web/live/compose_component.ex:446
+#: lib/abuuba_web/live/compose_component.ex:441
+#: lib/abuuba_web/live/compose_component.ex:447
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:434
+#: lib/abuuba_web/live/compose_component.ex:435
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:750
+#: lib/abuuba_web/live/compose_component.ex:751
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:730
+#: lib/abuuba_web/live/compose_component.ex:731
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1090
+#: lib/abuuba_web/live/compose_component.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1188
+#: lib/abuuba_web/live/compose_component.ex:1198
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1627
+#: lib/abuuba_web/live/compose_component.ex:1670
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:797
+#: lib/abuuba_web/live/compose_component.ex:798
 #, elixir-autogen, elixir-format
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:829
+#: lib/abuuba_web/live/compose_component.ex:830
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:1136
+#: lib/abuuba_web/live/compose_component.ex:1137
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:860
+#: lib/abuuba_web/live/compose_component.ex:861
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:821
+#: lib/abuuba_web/live/compose_component.ex:822
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:660
+#: lib/abuuba_web/live/compose_component.ex:661
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:811
-#: lib/abuuba_web/live/compose_component.ex:850
+#: lib/abuuba_web/live/compose_component.ex:812
+#: lib/abuuba_web/live/compose_component.ex:851
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1107
-#: lib/abuuba_web/live/compose_component.ex:1378
+#: lib/abuuba_web/live/compose_component.ex:1108
+#: lib/abuuba_web/live/compose_component.ex:1374
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:782
+#: lib/abuuba_web/live/compose_component.ex:783
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1432
+#: lib/abuuba_web/live/compose_component.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:306
+#: lib/abuuba_web/live/compose_component.ex:307
 #, elixir-autogen, elixir-format
 msgid "That draft could not be saved."
 msgstr ""
@@ -1097,109 +1097,109 @@ msgstr ""
 msgid "That post is scheduled."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1141
+#: lib/abuuba_web/live/compose_component.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:302
+#: lib/abuuba_web/live/compose_component.ex:303
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1426
+#: lib/abuuba_web/live/compose_component.ex:1422
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:667
+#: lib/abuuba_web/live/compose_component.ex:668
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1104
+#: lib/abuuba_web/live/compose_component.ex:1105
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:475
+#: lib/abuuba_web/live/compose_component.ex:476
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:570
+#: lib/abuuba_web/live/compose_component.ex:571
 #, elixir-autogen, elixir-format
 msgid "Add a still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:520
+#: lib/abuuba_web/live/compose_component.ex:521
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:537
-#: lib/abuuba_web/live/compose_component.ex:545
+#: lib/abuuba_web/live/compose_component.ex:538
+#: lib/abuuba_web/live/compose_component.ex:546
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:559
+#: lib/abuuba_web/live/compose_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:574
+#: lib/abuuba_web/live/compose_component.ex:575
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:532
+#: lib/abuuba_web/live/compose_component.ex:533
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:500
+#: lib/abuuba_web/live/compose_component.ex:501
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:585
+#: lib/abuuba_web/live/compose_component.ex:586
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:241
-#: lib/abuuba_web/live/compose_component.ex:1422
+#: lib/abuuba_web/live/compose_component.ex:242
+#: lib/abuuba_web/live/compose_component.ex:1418
 #, elixir-autogen, elixir-format
 msgid "That file could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1419
+#: lib/abuuba_web/live/compose_component.ex:1415
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:228
+#: lib/abuuba_web/live/compose_component.ex:229
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1420
+#: lib/abuuba_web/live/compose_component.ex:1416
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1421
+#: lib/abuuba_web/live/compose_component.ex:1417
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:479
+#: lib/abuuba_web/live/compose_component.ex:480
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:316
+#: lib/abuuba_web/live/status_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr ""
@@ -1218,7 +1218,7 @@ msgstr ""
 
 #: lib/abuuba_web/live/explore_live.ex:114
 #: lib/abuuba_web/live/profile_live.ex:144
-#: lib/abuuba_web/live/tag_live.ex:63
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Follow"
 msgstr ""
@@ -1228,12 +1228,12 @@ msgstr ""
 msgid "Go to the new account"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:121
+#: lib/abuuba_web/live/status_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:797
+#: lib/abuuba_web/live/profile_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
@@ -1256,8 +1256,8 @@ msgstr ""
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:256
-#: lib/abuuba_web/live/profile_live.ex:795
+#: lib/abuuba_web/live/explore_live.ex:247
+#: lib/abuuba_web/live/profile_live.ex:772
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:208
@@ -1265,7 +1265,7 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:796
+#: lib/abuuba_web/live/profile_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
@@ -1295,7 +1295,7 @@ msgstr ""
 #: lib/abuuba_web/live/profile_live.ex:162
 #: lib/abuuba_web/live/report_live.ex:263
 #: lib/abuuba_web/live/report_live.ex:268
-#: lib/abuuba_web/live/tag_live.ex:63
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
@@ -1316,103 +1316,103 @@ msgstr ""
 msgid "What to show"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:112
+#: lib/abuuba_web/live/notifications_live.ex:119
 #, elixir-autogen, elixir-format
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:162
+#: lib/abuuba_web/live/notifications_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:409
+#: lib/abuuba_web/live/notifications_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:413
+#: lib/abuuba_web/live/notifications_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:420
+#: lib/abuuba_web/live/notifications_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:423
+#: lib/abuuba_web/live/notifications_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:147
+#: lib/abuuba_web/live/notifications_live.ex:154
 #, elixir-autogen, elixir-format
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:427
+#: lib/abuuba_web/live/notifications_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:376
+#: lib/abuuba_web/live/notifications_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:374
+#: lib/abuuba_web/live/notifications_live.ex:408
 #, elixir-autogen, elixir-format
 msgid "%{name} boosted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:379
+#: lib/abuuba_web/live/notifications_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:377
+#: lib/abuuba_web/live/notifications_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:375
+#: lib/abuuba_web/live/notifications_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:373
+#: lib/abuuba_web/live/notifications_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:380
+#: lib/abuuba_web/live/notifications_live.ex:414
 #, elixir-autogen, elixir-format
 msgid "%{name} posted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:381
+#: lib/abuuba_web/live/notifications_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:378
+#: lib/abuuba_web/live/notifications_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Accounts made very recently"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:459
+#: lib/abuuba_web/live/notifications_live.ex:493
 #, elixir-autogen, elixir-format
 msgid "All"
 msgstr ""
@@ -1467,17 +1467,17 @@ msgstr ""
 msgid "Automated accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:468
+#: lib/abuuba_web/live/notifications_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Boosts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:140
+#: lib/abuuba_web/live/notifications_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:207
+#: lib/abuuba_web/live/notifications_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -1487,13 +1487,13 @@ msgstr ""
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:473
+#: lib/abuuba_web/live/notifications_live.ex:507
 #, elixir-autogen, elixir-format
 msgid "Edits"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:151
-#: lib/abuuba_web/live/notifications_live.ex:471
+#: lib/abuuba_web/live/notifications_live.ex:505
 #: lib/abuuba_web/live/saved_live.ex:88
 #: lib/abuuba_web/live/saved_live.ex:95
 #: lib/abuuba_web/live/settings_live.ex:220
@@ -1509,15 +1509,15 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:292
 #: lib/abuuba_web/live/follow_requests_live.ex:37
 #: lib/abuuba_web/live/follow_requests_live.ex:44
-#: lib/abuuba_web/live/notifications_live.ex:470
+#: lib/abuuba_web/live/notifications_live.ex:504
 #, elixir-autogen, elixir-format
 msgid "Follow requests"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:469
-#: lib/abuuba_web/live/profile_live.ex:799
-#: lib/abuuba_web/live/settings_live.ex:2121
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/notifications_live.ex:503
+#: lib/abuuba_web/live/profile_live.ex:776
+#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format
 msgid "Follows"
 msgstr ""
@@ -1532,28 +1532,28 @@ msgstr ""
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:176
+#: lib/abuuba_web/live/notifications_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:136
+#: lib/abuuba_web/live/notifications_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:459
-#: lib/abuuba_web/live/notifications_live.ex:467
+#: lib/abuuba_web/live/notifications_live.ex:493
+#: lib/abuuba_web/live/notifications_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:185
+#: lib/abuuba_web/live/notifications_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:221
+#: lib/abuuba_web/live/notifications_live.ex:228
 #, elixir-autogen, elixir-format
 msgid "Nothing has happened yet."
 msgstr ""
@@ -1568,7 +1568,7 @@ msgstr ""
 msgid "People you do not follow"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:472
+#: lib/abuuba_web/live/notifications_live.ex:506
 #, elixir-autogen, elixir-format
 msgid "Polls"
 msgstr ""
@@ -1604,8 +1604,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:371
-#: lib/abuuba_web/live/notifications_live.ex:436
+#: lib/abuuba_web/live/notifications_live.ex:405
+#: lib/abuuba_web/live/notifications_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Somebody"
 msgstr ""
@@ -1615,7 +1615,7 @@ msgstr ""
 msgid "Somebody a moderator here has already restricted."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:406
+#: lib/abuuba_web/live/notifications_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr ""
@@ -1625,7 +1625,7 @@ msgstr ""
 msgid "That could not be saved. Try again."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:101
+#: lib/abuuba_web/live/notifications_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr ""
@@ -1635,7 +1635,7 @@ msgstr ""
 msgid "Who can reach you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:154
+#: lib/abuuba_web/live/notifications_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr ""
@@ -1658,7 +1658,7 @@ msgstr ""
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:257
+#: lib/abuuba_web/live/explore_live.ex:248
 #: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:207
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:70
+#: lib/abuuba_web/live/landing_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "It runs %{software}, which is free software anybody may run."
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:84
+#: lib/abuuba_web/live/landing_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Look around first"
 msgstr ""
@@ -1681,17 +1681,17 @@ msgstr ""
 msgid "Narrowing a search"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:100
+#: lib/abuuba_web/live/landing_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted publicly here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/tag_live.ex:78
+#: lib/abuuba_web/live/tag_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:124
+#: lib/abuuba_web/live/explore_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1701,7 +1701,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:258
+#: lib/abuuba_web/live/explore_live.ex:249
 #: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:206
@@ -1709,7 +1709,7 @@ msgstr ""
 msgid "People"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:89
+#: lib/abuuba_web/live/landing_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Recently, from people here"
 msgstr ""
@@ -1738,7 +1738,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:64
+#: lib/abuuba_web/live/landing_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgid "About you"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3378
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
@@ -1794,22 +1794,22 @@ msgstr ""
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2123
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2295
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2148
+#: lib/abuuba_web/live/settings_live.ex:2154
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2290
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2306
+#: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
@@ -1851,12 +1851,12 @@ msgstr ""
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2291
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2146
+#: lib/abuuba_web/live/settings_live.ex:2152
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
@@ -1871,33 +1871,33 @@ msgstr ""
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2120
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2271
 #, elixir-autogen, elixir-format
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2347
+#: lib/abuuba_web/live/settings_live.ex:2353
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2348
+#: lib/abuuba_web/live/settings_live.ex:2354
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2304
+#: lib/abuuba_web/live/settings_live.ex:2310
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2148
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
@@ -1907,17 +1907,17 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2292
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
@@ -1942,47 +1942,47 @@ msgstr ""
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2149
+#: lib/abuuba_web/live/settings_live.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2311
+#: lib/abuuba_web/live/settings_live.ex:2317
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2121
 #, elixir-autogen, elixir-format
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2332
+#: lib/abuuba_web/live/settings_live.ex:2338
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2336
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2303
+#: lib/abuuba_web/live/settings_live.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1999,7 +1999,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
@@ -2014,7 +2014,7 @@ msgstr ""
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
@@ -2025,7 +2025,7 @@ msgid "Take it back out"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3746
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format
 msgid "That could not be saved. Check what you typed."
 msgstr ""
@@ -2040,17 +2040,17 @@ msgstr ""
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2303
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2304
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2331
+#: lib/abuuba_web/live/settings_live.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
@@ -2070,7 +2070,7 @@ msgstr ""
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2305
+#: lib/abuuba_web/live/settings_live.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
@@ -2080,7 +2080,7 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2307
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2143
+#: lib/abuuba_web/live/settings_live.ex:2149
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
@@ -2106,7 +2106,7 @@ msgstr ""
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2144
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2145
+#: lib/abuuba_web/live/settings_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
@@ -2131,7 +2131,7 @@ msgstr ""
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
@@ -2141,7 +2141,7 @@ msgstr ""
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2141
+#: lib/abuuba_web/live/settings_live.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2147
+#: lib/abuuba_web/live/settings_live.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2307,12 +2307,12 @@ msgstr ""
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1876
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2152
+#: lib/abuuba_web/live/settings_live.ex:2158
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
@@ -2332,7 +2332,7 @@ msgstr ""
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
@@ -2342,13 +2342,13 @@ msgstr ""
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1879
+#: lib/abuuba_web/live/settings_live.ex:1885
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:1218
-#: lib/abuuba_web/live/settings_live.ex:1856
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
@@ -2358,37 +2358,37 @@ msgstr ""
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1871
+#: lib/abuuba_web/live/settings_live.ex:1877
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1870
+#: lib/abuuba_web/live/settings_live.ex:1876
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1872
+#: lib/abuuba_web/live/settings_live.ex:1878
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1877
+#: lib/abuuba_web/live/settings_live.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1880
+#: lib/abuuba_web/live/settings_live.ex:1886
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1881
+#: lib/abuuba_web/live/settings_live.ex:1887
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1878
+#: lib/abuuba_web/live/settings_live.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
@@ -2845,7 +2845,7 @@ msgstr ""
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2115
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2154
+#: lib/abuuba_web/live/settings_live.ex:2160
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2905,7 +2905,7 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
@@ -3001,7 +3001,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2112
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3115,9 +3115,9 @@ msgstr ""
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:357
-#: lib/abuuba_web/live/post_actions.ex:395
-#: lib/abuuba_web/live/status_live.ex:226
+#: lib/abuuba_web/live/home_live.ex:351
+#: lib/abuuba_web/live/post_actions.ex:402
+#: lib/abuuba_web/live/status_live.ex:225
 #, elixir-autogen, elixir-format
 msgid "That could not be translated just now."
 msgstr ""
@@ -3137,133 +3137,133 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2005
+#: lib/abuuba_web/live/settings_live.ex:2011
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1996
+#: lib/abuuba_web/live/settings_live.ex:2002
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1912
+#: lib/abuuba_web/live/settings_live.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2069
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1893
+#: lib/abuuba_web/live/settings_live.ex:1899
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1918
+#: lib/abuuba_web/live/settings_live.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2090
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2157
+#: lib/abuuba_web/live/settings_live.ex:2163
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2097
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2080
-#: lib/abuuba_web/live/settings_live.ex:2085
+#: lib/abuuba_web/live/settings_live.ex:2086
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2088
 #, elixir-autogen, elixir-format
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2089
 #, elixir-autogen, elixir-format
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1902
+#: lib/abuuba_web/live/settings_live.ex:1908
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1899
+#: lib/abuuba_web/live/settings_live.ex:1905
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1907
+#: lib/abuuba_web/live/settings_live.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2104
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
@@ -3273,7 +3273,7 @@ msgstr ""
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1951
+#: lib/abuuba_web/live/settings_live.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
@@ -3283,7 +3283,7 @@ msgstr ""
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1969
+#: lib/abuuba_web/live/settings_live.ex:1975
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
@@ -3303,19 +3303,19 @@ msgstr ""
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1982
+#: lib/abuuba_web/live/settings_live.ex:1988
 #, elixir-autogen, elixir-format
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1959
+#: lib/abuuba_web/live/settings_live.ex:1965
 #, elixir-autogen, elixir-format
 msgid "Import list"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:1082
-#: lib/abuuba_web/live/settings_live.ex:1931
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:1937
+#: lib/abuuba_web/live/settings_live.ex:2268
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
@@ -3330,7 +3330,7 @@ msgstr ""
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2055
+#: lib/abuuba_web/live/settings_live.ex:2061
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
@@ -3340,22 +3340,22 @@ msgstr ""
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1955
+#: lib/abuuba_web/live/settings_live.ex:1961
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2045
+#: lib/abuuba_web/live/settings_live.ex:2051
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:2062
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:1939
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
@@ -3370,17 +3370,17 @@ msgstr ""
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1948
+#: lib/abuuba_web/live/settings_live.ex:1954
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2051
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:673
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:679
 #, elixir-autogen, elixir-format
 msgid "No such post here."
 msgstr ""
@@ -3841,20 +3841,20 @@ msgstr ""
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2269
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:822
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format
 msgid "Blocks"
 msgstr ""
@@ -3863,7 +3863,7 @@ msgstr ""
 #: lib/abuuba_web/live/saved_live.ex:88
 #: lib/abuuba_web/live/saved_live.ex:94
 #: lib/abuuba_web/live/settings_live.ex:218
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2270
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
 msgstr ""
@@ -3873,7 +3873,7 @@ msgstr ""
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2271
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
@@ -3883,12 +3883,12 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format
 msgid "Mutes"
 msgstr ""
@@ -3908,7 +3908,7 @@ msgstr ""
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2270
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3928,7 +3928,7 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2268
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format
 msgid "Waiting to start"
 msgstr ""
@@ -3974,7 +3974,7 @@ msgstr ""
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2160
+#: lib/abuuba_web/live/settings_live.ex:2166
 #, elixir-autogen, elixir-format
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
@@ -4019,7 +4019,7 @@ msgstr ""
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
 
-#: lib/abuuba_web/controllers/feed_controller.ex:132
+#: lib/abuuba_web/controllers/feed_controller.ex:141
 #, elixir-autogen, elixir-format
 msgid "A post"
 msgstr ""
@@ -4029,7 +4029,7 @@ msgstr ""
 msgid "Nobody yet."
 msgstr ""
 
-#: lib/abuuba_web/controllers/feed_controller.ex:77
+#: lib/abuuba_web/controllers/feed_controller.ex:74
 #, elixir-autogen, elixir-format
 msgid "Public posts tagged #%{tag}"
 msgstr ""
@@ -4965,12 +4965,12 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2244
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2079
+#: lib/abuuba_web/live/settings_live.ex:2085
 #, elixir-autogen, elixir-format
 msgid "One picture at a time."
 msgstr ""
@@ -5001,19 +5001,19 @@ msgstr ""
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2077
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2227
-#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2080
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
@@ -5072,7 +5072,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/abuuba_web/live/settings_live.ex:703
-#: lib/abuuba_web/live/settings_live.ex:1806
+#: lib/abuuba_web/live/settings_live.ex:1812
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
@@ -5122,7 +5122,7 @@ msgstr ""
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1807
+#: lib/abuuba_web/live/settings_live.ex:1813
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -5603,7 +5603,7 @@ msgstr ""
 msgid "Unmute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:479
+#: lib/abuuba_web/live/notifications_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr ""
@@ -5613,37 +5613,37 @@ msgstr ""
 msgid "Tell me when they post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:398
+#: lib/abuuba_web/live/notifications_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:402
+#: lib/abuuba_web/live/notifications_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:400
+#: lib/abuuba_web/live/notifications_live.ex:434
 #, elixir-autogen, elixir-format
 msgid "%{name} signed up"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:391
+#: lib/abuuba_web/live/notifications_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:387
+#: lib/abuuba_web/live/notifications_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:395
+#: lib/abuuba_web/live/notifications_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:474
+#: lib/abuuba_web/live/notifications_live.ex:508
 #, elixir-autogen, elixir-format
 msgid "Quotes"
 msgstr ""
@@ -5792,7 +5792,7 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:149
+#: lib/abuuba_web/live/explore_live.ex:153
 #: lib/abuuba_web/live/profile_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
@@ -5858,8 +5858,8 @@ msgstr ""
 msgid "Warned"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2252
-#: lib/abuuba_web/live/settings_live.ex:2255
+#: lib/abuuba_web/live/settings_live.ex:2258
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr ""
@@ -5890,7 +5890,7 @@ msgstr ""
 msgid "Sign out"
 msgstr ""
 
-#: lib/abuuba_web/live/post_actions.ex:428
+#: lib/abuuba_web/live/post_actions.ex:435
 #, elixir-autogen, elixir-format
 msgid "That post is gone."
 msgstr ""
@@ -6109,4 +6109,9 @@ msgstr ""
 #: lib/abuuba_web/formats.ex:73
 #, elixir-autogen, elixir-format
 msgid "%{time} UTC"
+msgstr ""
+
+#: lib/abuuba_web/live/explore_live.ex:127
+#, elixir-autogen, elixir-format
+msgid "This server shows what people are posting to those with an account here."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -49,7 +49,7 @@ msgid "Change"
 msgstr ""
 
 #: lib/abuuba_web/components/language_picker.ex:37
-#: lib/abuuba_web/live/compose_component.ex:714
+#: lib/abuuba_web/live/compose_component.ex:715
 #, elixir-autogen, elixir-format
 msgid "Language"
 msgstr ""
@@ -124,7 +124,7 @@ msgstr ""
 msgid "Create account"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:81
+#: lib/abuuba_web/live/landing_live.ex:78
 #: lib/abuuba_web/live/registration_live.ex:37
 #: lib/abuuba_web/live/registration_live.ex:207
 #, elixir-autogen, elixir-format
@@ -466,8 +466,8 @@ msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1755
 #: lib/abuuba_web/live/authorize_live.ex:123
-#: lib/abuuba_web/live/compose_component.ex:388
-#: lib/abuuba_web/live/compose_component.ex:401
+#: lib/abuuba_web/live/compose_component.ex:389
+#: lib/abuuba_web/live/compose_component.ex:402
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -624,14 +624,14 @@ msgstr ""
 msgid "Upload files as you"
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:667
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:673
 #: lib/abuuba_web/controllers/well_known_controller.ex:42
 #: lib/abuuba_web/controllers/well_known_controller.ex:48
 #, elixir-autogen, elixir-format
 msgid "No such account here."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:587
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:593
 #: lib/abuuba_web/controllers/well_known_controller.ex:64
 #, elixir-autogen, elixir-format
 msgid "That account is gone."
@@ -642,12 +642,12 @@ msgstr ""
 msgid "That is not a resource we understand."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:685
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:691
 #, elixir-autogen, elixir-format
 msgid "A server may only ask about its own followers."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:679
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:685
 #, elixir-autogen, elixir-format
 msgid "That request has to be signed."
 msgstr ""
@@ -662,7 +662,7 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:258
 #: lib/abuuba_web/components/layouts.ex:279
 #: lib/abuuba_web/live/home_live.ex:55
-#: lib/abuuba_web/live/settings_live.ex:2328
+#: lib/abuuba_web/live/settings_live.ex:2334
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -675,7 +675,7 @@ msgid "Keyboard shortcuts"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:282
-#: lib/abuuba_web/live/landing_live.ex:83
+#: lib/abuuba_web/live/landing_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Log in"
 msgstr ""
@@ -688,15 +688,15 @@ msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:261
 #: lib/abuuba_web/live/notification_settings_live.ex:31
-#: lib/abuuba_web/live/notifications_live.ex:59
-#: lib/abuuba_web/live/settings_live.ex:2329
+#: lib/abuuba_web/live/notifications_live.ex:65
+#: lib/abuuba_web/live/settings_live.ex:2335
 #, elixir-autogen, elixir-format
 msgid "Notifications"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:273
 #: lib/abuuba_web/live/settings_live.ex:121
-#: lib/abuuba_web/live/settings_live.ex:2137
+#: lib/abuuba_web/live/settings_live.ex:2143
 #, elixir-autogen, elixir-format
 msgid "Settings"
 msgstr ""
@@ -761,7 +761,7 @@ msgid "Follow some people and their posts will appear here."
 msgstr ""
 
 #: lib/abuuba_web/components/status_component.ex:283
-#: lib/abuuba_web/live/compose_component.ex:594
+#: lib/abuuba_web/live/compose_component.ex:595
 #, elixir-autogen, elixir-format
 msgid "Poll"
 msgstr ""
@@ -771,7 +771,7 @@ msgstr ""
 msgid "Reply"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:305
+#: lib/abuuba_web/live/home_live.ex:299
 #, elixir-autogen, elixir-format
 msgid "That vote could not be counted."
 msgstr ""
@@ -791,96 +791,96 @@ msgstr ""
 msgid "Your choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1658
+#: lib/abuuba_web/live/compose_component.ex:1701
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 day"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1656
+#: lib/abuuba_web/live/compose_component.ex:1699
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 hour"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1659
+#: lib/abuuba_web/live/compose_component.ex:1702
 #, elixir-autogen, elixir-format
 msgid "3 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1655
+#: lib/abuuba_web/live/compose_component.ex:1698
 #, elixir-autogen, elixir-format
 msgid "30 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1654
+#: lib/abuuba_web/live/compose_component.ex:1697
 #, elixir-autogen, elixir-format
 msgid "5 minutes"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1657
+#: lib/abuuba_web/live/compose_component.ex:1700
 #, elixir-autogen, elixir-format
 msgid "6 hours"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1660
+#: lib/abuuba_web/live/compose_component.ex:1703
 #, elixir-autogen, elixir-format
 msgid "7 days"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1132
+#: lib/abuuba_web/live/compose_component.ex:1133
 #, elixir-autogen, elixir-format
 msgid "A poll needs at least two options."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:629
+#: lib/abuuba_web/live/compose_component.ex:630
 #, elixir-autogen, elixir-format
 msgid "Add a choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:700
+#: lib/abuuba_web/live/compose_component.ex:701
 #, elixir-autogen, elixir-format
 msgid "Add a poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:641
+#: lib/abuuba_web/live/compose_component.ex:642
 #, elixir-autogen, elixir-format
 msgid "Allow more than one choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1675
-#: lib/abuuba_web/live/settings_live.ex:2323
+#: lib/abuuba_web/live/compose_component.ex:1718
+#: lib/abuuba_web/live/settings_live.ex:2329
 #, elixir-autogen, elixir-format
 msgid "Anyone"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/settings_live.ex:2318
+#: lib/abuuba_web/live/compose_component.ex:1709
+#: lib/abuuba_web/live/settings_live.ex:2324
 #, elixir-autogen, elixir-format
 msgid "Anyone, and listed everywhere"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1667
-#: lib/abuuba_web/live/settings_live.ex:2319
+#: lib/abuuba_web/live/compose_component.ex:1710
+#: lib/abuuba_web/live/settings_live.ex:2325
 #, elixir-autogen, elixir-format
 msgid "Anyone, but not in public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:605
+#: lib/abuuba_web/live/compose_component.ex:606
 #, elixir-autogen, elixir-format
 msgid "Choice %{number}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:429
-#: lib/abuuba_web/live/compose_component.ex:690
+#: lib/abuuba_web/live/compose_component.ex:430
+#: lib/abuuba_web/live/compose_component.ex:691
 #, elixir-autogen, elixir-format
 msgid "Content warning"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:791
+#: lib/abuuba_web/live/compose_component.ex:792
 #, elixir-autogen, elixir-format
 msgid "Ctrl + Enter posts"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:424
+#: lib/abuuba_web/live/compose_component.ex:425
 #, elixir-autogen, elixir-format
 msgid "Do not reply to this person"
 msgstr ""
@@ -891,203 +891,203 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:394
+#: lib/abuuba_web/live/compose_component.ex:395
 #, elixir-autogen, elixir-format
 msgid "Editing a post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:645
+#: lib/abuuba_web/live/compose_component.ex:646
 #, elixir-autogen, elixir-format
 msgid "Ends after"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/profile_live.ex:798
+#: lib/abuuba_web/live/compose_component.ex:1711
+#: lib/abuuba_web/live/profile_live.ex:775
 #, elixir-autogen, elixir-format
 msgid "Followers"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1669
+#: lib/abuuba_web/live/compose_component.ex:1712
 #, elixir-autogen, elixir-format
 msgid "Mentioned people"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3427
-#: lib/abuuba_web/live/compose_component.ex:1677
-#: lib/abuuba_web/live/settings_live.ex:2325
+#: lib/abuuba_web/live/compose_component.ex:1720
+#: lib/abuuba_web/live/settings_live.ex:2331
 #, elixir-autogen, elixir-format
 msgid "Nobody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1668
-#: lib/abuuba_web/live/settings_live.ex:2320
+#: lib/abuuba_web/live/compose_component.ex:1711
+#: lib/abuuba_web/live/settings_live.ex:2326
 #, elixir-autogen, elixir-format
 msgid "Only the people who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1669
+#: lib/abuuba_web/live/compose_component.ex:1712
 #, elixir-autogen, elixir-format
 msgid "Only the people you name"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1676
-#: lib/abuuba_web/live/settings_live.ex:2324
+#: lib/abuuba_web/live/compose_component.ex:1719
+#: lib/abuuba_web/live/settings_live.ex:2330
 #, elixir-autogen, elixir-format
 msgid "People who follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1433
+#: lib/abuuba_web/live/compose_component.ex:1429
 #, elixir-autogen, elixir-format
 msgid "Post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:674
+#: lib/abuuba_web/live/compose_component.ex:675
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1666
-#: lib/abuuba_web/live/compose_component.ex:1684
+#: lib/abuuba_web/live/compose_component.ex:1709
+#: lib/abuuba_web/live/compose_component.ex:1727
 #, elixir-autogen, elixir-format
 msgid "Public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1667
+#: lib/abuuba_web/live/compose_component.ex:1710
 #, elixir-autogen, elixir-format
 msgid "Quiet public"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:710
+#: lib/abuuba_web/live/compose_component.ex:711
 #, elixir-autogen, elixir-format
 msgid "Remove the poll"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:617
+#: lib/abuuba_web/live/compose_component.ex:618
 #, elixir-autogen, elixir-format
 msgid "Remove this choice"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:381
+#: lib/abuuba_web/live/compose_component.ex:382
 #, elixir-autogen, elixir-format
 msgid "Replying to %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1431
+#: lib/abuuba_web/live/compose_component.ex:1427
 #, elixir-autogen, elixir-format
 msgid "Save changes"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3388
-#: lib/abuuba_web/live/compose_component.ex:456
+#: lib/abuuba_web/live/compose_component.ex:457
 #, elixir-autogen, elixir-format
 msgid "Suggestions"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1094
+#: lib/abuuba_web/live/compose_component.ex:1095
 #, elixir-autogen, elixir-format
 msgid "That is too long by %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1156
-#: lib/abuuba_web/live/compose_component.ex:1191
-#: lib/abuuba_web/live/compose_component.ex:1387
+#: lib/abuuba_web/live/compose_component.ex:1157
+#: lib/abuuba_web/live/compose_component.ex:1201
+#: lib/abuuba_web/live/compose_component.ex:1383
 #, elixir-autogen, elixir-format
 msgid "That post could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:440
-#: lib/abuuba_web/live/compose_component.ex:446
+#: lib/abuuba_web/live/compose_component.ex:441
+#: lib/abuuba_web/live/compose_component.ex:447
 #, elixir-autogen, elixir-format
 msgid "What is on your mind?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:434
+#: lib/abuuba_web/live/compose_component.ex:435
 #, elixir-autogen, elixir-format
 msgid "What should people be warned about?"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:750
+#: lib/abuuba_web/live/compose_component.ex:751
 #, elixir-autogen, elixir-format
 msgid "Who can quote this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:730
+#: lib/abuuba_web/live/compose_component.ex:731
 #, elixir-autogen, elixir-format
 msgid "Who can see this"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1090
+#: lib/abuuba_web/live/compose_component.ex:1091
 #, elixir-autogen, elixir-format
 msgid "Write something first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1188
+#: lib/abuuba_web/live/compose_component.ex:1198
 #, elixir-autogen, elixir-format
 msgid "You have posted a lot just now. Try again in a while."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1627
+#: lib/abuuba_web/live/compose_component.ex:1670
 #, elixir-autogen, elixir-format
 msgid "somebody"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:797
+#: lib/abuuba_web/live/compose_component.ex:798
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} draft"
 msgid_plural "%{count} drafts"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:829
+#: lib/abuuba_web/live/compose_component.ex:830
 #, elixir-autogen, elixir-format
 msgid "%{count} post waiting to go out"
 msgid_plural "%{count} posts waiting to go out"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/compose_component.ex:1136
+#: lib/abuuba_web/live/compose_component.ex:1137
 #, elixir-autogen, elixir-format
 msgid "A poll choice is too long. Keep each under %{count} characters."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:860
+#: lib/abuuba_web/live/compose_component.ex:861
 #, elixir-autogen, elixir-format
 msgid "Call off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:821
+#: lib/abuuba_web/live/compose_component.ex:822
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:660
+#: lib/abuuba_web/live/compose_component.ex:661
 #, elixir-autogen, elixir-format
 msgid "Goes out on"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:811
-#: lib/abuuba_web/live/compose_component.ex:850
+#: lib/abuuba_web/live/compose_component.ex:812
+#: lib/abuuba_web/live/compose_component.ex:851
 #, elixir-autogen, elixir-format
 msgid "Open"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1107
-#: lib/abuuba_web/live/compose_component.ex:1378
+#: lib/abuuba_web/live/compose_component.ex:1108
+#: lib/abuuba_web/live/compose_component.ex:1374
 #, elixir-autogen, elixir-format
 msgid "Say when it should go out."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:782
+#: lib/abuuba_web/live/compose_component.ex:783
 #, elixir-autogen, elixir-format
 msgid "Schedule"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1432
+#: lib/abuuba_web/live/compose_component.ex:1428
 #, elixir-autogen, elixir-format
 msgid "Schedule it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:306
+#: lib/abuuba_web/live/compose_component.ex:307
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That draft could not be saved."
 msgstr ""
@@ -1097,109 +1097,109 @@ msgstr ""
 msgid "That post is scheduled."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1141
+#: lib/abuuba_web/live/compose_component.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Two poll choices are the same. Make them different."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:302
+#: lib/abuuba_web/live/compose_component.ex:303
 #, elixir-autogen, elixir-format
 msgid "You have too many drafts to start another. Discard one first."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1426
+#: lib/abuuba_web/live/compose_component.ex:1422
 #, elixir-autogen, elixir-format
 msgid "an empty post"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:667
+#: lib/abuuba_web/live/compose_component.ex:668
 #, elixir-autogen, elixir-format
 msgid "your own time, at least %{count} minutes from now"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1104
+#: lib/abuuba_web/live/compose_component.ex:1105
 #, elixir-autogen, elixir-format
 msgid "A picture is going out without a description. Send again to post it anyway."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:475
+#: lib/abuuba_web/live/compose_component.ex:476
 #, elixir-autogen, elixir-format
 msgid "Add a picture, video or sound"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:570
+#: lib/abuuba_web/live/compose_component.ex:571
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add a still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:520
+#: lib/abuuba_web/live/compose_component.ex:521
 #, elixir-autogen, elixir-format
 msgid "Click the part that matters most"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:537
-#: lib/abuuba_web/live/compose_component.ex:545
+#: lib/abuuba_web/live/compose_component.ex:538
+#: lib/abuuba_web/live/compose_component.ex:546
 #, elixir-autogen, elixir-format
 msgid "Describe this for people who cannot see it"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:559
+#: lib/abuuba_web/live/compose_component.ex:560
 #, elixir-autogen, elixir-format
 msgid "Move earlier"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:574
+#: lib/abuuba_web/live/compose_component.ex:575
 #, elixir-autogen, elixir-format
 msgid "Pick the still"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:532
+#: lib/abuuba_web/live/compose_component.ex:533
 #, elixir-autogen, elixir-format
 msgid "Set the focal point"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:500
+#: lib/abuuba_web/live/compose_component.ex:501
 #, elixir-autogen, elixir-format
 msgid "Stop"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:585
+#: lib/abuuba_web/live/compose_component.ex:586
 #, elixir-autogen, elixir-format
 msgid "Take off"
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:241
-#: lib/abuuba_web/live/compose_component.ex:1422
+#: lib/abuuba_web/live/compose_component.ex:242
+#: lib/abuuba_web/live/compose_component.ex:1418
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1419
+#: lib/abuuba_web/live/compose_component.ex:1415
 #, elixir-autogen, elixir-format
 msgid "That file is too big."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:228
+#: lib/abuuba_web/live/compose_component.ex:229
 #, elixir-autogen, elixir-format
 msgid "That is as many pictures as one post carries (%{count})."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1420
+#: lib/abuuba_web/live/compose_component.ex:1416
 #, elixir-autogen, elixir-format
 msgid "That is more files than a post can carry."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:1421
+#: lib/abuuba_web/live/compose_component.ex:1417
 #, elixir-autogen, elixir-format
 msgid "This server does not take files of that kind."
 msgstr ""
 
-#: lib/abuuba_web/live/compose_component.ex:479
+#: lib/abuuba_web/live/compose_component.ex:480
 #, elixir-autogen, elixir-format
 msgid "or drop one on the box, or paste it"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:316
+#: lib/abuuba_web/live/status_live.ex:315
 #, elixir-autogen, elixir-format
 msgid "%{name} on %{server}"
 msgstr ""
@@ -1218,7 +1218,7 @@ msgstr ""
 
 #: lib/abuuba_web/live/explore_live.ex:114
 #: lib/abuuba_web/live/profile_live.ex:144
-#: lib/abuuba_web/live/tag_live.ex:63
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow"
 msgstr ""
@@ -1228,12 +1228,12 @@ msgstr ""
 msgid "Go to the new account"
 msgstr ""
 
-#: lib/abuuba_web/live/status_live.ex:121
+#: lib/abuuba_web/live/status_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Look for more replies on the other server"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:797
+#: lib/abuuba_web/live/profile_live.ex:774
 #, elixir-autogen, elixir-format
 msgid "Media"
 msgstr ""
@@ -1256,8 +1256,8 @@ msgstr ""
 msgid "Pinned"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:256
-#: lib/abuuba_web/live/profile_live.ex:795
+#: lib/abuuba_web/live/explore_live.ex:247
+#: lib/abuuba_web/live/profile_live.ex:772
 #: lib/abuuba_web/live/search_live.ex:120
 #: lib/abuuba_web/live/search_live.ex:121
 #: lib/abuuba_web/live/search_live.ex:208
@@ -1265,7 +1265,7 @@ msgstr ""
 msgid "Posts"
 msgstr ""
 
-#: lib/abuuba_web/live/profile_live.ex:796
+#: lib/abuuba_web/live/profile_live.ex:773
 #, elixir-autogen, elixir-format
 msgid "Posts and replies"
 msgstr ""
@@ -1295,7 +1295,7 @@ msgstr ""
 #: lib/abuuba_web/live/profile_live.ex:162
 #: lib/abuuba_web/live/report_live.ex:263
 #: lib/abuuba_web/live/report_live.ex:268
-#: lib/abuuba_web/live/tag_live.ex:63
+#: lib/abuuba_web/live/tag_live.ex:62
 #, elixir-autogen, elixir-format
 msgid "Unfollow"
 msgstr ""
@@ -1316,103 +1316,103 @@ msgstr ""
 msgid "What to show"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:112
+#: lib/abuuba_web/live/notifications_live.ex:119
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} new"
 msgid_plural "%{count} new"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:162
+#: lib/abuuba_web/live/notifications_live.ex:169
 #, elixir-autogen, elixir-format
 msgid "%{count} notification"
 msgid_plural "%{count} notifications"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:409
+#: lib/abuuba_web/live/notifications_live.ex:443
 #, elixir-autogen, elixir-format
 msgid "%{count} person boosted your post"
 msgid_plural "%{count} people boosted your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:413
+#: lib/abuuba_web/live/notifications_live.ex:447
 #, elixir-autogen, elixir-format
 msgid "%{count} person favourited your post"
 msgid_plural "%{count} people favourited your post"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:420
+#: lib/abuuba_web/live/notifications_live.ex:454
 #, elixir-autogen, elixir-format
 msgid "%{count} person followed you"
 msgid_plural "%{count} people followed you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:423
+#: lib/abuuba_web/live/notifications_live.ex:457
 #, elixir-autogen, elixir-format
 msgid "%{count} person mentioned you"
 msgid_plural "%{count} people mentioned you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:147
+#: lib/abuuba_web/live/notifications_live.ex:154
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{count} person waiting to reach you"
 msgid_plural "%{count} people waiting to reach you"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:427
+#: lib/abuuba_web/live/notifications_live.ex:461
 #, elixir-autogen, elixir-format
 msgid "%{name} and %{count} other person"
 msgid_plural "%{name} and %{count} other people"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/notifications_live.ex:376
+#: lib/abuuba_web/live/notifications_live.ex:410
 #, elixir-autogen, elixir-format
 msgid "%{name} asked to follow you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:374
+#: lib/abuuba_web/live/notifications_live.ex:408
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} boosted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:379
+#: lib/abuuba_web/live/notifications_live.ex:413
 #, elixir-autogen, elixir-format
 msgid "%{name} edited a post you boosted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:377
+#: lib/abuuba_web/live/notifications_live.ex:411
 #, elixir-autogen, elixir-format
 msgid "%{name} favourited your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:375
+#: lib/abuuba_web/live/notifications_live.ex:409
 #, elixir-autogen, elixir-format
 msgid "%{name} followed you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:373
+#: lib/abuuba_web/live/notifications_live.ex:407
 #, elixir-autogen, elixir-format
 msgid "%{name} mentioned you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:380
+#: lib/abuuba_web/live/notifications_live.ex:414
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} posted"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:381
+#: lib/abuuba_web/live/notifications_live.ex:415
 #, elixir-autogen, elixir-format
 msgid "%{name} quoted your post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:378
+#: lib/abuuba_web/live/notifications_live.ex:412
 #, elixir-autogen, elixir-format
 msgid "A poll by %{name} has ended"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Accounts made very recently"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:459
+#: lib/abuuba_web/live/notifications_live.ex:493
 #, elixir-autogen, elixir-format, fuzzy
 msgid "All"
 msgstr ""
@@ -1467,17 +1467,17 @@ msgstr ""
 msgid "Automated accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:468
+#: lib/abuuba_web/live/notifications_live.ex:502
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Boosts"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:140
+#: lib/abuuba_web/live/notifications_live.ex:147
 #, elixir-autogen, elixir-format
 msgid "Clear all"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:207
+#: lib/abuuba_web/live/notifications_live.ex:214
 #, elixir-autogen, elixir-format
 msgid "Dismiss"
 msgstr ""
@@ -1487,13 +1487,13 @@ msgstr ""
 msgid "Each of these describes a kind of sender. Accept lets them through, Filter puts them in the waiting list on your notifications page, and Ignore drops them."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:473
+#: lib/abuuba_web/live/notifications_live.ex:507
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edits"
 msgstr ""
 
 #: lib/abuuba_web/components/layouts.ex:151
-#: lib/abuuba_web/live/notifications_live.ex:471
+#: lib/abuuba_web/live/notifications_live.ex:505
 #: lib/abuuba_web/live/saved_live.ex:88
 #: lib/abuuba_web/live/saved_live.ex:95
 #: lib/abuuba_web/live/settings_live.ex:220
@@ -1509,15 +1509,15 @@ msgstr ""
 #: lib/abuuba_web/components/layouts.ex:292
 #: lib/abuuba_web/live/follow_requests_live.ex:37
 #: lib/abuuba_web/live/follow_requests_live.ex:44
-#: lib/abuuba_web/live/notifications_live.ex:470
+#: lib/abuuba_web/live/notifications_live.ex:504
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follow requests"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:469
-#: lib/abuuba_web/live/profile_live.ex:799
-#: lib/abuuba_web/live/settings_live.ex:2121
-#: lib/abuuba_web/live/settings_live.ex:2259
+#: lib/abuuba_web/live/notifications_live.ex:503
+#: lib/abuuba_web/live/profile_live.ex:776
+#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2265
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Follows"
 msgstr ""
@@ -1532,28 +1532,28 @@ msgstr ""
 msgid "Ignore is the one to be careful with: nothing is filed anywhere and it cannot be recovered. Filter is the reversible one."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:176
+#: lib/abuuba_web/live/notifications_live.ex:183
 #, elixir-autogen, elixir-format
 msgid "Let them through"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:136
+#: lib/abuuba_web/live/notifications_live.ex:143
 #, elixir-autogen, elixir-format
 msgid "Mark as read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:459
-#: lib/abuuba_web/live/notifications_live.ex:467
+#: lib/abuuba_web/live/notifications_live.ex:493
+#: lib/abuuba_web/live/notifications_live.ex:501
 #, elixir-autogen, elixir-format
 msgid "Mentions"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:185
+#: lib/abuuba_web/live/notifications_live.ex:192
 #, elixir-autogen, elixir-format
 msgid "Not now"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:221
+#: lib/abuuba_web/live/notifications_live.ex:228
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Nothing has happened yet."
 msgstr ""
@@ -1568,7 +1568,7 @@ msgstr ""
 msgid "People you do not follow"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:472
+#: lib/abuuba_web/live/notifications_live.ex:506
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Polls"
 msgstr ""
@@ -1604,8 +1604,8 @@ msgstr ""
 msgid "Saved."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:371
-#: lib/abuuba_web/live/notifications_live.ex:436
+#: lib/abuuba_web/live/notifications_live.ex:405
+#: lib/abuuba_web/live/notifications_live.ex:470
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Somebody"
 msgstr ""
@@ -1615,7 +1615,7 @@ msgstr ""
 msgid "Somebody a moderator here has already restricted."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:406
+#: lib/abuuba_web/live/notifications_live.ex:440
 #, elixir-autogen, elixir-format
 msgid "Something happened involving %{name}"
 msgstr ""
@@ -1625,7 +1625,7 @@ msgstr ""
 msgid "That could not be saved. Try again."
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:101
+#: lib/abuuba_web/live/notifications_live.ex:108
 #, elixir-autogen, elixir-format
 msgid "Which notifications"
 msgstr ""
@@ -1635,7 +1635,7 @@ msgstr ""
 msgid "Who can reach you"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:154
+#: lib/abuuba_web/live/notifications_live.ex:161
 #, elixir-autogen, elixir-format
 msgid "Your settings filed these instead of showing them."
 msgstr ""
@@ -1658,7 +1658,7 @@ msgstr ""
 msgid "Everything"
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:257
+#: lib/abuuba_web/live/explore_live.ex:248
 #: lib/abuuba_web/live/search_live.ex:111
 #: lib/abuuba_web/live/search_live.ex:112
 #: lib/abuuba_web/live/search_live.ex:207
@@ -1666,12 +1666,12 @@ msgstr ""
 msgid "Hashtags"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:70
+#: lib/abuuba_web/live/landing_live.ex:67
 #, elixir-autogen, elixir-format
 msgid "It runs %{software}, which is free software anybody may run."
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:84
+#: lib/abuuba_web/live/landing_live.ex:81
 #, elixir-autogen, elixir-format
 msgid "Look around first"
 msgstr ""
@@ -1681,17 +1681,17 @@ msgstr ""
 msgid "Narrowing a search"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:100
+#: lib/abuuba_web/live/landing_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted publicly here yet."
 msgstr ""
 
-#: lib/abuuba_web/live/tag_live.ex:78
+#: lib/abuuba_web/live/tag_live.ex:77
 #, elixir-autogen, elixir-format
 msgid "Nobody has posted under this tag yet."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:124
+#: lib/abuuba_web/live/explore_live.ex:125
 #, elixir-autogen, elixir-format
 msgid "Nothing here yet. Come back once people have posted."
 msgstr ""
@@ -1701,7 +1701,7 @@ msgstr ""
 msgid "Nothing matched that."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:258
+#: lib/abuuba_web/live/explore_live.ex:249
 #: lib/abuuba_web/live/search_live.ex:101
 #: lib/abuuba_web/live/search_live.ex:102
 #: lib/abuuba_web/live/search_live.ex:206
@@ -1709,7 +1709,7 @@ msgstr ""
 msgid "People"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:89
+#: lib/abuuba_web/live/landing_live.ex:86
 #, elixir-autogen, elixir-format
 msgid "Recently, from people here"
 msgstr ""
@@ -1738,7 +1738,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: lib/abuuba_web/live/landing_live.ex:64
+#: lib/abuuba_web/live/landing_live.ex:61
 #, elixir-autogen, elixir-format
 msgid "This is a server on the fediverse: a network of independent servers whose people can follow and talk to each other, whichever one they are on. An account here can follow anybody anywhere on it."
 msgstr ""
@@ -1779,7 +1779,7 @@ msgid "About you"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3378
-#: lib/abuuba_web/live/settings_live.ex:2124
+#: lib/abuuba_web/live/settings_live.ex:2130
 #, elixir-autogen, elixir-format
 msgid "Account"
 msgstr ""
@@ -1794,22 +1794,22 @@ msgstr ""
 msgid "Add a filter"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2117
+#: lib/abuuba_web/live/settings_live.ex:2123
 #, elixir-autogen, elixir-format
 msgid "Appearance"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2295
+#: lib/abuuba_web/live/settings_live.ex:2301
 #, elixir-autogen, elixir-format
 msgid "Applies to your public posts only."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2123
+#: lib/abuuba_web/live/settings_live.ex:2129
 #, elixir-autogen, elixir-format
 msgid "Apps"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2148
+#: lib/abuuba_web/live/settings_live.ex:2154
 #, elixir-autogen, elixir-format
 msgid "Apps that have been let into your account."
 msgstr ""
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Apps you have signed in to. Taking one back out signs it out immediately."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2290
+#: lib/abuuba_web/live/settings_live.ex:2296
 #, elixir-autogen, elixir-format
 msgid "Ask before letting somebody follow you"
 msgstr ""
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Display name"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2306
+#: lib/abuuba_web/live/settings_live.ex:2312
 #, elixir-autogen, elixir-format
 msgid "Do not play media on its own"
 msgstr ""
@@ -1851,12 +1851,12 @@ msgstr ""
 msgid "Each line has to be a web address, one per line."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2291
+#: lib/abuuba_web/live/settings_live.ex:2297
 #, elixir-autogen, elixir-format
 msgid "Every follow becomes a request you answer."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2146
+#: lib/abuuba_web/live/settings_live.ex:2152
 #, elixir-autogen, elixir-format
 msgid "Everybody you follow, and a way to stop."
 msgstr ""
@@ -1871,33 +1871,33 @@ msgstr ""
 msgid "Fields"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2120
-#: lib/abuuba_web/live/settings_live.ex:2265
+#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2271
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filters"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2347
+#: lib/abuuba_web/live/settings_live.ex:2353
 #, elixir-autogen, elixir-format
 msgid "Fold it behind a warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2348
+#: lib/abuuba_web/live/settings_live.ex:2354
 #, elixir-autogen, elixir-format
 msgid "Hide it completely"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2296
+#: lib/abuuba_web/live/settings_live.ex:2302
 #, elixir-autogen, elixir-format
 msgid "Hide who I follow and who follows me"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2304
+#: lib/abuuba_web/live/settings_live.ex:2310
 #, elixir-autogen, elixir-format
 msgid "Higher contrast"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2142
+#: lib/abuuba_web/live/settings_live.ex:2148
 #, elixir-autogen, elixir-format
 msgid "How the interface behaves and reads."
 msgstr ""
@@ -1907,17 +1907,17 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2294
+#: lib/abuuba_web/live/settings_live.ex:2300
 #, elixir-autogen, elixir-format
 msgid "Let search engines index my posts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2292
+#: lib/abuuba_web/live/settings_live.ex:2298
 #, elixir-autogen, elixir-format
 msgid "List me in the directory"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2299
+#: lib/abuuba_web/live/settings_live.ex:2305
 #, elixir-autogen, elixir-format
 msgid "Marks the account as a bot, which some people filter on."
 msgstr ""
@@ -1942,47 +1942,47 @@ msgstr ""
 msgid "Only the people you name is missing on purpose: as a default it turns every post you forget to change into a message to nobody."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2149
+#: lib/abuuba_web/live/settings_live.ex:2155
 #, elixir-autogen, elixir-format
 msgid "Other accounts of yours, and moving between them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2311
+#: lib/abuuba_web/live/settings_live.ex:2317
 #, elixir-autogen, elixir-format
 msgid "Overrides your system setting if it is wrong for you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2115
+#: lib/abuuba_web/live/settings_live.ex:2121
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Overview"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2118
+#: lib/abuuba_web/live/settings_live.ex:2124
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Posting"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2119
+#: lib/abuuba_web/live/settings_live.ex:2125
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2116
+#: lib/abuuba_web/live/settings_live.ex:2122
 #, elixir-autogen, elixir-format
 msgid "Profile"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2332
+#: lib/abuuba_web/live/settings_live.ex:2338
 #, elixir-autogen, elixir-format
 msgid "Profiles"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2330
+#: lib/abuuba_web/live/settings_live.ex:2336
 #, elixir-autogen, elixir-format
 msgid "Public timelines"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2303
+#: lib/abuuba_web/live/settings_live.ex:2309
 #, elixir-autogen, elixir-format
 msgid "Reduce motion"
 msgstr ""
@@ -1999,7 +1999,7 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2122
+#: lib/abuuba_web/live/settings_live.ex:2128
 #, elixir-autogen, elixir-format
 msgid "Security"
 msgstr ""
@@ -2014,7 +2014,7 @@ msgstr ""
 msgid "Signing out everywhere ends every session, including this one."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2314
+#: lib/abuuba_web/live/settings_live.ex:2320
 #, elixir-autogen, elixir-format
 msgid "Stops the first send when a picture has no description."
 msgstr ""
@@ -2025,7 +2025,7 @@ msgid "Take it back out"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:3746
-#: lib/abuuba_web/live/settings_live.ex:2111
+#: lib/abuuba_web/live/settings_live.ex:2117
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be saved. Check what you typed."
 msgstr ""
@@ -2040,17 +2040,17 @@ msgstr ""
 msgid "The language you usually write in"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2297
+#: lib/abuuba_web/live/settings_live.ex:2303
 #, elixir-autogen, elixir-format
 msgid "The lists stop being public; the follows themselves still work."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2298
+#: lib/abuuba_web/live/settings_live.ex:2304
 #, elixir-autogen, elixir-format
 msgid "This account posts automatically"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2331
+#: lib/abuuba_web/live/settings_live.ex:2337
 #, elixir-autogen, elixir-format
 msgid "Threads"
 msgstr ""
@@ -2070,7 +2070,7 @@ msgstr ""
 msgid "Up to four rows shown on your profile. The order here is the order there."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2305
+#: lib/abuuba_web/live/settings_live.ex:2311
 #, elixir-autogen, elixir-format
 msgid "Use my system's font"
 msgstr ""
@@ -2080,7 +2080,7 @@ msgstr ""
 msgid "Value"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2307
+#: lib/abuuba_web/live/settings_live.ex:2313
 #, elixir-autogen, elixir-format
 msgid "Warn me about missing descriptions"
 msgstr ""
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid "What it does"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2143
+#: lib/abuuba_web/live/settings_live.ex:2149
 #, elixir-autogen, elixir-format
 msgid "What the compose box starts with."
 msgstr ""
@@ -2106,7 +2106,7 @@ msgstr ""
 msgid "Where it applies"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2144
+#: lib/abuuba_web/live/settings_live.ex:2150
 #, elixir-autogen, elixir-format
 msgid "Who can find you and who has to ask to follow."
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 msgid "Who new posts go to"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2145
+#: lib/abuuba_web/live/settings_live.ex:2151
 #, elixir-autogen, elixir-format
 msgid "Words and phrases you would rather not see."
 msgstr ""
@@ -2131,7 +2131,7 @@ msgstr ""
 msgid "You are not following anybody yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2293
+#: lib/abuuba_web/live/settings_live.ex:2299
 #, elixir-autogen, elixir-format
 msgid "Your account appears on this server's public directory page."
 msgstr ""
@@ -2141,7 +2141,7 @@ msgstr ""
 msgid "Your current password"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2141
+#: lib/abuuba_web/live/settings_live.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Your name, what you say about yourself, your fields."
 msgstr ""
@@ -2151,7 +2151,7 @@ msgstr ""
 msgid "Your other accounts"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2147
+#: lib/abuuba_web/live/settings_live.ex:2153
 #, elixir-autogen, elixir-format
 msgid "Your password, two-factor, and signing out."
 msgstr ""
@@ -2307,12 +2307,12 @@ msgstr ""
 msgid "servers known"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1876
+#: lib/abuuba_web/live/settings_live.ex:1882
 #, elixir-autogen, elixir-format
 msgid "A warning"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2152
+#: lib/abuuba_web/live/settings_live.ex:2158
 #, elixir-autogen, elixir-format
 msgid "Anything a moderator here has decided about your account."
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Appeal this"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2125
+#: lib/abuuba_web/live/settings_live.ex:2131
 #, elixir-autogen, elixir-format
 msgid "Moderation"
 msgstr ""
@@ -2332,7 +2332,7 @@ msgstr ""
 msgid "Nothing here. No moderator here has taken any action about your account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1860
+#: lib/abuuba_web/live/settings_live.ex:1866
 #, elixir-autogen, elixir-format
 msgid "Say something about why you think it was wrong."
 msgstr ""
@@ -2342,13 +2342,13 @@ msgstr ""
 msgid "Say why you think this was wrong"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1879
+#: lib/abuuba_web/live/settings_live.ex:1885
 #, elixir-autogen, elixir-format
 msgid "Some of your posts were deleted"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:1218
-#: lib/abuuba_web/live/settings_live.ex:1856
+#: lib/abuuba_web/live/settings_live.ex:1862
 #, elixir-autogen, elixir-format
 msgid "The window for appealing this has passed."
 msgstr ""
@@ -2358,37 +2358,37 @@ msgstr ""
 msgid "What a moderator here has decided about your account, and what you were told."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1871
+#: lib/abuuba_web/live/settings_live.ex:1877
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was turned down."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1870
+#: lib/abuuba_web/live/settings_live.ex:1876
 #, elixir-autogen, elixir-format
 msgid "You appealed this and the appeal was upheld."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1872
+#: lib/abuuba_web/live/settings_live.ex:1878
 #, elixir-autogen, elixir-format
 msgid "You have appealed this. Nobody has decided yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1877
+#: lib/abuuba_web/live/settings_live.ex:1883
 #, elixir-autogen, elixir-format
 msgid "Your account was disabled"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1880
+#: lib/abuuba_web/live/settings_live.ex:1886
 #, elixir-autogen, elixir-format
 msgid "Your account was limited"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1881
+#: lib/abuuba_web/live/settings_live.ex:1887
 #, elixir-autogen, elixir-format
 msgid "Your account was suspended"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1878
+#: lib/abuuba_web/live/settings_live.ex:1884
 #, elixir-autogen, elixir-format
 msgid "Your posts were marked sensitive"
 msgstr ""
@@ -2845,7 +2845,7 @@ msgstr ""
 msgid "What more people than usual are posting about, then everything else, newest first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2109
+#: lib/abuuba_web/live/settings_live.ex:2115
 #, elixir-autogen, elixir-format
 msgid "%{uses} of %{max} used"
 msgstr ""
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "Announcements"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2154
+#: lib/abuuba_web/live/settings_live.ex:2160
 #, elixir-autogen, elixir-format
 msgid "Codes that let somebody you know sign up."
 msgstr ""
@@ -2905,7 +2905,7 @@ msgstr ""
 msgid "In effect from %{date}"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2126
+#: lib/abuuba_web/live/settings_live.ex:2132
 #, elixir-autogen, elixir-format
 msgid "Invites"
 msgstr ""
@@ -3001,7 +3001,7 @@ msgstr ""
 msgid "everybody was told"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2106
+#: lib/abuuba_web/live/settings_live.ex:2112
 #, elixir-autogen, elixir-format
 msgid "used %{count} time"
 msgid_plural "used %{count} times"
@@ -3115,9 +3115,9 @@ msgstr ""
 msgid "by %{name}"
 msgstr ""
 
-#: lib/abuuba_web/live/home_live.ex:357
-#: lib/abuuba_web/live/post_actions.ex:395
-#: lib/abuuba_web/live/status_live.ex:226
+#: lib/abuuba_web/live/home_live.ex:351
+#: lib/abuuba_web/live/post_actions.ex:402
+#: lib/abuuba_web/live/status_live.ex:225
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be translated just now."
 msgstr ""
@@ -3137,133 +3137,133 @@ msgstr ""
 msgid "This account has been disabled. Contact the moderators."
 msgstr "This account has been disabled. Contact the moderators."
 
-#: lib/abuuba_web/live/settings_live.ex:2005
+#: lib/abuuba_web/live/settings_live.ex:2011
 #, elixir-autogen, elixir-format
 msgid "%{count} could not be brought over"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1996
+#: lib/abuuba_web/live/settings_live.ex:2002
 #, elixir-autogen, elixir-format
 msgid "%{done} of %{total} read, %{imported} brought over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1912
+#: lib/abuuba_web/live/settings_live.ex:1918
 #, elixir-autogen, elixir-format
 msgid "Boosts and polls. A boost points at somebody else's post, which the archive does not contain, and a poll's votes could not be true here."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2069
+#: lib/abuuba_web/live/settings_live.ex:2075
 #, elixir-autogen, elixir-format
 msgid "Choose an archive first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1893
+#: lib/abuuba_web/live/settings_live.ex:1899
 #, elixir-autogen, elixir-format
 msgid "Every fediverse server can give you a zip of everything you posted. Upload one here and your posts come back, with their pictures and their original dates."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2092
+#: lib/abuuba_web/live/settings_live.ex:2098
 #, elixir-autogen, elixir-format
 msgid "Finished."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2127
+#: lib/abuuba_web/live/settings_live.ex:2133
 #, elixir-autogen, elixir-format
 msgid "Import"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1918
+#: lib/abuuba_web/live/settings_live.ex:1924
 #, elixir-autogen, elixir-format
 msgid "Imported posts stay off everybody's timeline and off the network. They appear on your profile, in the order you wrote them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2084
+#: lib/abuuba_web/live/settings_live.ex:2090
 #, elixir-autogen, elixir-format
 msgid "One archive at a time."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2157
+#: lib/abuuba_web/live/settings_live.ex:2163
 #, elixir-autogen, elixir-format
 msgid "Read an archive of your posts from another server back in."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2091
+#: lib/abuuba_web/live/settings_live.ex:2097
 #, elixir-autogen, elixir-format
 msgid "Reading your archive."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2093
+#: lib/abuuba_web/live/settings_live.ex:2099
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That archive could not be read."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2065
+#: lib/abuuba_web/live/settings_live.ex:2071
 #, elixir-autogen, elixir-format
 msgid "That could not be read. Upload the archive your old server gave you."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2080
-#: lib/abuuba_web/live/settings_live.ex:2085
+#: lib/abuuba_web/live/settings_live.ex:2086
+#: lib/abuuba_web/live/settings_live.ex:2091
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That could not be uploaded."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2082
+#: lib/abuuba_web/live/settings_live.ex:2088
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That file is too large."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2089
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That is not an archive file."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1902
+#: lib/abuuba_web/live/settings_live.ex:1908
 #, elixir-autogen, elixir-format
 msgid "The old addresses. Your posts lived on another domain and cannot live there again, so every link to one of them stays broken."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2090
+#: lib/abuuba_web/live/settings_live.ex:2096
 #, elixir-autogen, elixir-format
 msgid "Waiting to start."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1899
+#: lib/abuuba_web/live/settings_live.ex:1905
 #, elixir-autogen, elixir-format
 msgid "What cannot come with them"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1907
+#: lib/abuuba_web/live/settings_live.ex:1913
 #, elixir-autogen, elixir-format
 msgid "Your followers. A follow is an agreement between two servers and one of them is gone; they have to follow this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2096
+#: lib/abuuba_web/live/settings_live.ex:2102
 #, elixir-autogen, elixir-format
 msgid "a boost, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2098
+#: lib/abuuba_web/live/settings_live.ex:2104
 #, elixir-autogen, elixir-format
 msgid "a poll, which cannot come with you"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2099
+#: lib/abuuba_web/live/settings_live.ex:2105
 #, elixir-autogen, elixir-format
 msgid "it has no date, so it has nowhere to go"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2102
+#: lib/abuuba_web/live/settings_live.ex:2108
 #, elixir-autogen, elixir-format
 msgid "the file is not an archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2100
+#: lib/abuuba_web/live/settings_live.ex:2106
 #, elixir-autogen, elixir-format, fuzzy
 msgid "the post could not be found"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2101
+#: lib/abuuba_web/live/settings_live.ex:2107
 #, elixir-autogen, elixir-format
 msgid "this server would not accept it"
 msgstr ""
@@ -3273,7 +3273,7 @@ msgstr ""
 msgid "Accept all"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1951
+#: lib/abuuba_web/live/settings_live.ex:1957
 #, elixir-autogen, elixir-format
 msgid "Add to it"
 msgstr ""
@@ -3283,7 +3283,7 @@ msgstr ""
 msgid "After a move, everybody who followed you arrives at once. This accepts all of them, which is the same answer you already gave them."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1969
+#: lib/abuuba_web/live/settings_live.ex:1975
 #, elixir-autogen, elixir-format
 msgid "An archive of your posts"
 msgstr ""
@@ -3303,19 +3303,19 @@ msgstr ""
 msgid "I came back"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1982
+#: lib/abuuba_web/live/settings_live.ex:1988
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import archive"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1959
+#: lib/abuuba_web/live/settings_live.ex:1965
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Import list"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:1082
-#: lib/abuuba_web/live/settings_live.ex:1931
-#: lib/abuuba_web/live/settings_live.ex:2262
+#: lib/abuuba_web/live/settings_live.ex:1937
+#: lib/abuuba_web/live/settings_live.ex:2268
 #, elixir-autogen, elixir-format
 msgid "Lists"
 msgstr ""
@@ -3330,7 +3330,7 @@ msgstr ""
 msgid "Move to another account"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2055
+#: lib/abuuba_web/live/settings_live.ex:2061
 #, elixir-autogen, elixir-format
 msgid "Nobody could be found at that address."
 msgstr ""
@@ -3340,22 +3340,22 @@ msgstr ""
 msgid "Other servers are being told to follow the new account instead. Anybody who follows you from this server has already been moved over."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1955
+#: lib/abuuba_web/live/settings_live.ex:1961
 #, elixir-autogen, elixir-format
 msgid "Replace it with the file"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2045
+#: lib/abuuba_web/live/settings_live.ex:2051
 #, elixir-autogen, elixir-format
 msgid "That account does not name this one as one of yours. Add this account's address to its aliases first."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2056
+#: lib/abuuba_web/live/settings_live.ex:2062
 #, elixir-autogen, elixir-format
 msgid "That is this account."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1933
+#: lib/abuuba_web/live/settings_live.ex:1939
 #, elixir-autogen, elixir-format
 msgid "The CSV files your old server gives you: follows, blocks, mutes, domain blocks, lists, bookmarks, filters. Upload one at a time, under the name it came with."
 msgstr ""
@@ -3370,17 +3370,17 @@ msgstr ""
 msgid "This account has moved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1948
+#: lib/abuuba_web/live/settings_live.ex:1954
 #, elixir-autogen, elixir-format
 msgid "What to do with what is here"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2051
+#: lib/abuuba_web/live/settings_live.ex:2057
 #, elixir-autogen, elixir-format
 msgid "You moved recently. An account can only be moved once every %{days} days."
 msgstr ""
 
-#: lib/abuuba_web/controllers/activity_pub_controller.ex:673
+#: lib/abuuba_web/controllers/activity_pub_controller.ex:679
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No such post here."
 msgstr ""
@@ -3841,20 +3841,20 @@ msgstr ""
 msgid "A copy of everything"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2269
+#: lib/abuuba_web/live/settings_live.ex:2275
 #, elixir-autogen, elixir-format
 msgid "Being built"
 msgstr ""
 
 #: lib/abuuba_web/live/settings_live.ex:822
-#: lib/abuuba_web/live/settings_live.ex:2263
+#: lib/abuuba_web/live/settings_live.ex:2269
 #, elixir-autogen, elixir-format
 msgid "Blocked servers"
 msgstr ""
 
 #: lib/abuuba_web/live/admin_live.ex:1316
 #: lib/abuuba_web/live/admin_live.ex:1331
-#: lib/abuuba_web/live/settings_live.ex:2260
+#: lib/abuuba_web/live/settings_live.ex:2266
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Blocks"
 msgstr ""
@@ -3863,7 +3863,7 @@ msgstr ""
 #: lib/abuuba_web/live/saved_live.ex:88
 #: lib/abuuba_web/live/saved_live.ex:94
 #: lib/abuuba_web/live/settings_live.ex:218
-#: lib/abuuba_web/live/settings_live.ex:2264
+#: lib/abuuba_web/live/settings_live.ex:2270
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Bookmarks"
 msgstr ""
@@ -3873,7 +3873,7 @@ msgstr ""
 msgid "Build me a copy"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2271
+#: lib/abuuba_web/live/settings_live.ex:2277
 #, elixir-autogen, elixir-format
 msgid "Did not work"
 msgstr ""
@@ -3883,12 +3883,12 @@ msgstr ""
 msgid "Download"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2128
+#: lib/abuuba_web/live/settings_live.ex:2134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Export"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2261
+#: lib/abuuba_web/live/settings_live.ex:2267
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Mutes"
 msgstr ""
@@ -3908,7 +3908,7 @@ msgstr ""
 msgid "Pictures and video are not in the file. It holds their addresses, which work while this server does."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2270
+#: lib/abuuba_web/live/settings_live.ex:2276
 #, elixir-autogen, elixir-format
 msgid "Ready"
 msgstr ""
@@ -3928,7 +3928,7 @@ msgstr ""
 msgid "There is nothing of that kind to export."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2268
+#: lib/abuuba_web/live/settings_live.ex:2274
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Waiting to start"
 msgstr ""
@@ -3974,7 +3974,7 @@ msgstr ""
 msgid "Everything here is yours to take, and the account is yours to close."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2160
+#: lib/abuuba_web/live/settings_live.ex:2166
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Take a copy of everything, or close the account for good."
 msgstr ""
@@ -4019,7 +4019,7 @@ msgstr ""
 msgid "Your username is kept and nobody can ever have it, so that old links and mentions of you never point at somebody else."
 msgstr ""
 
-#: lib/abuuba_web/controllers/feed_controller.ex:132
+#: lib/abuuba_web/controllers/feed_controller.ex:141
 #, elixir-autogen, elixir-format, fuzzy
 msgid "A post"
 msgstr ""
@@ -4029,7 +4029,7 @@ msgstr ""
 msgid "Nobody yet."
 msgstr ""
 
-#: lib/abuuba_web/controllers/feed_controller.ex:77
+#: lib/abuuba_web/controllers/feed_controller.ex:74
 #, elixir-autogen, elixir-format
 msgid "Public posts tagged #%{tag}"
 msgstr ""
@@ -4965,12 +4965,12 @@ msgid_plural "%{count} signed up"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/abuuba_web/live/settings_live.ex:2238
+#: lib/abuuba_web/live/settings_live.ex:2244
 #, elixir-autogen, elixir-format
 msgid "Avatar"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2239
+#: lib/abuuba_web/live/settings_live.ex:2245
 #, elixir-autogen, elixir-format
 msgid "Header"
 msgstr ""
@@ -4986,7 +4986,7 @@ msgstr ""
 msgid "None yet."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2079
+#: lib/abuuba_web/live/settings_live.ex:2085
 #, elixir-autogen, elixir-format, fuzzy
 msgid "One picture at a time."
 msgstr ""
@@ -5001,19 +5001,19 @@ msgstr ""
 msgid "Take it off"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2077
-#: lib/abuuba_web/live/settings_live.ex:2232
+#: lib/abuuba_web/live/settings_live.ex:2083
+#: lib/abuuba_web/live/settings_live.ex:2238
 #, elixir-autogen, elixir-format
 msgid "That is not a picture this server can use. Try a JPEG, PNG, GIF or WebP."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2227
-#: lib/abuuba_web/live/settings_live.ex:2234
+#: lib/abuuba_web/live/settings_live.ex:2233
+#: lib/abuuba_web/live/settings_live.ex:2240
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That picture could not be saved."
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2074
+#: lib/abuuba_web/live/settings_live.ex:2080
 #, elixir-autogen, elixir-format
 msgid "That picture is too large. The limit is on the line above."
 msgstr ""
@@ -5072,7 +5072,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/abuuba_web/live/settings_live.ex:703
-#: lib/abuuba_web/live/settings_live.ex:1806
+#: lib/abuuba_web/live/settings_live.ex:1812
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
@@ -5122,7 +5122,7 @@ msgstr ""
 msgid "you@example.com"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:1807
+#: lib/abuuba_web/live/settings_live.ex:1813
 #, elixir-autogen, elixir-format
 msgid "Message"
 msgstr ""
@@ -5603,7 +5603,7 @@ msgstr ""
 msgid "Unmute this conversation"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:479
+#: lib/abuuba_web/live/notifications_live.ex:513
 #, elixir-autogen, elixir-format
 msgid "Posts from people you watch"
 msgstr ""
@@ -5613,37 +5613,37 @@ msgstr ""
 msgid "Tell me when they post"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:398
+#: lib/abuuba_web/live/notifications_live.ex:432
 #, elixir-autogen, elixir-format
 msgid "%{name} added your post to a collection"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:402
+#: lib/abuuba_web/live/notifications_live.ex:436
 #, elixir-autogen, elixir-format
 msgid "%{name} filed a report"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:400
+#: lib/abuuba_web/live/notifications_live.ex:434
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{name} signed up"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:391
+#: lib/abuuba_web/live/notifications_live.ex:425
 #, elixir-autogen, elixir-format
 msgid "Some of your follows were removed when this server stopped federating with another"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:387
+#: lib/abuuba_web/live/notifications_live.ex:421
 #, elixir-autogen, elixir-format
 msgid "Your account has received a moderation warning"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:395
+#: lib/abuuba_web/live/notifications_live.ex:429
 #, elixir-autogen, elixir-format
 msgid "Your year on this server is ready to read"
 msgstr ""
 
-#: lib/abuuba_web/live/notifications_live.ex:474
+#: lib/abuuba_web/live/notifications_live.ex:508
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Quotes"
 msgstr ""
@@ -5792,7 +5792,7 @@ msgstr ""
 msgid "Too many sign-ups from here just now. Please try again later."
 msgstr ""
 
-#: lib/abuuba_web/live/explore_live.ex:149
+#: lib/abuuba_web/live/explore_live.ex:153
 #: lib/abuuba_web/live/profile_live.ex:540
 #, elixir-autogen, elixir-format
 msgid "Too many follows today. Try again tomorrow."
@@ -5858,8 +5858,8 @@ msgstr ""
 msgid "Warned"
 msgstr ""
 
-#: lib/abuuba_web/live/settings_live.ex:2252
-#: lib/abuuba_web/live/settings_live.ex:2255
+#: lib/abuuba_web/live/settings_live.ex:2258
+#: lib/abuuba_web/live/settings_live.ex:2261
 #, elixir-autogen, elixir-format
 msgid "%{size} MB"
 msgstr ""
@@ -5890,7 +5890,7 @@ msgstr ""
 msgid "Sign out"
 msgstr ""
 
-#: lib/abuuba_web/live/post_actions.ex:428
+#: lib/abuuba_web/live/post_actions.ex:435
 #, elixir-autogen, elixir-format, fuzzy
 msgid "That post is gone."
 msgstr ""
@@ -6109,4 +6109,9 @@ msgstr ""
 #: lib/abuuba_web/formats.ex:73
 #, elixir-autogen, elixir-format
 msgid "%{time} UTC"
+msgstr ""
+
+#: lib/abuuba_web/live/explore_live.ex:127
+#, elixir-autogen, elixir-format
+msgid "This server shows what people are posting to those with an account here."
 msgstr ""

--- a/test/abuuba/account_listing_test.exs
+++ b/test/abuuba/account_listing_test.exs
@@ -1,0 +1,153 @@
+defmodule Abuuba.AccountListingTest do
+  @moduledoc """
+  Who this server puts in front of somebody who did not ask for them by name.
+
+  Four surfaces answer that, and each carried its own spelling of the answer:
+  the public directory, follow suggestions, the admin's popular list, and
+  whether a post may feed the trends. The clauses had drifted -- the admin
+  list and the trends check both still offered an account that had migrated
+  away, and the admin docstring claimed it matched the suggestions it did not
+  match.
+
+  Written per surface rather than per clause, for the reason
+  `AbuubaWeb.CollectionsVisibilityTest` gives: the bug is never that a rule was
+  wrong, it is that a surface never asked it.
+  """
+  use Abuuba.DataCase, async: true
+
+  import Abuuba.AccountsFixtures
+  import Abuuba.StatusesFixtures
+
+  alias Abuuba.Accounts
+  alias Abuuba.Accounts.Suggestions
+  alias Abuuba.Admin
+  alias Abuuba.Relationships
+  alias Abuuba.Trends
+
+  setup do
+    # Every surface below needs somebody to already follow the subject: two of
+    # them rank by exactly that, and one is friend-of-a-friend.
+    reader = account_fixture()
+    friend = account_fixture(%{discoverable: true})
+    subject = account_fixture(%{discoverable: true})
+
+    {:ok, _} = Relationships.follow(reader, friend)
+    {:ok, _} = Relationships.follow(friend, subject)
+
+    %{reader: reader, subject: subject}
+  end
+
+  defp in_directory?(subject), do: subject.id in Enum.map(Accounts.directory(), & &1.id)
+
+  defp suggested?(reader, subject),
+    do: subject.id in Enum.map(Suggestions.for_account(reader), & &1.id)
+
+  defp popular_for_admin?(subject),
+    do: subject.id in Enum.map(Admin.suggestion_candidates(), & &1.id)
+
+  defp trendable?(subject),
+    do: Trends.eligible?(status_fixture(%{account_id: subject.id, text: "hello"}))
+
+  describe "an account that has asked for nothing in particular" do
+    test "is offered by all four", %{reader: reader, subject: subject} do
+      # The control. Every assertion below is that something is absent, which a
+      # server offering nobody anything would satisfy just as well.
+      assert in_directory?(subject)
+      assert suggested?(reader, subject)
+      assert popular_for_admin?(subject)
+      assert trendable?(subject)
+    end
+  end
+
+  describe "an account that is not discoverable" do
+    setup %{subject: subject} do
+      {:ok, subject} = Accounts.update_profile(subject, %{"discoverable" => false})
+      %{subject: subject}
+    end
+
+    test "is offered by none of them", %{reader: reader, subject: subject} do
+      refute in_directory?(subject)
+      refute suggested?(reader, subject)
+      refute popular_for_admin?(subject)
+      refute trendable?(subject)
+    end
+  end
+
+  describe "an account a moderator suspended" do
+    setup %{subject: subject} do
+      {:ok, subject} = Accounts.update_moderation(subject, %{suspended_at: DateTime.utc_now()})
+      %{subject: subject}
+    end
+
+    test "is offered by none of them", %{reader: reader, subject: subject} do
+      refute in_directory?(subject)
+      refute suggested?(reader, subject)
+      refute popular_for_admin?(subject)
+      refute trendable?(subject)
+    end
+  end
+
+  describe "an account a moderator limited" do
+    setup %{subject: subject} do
+      {:ok, subject} = Accounts.update_moderation(subject, %{silenced_at: DateTime.utc_now()})
+      %{subject: subject}
+    end
+
+    test "is offered by none of them", %{reader: reader, subject: subject} do
+      refute in_directory?(subject)
+      refute suggested?(reader, subject)
+      refute popular_for_admin?(subject)
+      refute trendable?(subject)
+    end
+  end
+
+  describe "an account that has migrated away" do
+    setup %{subject: subject} do
+      # The column is set directly because what is under test is the listing,
+      # not the migration that writes it.
+      {:ok, subject} =
+        subject
+        |> Ecto.Changeset.change(moved_to_account_id: account_fixture().id)
+        |> Repo.update()
+
+      %{subject: subject}
+    end
+
+    test "is offered by none of them", %{reader: reader, subject: subject} do
+      # Two of these were the bug: pointing a newcomer at an account that will
+      # never post again, and letting one drive what the server is talking
+      # about today.
+      refute in_directory?(subject)
+      refute suggested?(reader, subject)
+      refute popular_for_admin?(subject)
+      refute trendable?(subject)
+    end
+  end
+
+  describe "the clauses that are genuinely one surface's own" do
+    test "the directory is local and the other three are not", %{reader: reader} do
+      # Nobody on another server agreed to appear in our directory. They can
+      # still be suggested, be popular, and be part of a trend.
+      friend = account_fixture(%{discoverable: true})
+      elsewhere = remote_account_fixture(%{domain: "remote.example", discoverable: true})
+
+      {:ok, _} = Relationships.follow(reader, friend)
+      {:ok, _} = Relationships.follow(friend, elsewhere)
+
+      refute in_directory?(elsewhere)
+      assert suggested?(reader, elsewhere)
+      assert popular_for_admin?(elsewhere)
+    end
+
+    test "only the trends honour trendable", %{reader: reader, subject: subject} do
+      # A moderator can stop an account trending without taking it out of the
+      # directory, which is a smaller thing than limiting them.
+      {:ok, subject} = Accounts.update_moderation(subject, %{trendable: false})
+
+      assert in_directory?(subject)
+      assert suggested?(reader, subject)
+      assert popular_for_admin?(subject)
+      refute trendable?(subject)
+    end
+  end
+end


### PR DESCRIPTION
`Accounts.listable/1` is the one answer now, and the directory, the follow
suggestions, the admin's popular list and the trends check all compose it. Two
gained the migrated-away clause, including the admin list whose own docstring
already claimed it. Each half is proven to fail without the fix.

The move to SQL had one trap. `trendable` is a nullable boolean, and the
in-memory `!= false` it replaced is *true* for NULL where SQL's is NULL, which
a `WHERE` drops. A naive translation would have emptied the trends for every
account nobody has moderated, and that reads as "nothing is trending" rather
than as a bug. Spelled `is_nil(trendable) or trendable`, and checked against a
real Postgres, not only fixtures.

Second commit is housekeeping: the last `gettext.extract` predates three merged
issues, and turned up an empty German msgstr on the logged-out explore page.

Closes #24

An AI agent wrote this text in my name. I know that is problematic.
